### PR TITLE
Fix for biocache-hub war file deployment.

### DIFF
--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -1,7 +1,7 @@
 - include: ../../common/tasks/setfacts.yml
 
 - name: copy biocache hub app
-  get_url: url={{biocache_hub_url}} dest=/var/lib/{{tomcat}}/webapps/{{biocache_hub}}.war
+  get_url: url={{biocache_hub_war_url}} force=yes dest=/var/lib/{{tomcat}}/webapps/{{biocache_hub}}.war
   tags: 
     - webapps
 

--- a/ansible/roles/biocache-hub/vars/main.yml
+++ b/ansible/roles/biocache-hub/vars/main.yml
@@ -8,4 +8,4 @@ biocache_service: biocache-service
 biocache_hub_version: 0.1
 
 # assets
-biocache_hub_url: http://maven.ala.org.au/repository/au/org/ala/{{biocache_hub}}/{{biocache_hub_version}}/{{biocache_hub}}-{{biocache_hub_version}}.war
+biocache_hub_war_url: http://maven.ala.org.au/repository/au/org/ala/{{biocache_hub}}/{{biocache_hub_version}}/{{biocache_hub}}-{{biocache_hub_version}}.war


### PR DESCRIPTION
Existing war file was not being over written, adding force=yes fixed
it. Also renamed variable as it clashed with another variable set in
inventory script.
