### PR TITLE
machine audit v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 *.class
+*.DS_Store
+*.pyc
 
 # Package Files #
 *.ear
@@ -55,3 +57,5 @@ ansible/inventories/solr-amazon
 ansible/inventories/profiles-nectar
 
 ansible/inventories/profiles
+
+ansible/machine_audit

--- a/ansible/callback_plugins/machine_audit_callback.py
+++ b/ansible/callback_plugins/machine_audit_callback.py
@@ -24,7 +24,12 @@ def prepfile():
   if not os.path.exists(outputdir):
     os.makedirs(outputdir)
   outputfilename = 'machine_audit.csv'
-  outputline = 'Hostname,Reachable,IPv4 address,IPv4 network,vCPUs,RAM total GB,RAM free GB,mount sizes,total storage,used storage,swap GB,Linux distro,distro version,Tomcat dir/s,Tomcat webapps,Tomcat version,Java version,Java vendor\n'
+  outputline = 'Hostname,Reachable,IPv4 address,IPv4 network,Data centre,vCPUs,'
+  outputline += 'RAM total GB,RAM free GB,mount sizes,total storage,used storage,'
+  outputline += 'swap GB,Linux distro,distro version,Tomcat dir/s,Tomcat webapps,'
+  outputline += 'Tomcat version,Java version,Java vendor,MySQL,Postgres,'
+  outputline += 'Cassandra,MongoDB'
+  outputline += '\n'
   with open(outputdir + "/" + outputfilename, 'w') as of:
     of.write(outputline + "\n")
 
@@ -70,8 +75,30 @@ def log(host, data):
     # IP
     outputline += "{data},".format(data=facts.get('ansible_default_ipv4', None).get('address', None))
     # network
-    outputline += "{data},".format(data=facts.get('ansible_default_ipv4', None).get('network', None))
+    thisnetwork = facts.get('ansible_default_ipv4', None).get('network', None)
+    outputline += "{data},".format(data=thisnetwork)
     # Data centre (Melbourne/Canberra)
+    datacentre = "???"
+    if thisnetwork in ('138.194.80.0', '138.194.85.0', '138.194.104.0', '150.229.66.0'):
+      datacentre = "Melbourne"
+    elif thisnetwork in ('150.229.2.0', '152.83.240.0', '152.83.3.0', '152.83.8.0'):
+      datacentre = "Canberra"
+    outputline += "{data},".format(data=datacentre)
+    # The following IP addresses are based in Melbourne:
+    # 138.194.80.0
+    # 138.194.85.0
+    # 138.194.104.0
+    # 150.229.66.0
+    #
+    # The following IP addresses are based in Canberra:
+    # 150.229.2.0
+    # 152.83.240.0
+    # 152.83.3.0
+    # 152.83.8.0
+    #
+    # Note that the network 150.229.0.0 is broad and encompasses many subnets which are based around the country.
+
+
     # CPU allocation
     outputline += "{data},".format(data=facts.get('ansible_processor_vcpus', None))
     # RAM allocation in GB
@@ -119,19 +146,39 @@ def log(host, data):
       # Tomcat version
       tomcatversion = machine_audit.get('tomcat_version', None)
       if tomcatversion is not None:
-          outputline += "{data} ".format(data=tomcatversion)
+          outputline += "{data}".format(data=tomcatversion)
       outputline += ","
       # Java version
       javaversion = machine_audit.get('java_version', None)
       if javaversion is not None:
-          outputline += "{data} ".format(data=javaversion)
+          outputline += "{data}".format(data=javaversion)
       outputline += ","
       # Java vendor (variant will be Oracle, Sun, or the dreaded IBM JDK)
       javavendor = machine_audit.get('java_vendor', None)
       if javavendor is not None:
-          outputline += "{data} ".format(data=javavendor)
+          outputline += "{data}".format(data=javavendor)
       outputline += ","
-      # DBs installed (MySQL, Postgres, Cassandra, MongoDB)
+      # MySQL
+      mysqlver = machine_audit.get('mysql_version', None)
+      if mysqlver is not None:
+          outputline += "{data}".format(data=mysqlver)
+      outputline += ","
+      # Postgres
+      postgresver = machine_audit.get('postgres_version', None)
+      if postgresver is not None:
+          outputline += "{data}".format(data=postgresver)
+      outputline += ","
+      # Cassandra
+      cassver = machine_audit.get('cassandra_version', None)
+      if cassver is not None:
+          outputline += "{data}".format(data=cassver)
+      outputline += ","
+      # MongoDB
+      mongover = machine_audit.get('mongodb_version', None)
+      if mongover is not None:
+          outputline += "{data}".format(data=mongover)
+      outputline += ","
+
       # Additional running processes (ActiveMQ, Jenkins)
       # RAM allocation for Tomcat instances
 

--- a/ansible/callback_plugins/machine_audit_callback.py
+++ b/ansible/callback_plugins/machine_audit_callback.py
@@ -1,0 +1,188 @@
+# callback to store server audit data
+
+# ===== READ ME =====
+# This has to be installed as a callback plugin to your Ansible setup.
+# The location of your callback plugins directory is set in your Ansible
+# configuration as the value of "callback_plugins".  The default location is
+# /usr/share/ansible_plugins/callback_plugins but this can be changed.
+#
+# Copy this file to your callback plugins directory.  You may have to create
+# the directory if it doesn't exist.
+
+
+import os
+import time
+import json
+import humanize
+
+TIME_FORMAT='%Y-%m-%d-%H-%M'
+outputdir = "machine_audit"
+
+
+def prepfile():
+  # ensure that the output directory is present
+  if not os.path.exists(outputdir):
+    os.makedirs(outputdir)
+  outputfilename = 'machine_audit.csv'
+  outputline = 'Hostname,Reachable,IPv4 address,IPv4 network,vCPUs,RAM total GB,RAM free GB,mount sizes,total storage,used storage,swap GB,Linux distro,distro version,Tomcat dir/s,Tomcat webapps,Tomcat version,Java version,Java vendor\n'
+  with open(outputdir + "/" + outputfilename, 'w') as of:
+    of.write(outputline + "\n")
+
+
+def logfail(host, data, failstring):
+  if data is None or isinstance(data, basestring):
+    outputfilename = 'machine_audit.csv'
+  else:
+    facts = data.get('ansible_facts', None)
+    outputfilename = facts.get('outputfile', 'machine_audit.csv')
+  outputline = "{hname},{fstring}".format(hname=host,fstring=failstring)
+  try:
+    with open(outputdir + "/" + outputfilename, 'a') as of:
+      of.write(outputline + "\n")
+  except:
+    pass
+
+def log(host, data):
+  if type(data) == dict:
+    invocation = data.pop('invocation', None)
+    if invocation.get('module_name', None) != 'machine_audit':
+      return
+
+  # debug
+  # print "ALL DATA: " + json.dumps(data)
+
+  facts = data.get('ansible_facts', None)
+
+  outputfilename = facts.get('outputfile', 'machine_audit.csv')
+
+  try:
+    # gather the useful data
+
+    # hostname
+    outputline = "{data},".format(data=host)
+    # if facts.get('ansible_fqdn', None) == 'localhost':
+    #   outputline = "{data},".format(data=facts.get('ansible_hostname', None))
+    # else:
+    #   outputline = "{data},".format(data=facts.get('ansible_fqdn', None))
+
+    # reachable
+    outputline += "OK,"
+    # IP
+    outputline += "{data},".format(data=facts.get('ansible_default_ipv4', None).get('address', None))
+    # network
+    outputline += "{data},".format(data=facts.get('ansible_default_ipv4', None).get('network', None))
+    # Data centre (Melbourne/Canberra)
+    # CPU allocation
+    outputline += "{data},".format(data=facts.get('ansible_processor_vcpus', None))
+    # RAM allocation in GB
+    totalram = float(facts.get('ansible_memtotal_mb', 0)) / 1024
+    outputline += "{0:.2f},".format(totalram)
+    # RAM free in GB
+    ramfree = float(facts.get('ansible_memfree_mb', 0)) / 1024
+    outputline += "{0:.2f},".format(ramfree)
+
+    # Disk partitions including current usage
+    totalstorage = 0
+    availstorage = 0
+    for thismount in facts.get('ansible_mounts'):
+      totalstorage += float(thismount.get('size_total'))
+      availstorage += float(thismount.get('size_available'))
+      totalsize = humanize.naturalsize(float(thismount.get('size_total')))
+      availsize = humanize.naturalsize(float(thismount.get('size_available')))
+      outputline += "{dname}:{total}({avail} avail) ".format(dname=thismount.get('device'),total=totalsize,avail=availsize)
+    outputline += ","
+    outputline += "{storagetotal},".format(storagetotal=humanize.naturalsize(totalstorage))
+    outputline += "{0:.1f}%,".format((1 - (availstorage/totalstorage)) * 100)
+
+    # Swap space in GB
+    swaptotal = float(facts.get('ansible_swaptotal_mb', 0)) / 1024
+    outputline += "{0:.2f},".format(swaptotal)
+    # Linux distro
+    outputline += "{data},".format(data=facts.get('ansible_distribution', None))
+    # Linux distro version
+    outputline += "{data},".format(data=facts.get('ansible_distribution_version', None))
+
+    machine_audit = data.get('machine_audit', None)
+    if machine_audit is not None:
+      # webapp dir/s
+      tomcatdirs = machine_audit.get('tomcat_dirs', None)
+      if tomcatdirs is not None:
+        for thistomcat in tomcatdirs:
+          outputline += "{data} ".format(data=thistomcat)
+      outputline += ","
+      # Webapps install
+      tomcatapps = machine_audit.get('tomcat_apps', None)
+      if tomcatapps is not None:
+        for thistomcat in tomcatapps:
+          outputline += "{data} ".format(data=thistomcat)
+      outputline += ","
+      # Tomcat version
+      tomcatversion = machine_audit.get('tomcat_version', None)
+      if tomcatversion is not None:
+          outputline += "{data} ".format(data=tomcatversion)
+      outputline += ","
+      # Java version
+      javaversion = machine_audit.get('java_version', None)
+      if javaversion is not None:
+          outputline += "{data} ".format(data=javaversion)
+      outputline += ","
+      # Java vendor (variant will be Oracle, Sun, or the dreaded IBM JDK)
+      javavendor = machine_audit.get('java_vendor', None)
+      if javavendor is not None:
+          outputline += "{data} ".format(data=javavendor)
+      outputline += ","
+      # DBs installed (MySQL, Postgres, Cassandra, MongoDB)
+      # Additional running processes (ActiveMQ, Jenkins)
+      # RAM allocation for Tomcat instances
+
+      # Open ports
+
+    # write the data
+    # print "callback filename is {fname}".format(fname=outputfilename)
+    # print "callback output line is {oline}".format(oline=outputline)
+    with open(outputdir + "/" + outputfilename, 'a') as of:
+      of.write(outputline + "\n")
+  except:
+    pass
+
+class CallbackModule(object):
+  def on_any(self, *args, **kwargs):
+    pass
+  def runner_on_failed(self, host, res, ignore_errors=False):
+    pass
+  def runner_on_ok(self, host, res):
+    log(host, res)
+  def runner_on_skipped(self, host, item=None):
+    logfail(host, res, 'Host skipped')
+  def runner_on_unreachable(self, host, res):
+    logfail(host, res, 'Unreachable')
+  def runner_on_no_hosts(self):
+    pass
+  def runner_on_async_poll(self, host, res, jid, clock):
+    pass
+  def runner_on_async_ok(self, host, res, jid):
+    pass
+  def runner_on_async_failed(self, host, res, jid):
+    pass
+  def playbook_on_start(self):
+    prepfile()
+  def playbook_on_notify(self, host, handler):
+    pass
+  def playbook_on_no_hosts_matched(self):
+    pass
+  def playbook_on_no_hosts_remaining(self):
+    pass
+  def playbook_on_task_start(self, name, is_conditional):
+    pass
+  def playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+    pass
+  def playbook_on_setup(self):
+    pass
+  def playbook_on_import_for_host(self, host, imported_file):
+    pass
+  def playbook_on_not_import_for_host(self, host, missing_file):
+    pass
+  def playbook_on_play_start(self, name):
+    pass
+  def playbook_on_stats(self, stats):
+    pass

--- a/ansible/library/machine_audit.py
+++ b/ansible/library/machine_audit.py
@@ -159,8 +159,36 @@ def get_custom_facts(module, data):
       elif javaminorversion == '7':
          data['machine_audit']['java_vendor'] = 'Oracle?'
 
-
     # DBs installed (MySQL, Postgres, Cassandra, MongoDB)
+    # MySQL
+    rc, out, err = module.run_command("which mysql")
+    if rc == 0:
+      # we appear to have MySQL installed
+      rc, out, err = module.run_command("mysql --version")
+      data['machine_audit']['mysql_version'] = out.split('\n')[0].split(',')[0]
+
+    # Postgres
+    rc, out, err = module.run_command("which psql")
+    if rc == 0:
+      # we appear to have Postgres installed
+      rc, out, err = module.run_command("psql --version")
+      data['machine_audit']['postgres_version'] = out.split('\n')[0].split(',')[0]
+
+    # Cassandra
+    rc, out, err = module.run_command("which cqlsh")
+    if rc == 0:
+      # we appear to have Cassandra installed
+      rc, out, err = module.run_command("cqlsh --version")
+      data['machine_audit']['cassandra_version'] = out.split('\n')[0].split(',')[0]
+
+    # MongoDB
+    rc, out, err = module.run_command("which mongod")
+    if rc == 0:
+      # we appear to have MongoDB installed
+      rc, out, err = module.run_command("mongod --version")
+      data['machine_audit']['mongodb_version'] = out.split('\n')[0].split(',')[0]
+
+    # solr: ala-bie1 (running)
 
     # Additional running processes (ActiveMQ, Jenkins)
 

--- a/ansible/library/machine_audit.py
+++ b/ansible/library/machine_audit.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Written by Matt Andrews for Atlas of Living Australia (ala.org.au)
+# as a custom Ansible module used to gather additional facts about
+# servers.  This is a fork of the core Ansible "setup" module.
+
+import os
+
+DOCUMENTATION = '''
+---
+module: machine_audit
+version_added: historical
+short_description: Gathers custom (Java oriented) facts about remote hosts
+description:
+     - This is a custom module which is a fork of the core 'setup' module. It
+      includes all the standard 'setup' fact-gathering, and also gathers more
+      facts about Tomcat web apps, Java virtual machines, etc.
+author: Matt Andrews (Michael DeHaan wrote the core setup module)
+'''
+
+EXAMPLES = """
+# Display facts from all hosts and store them indexed by I(hostname) at C(/tmp/facts).
+ansible all -m machine_audit --tree /tmp/facts
+
+"""
+
+
+def run_setup(module):
+
+    setup_options = dict(module_setup=True)
+    facts = ansible_facts(module)
+
+    for (k, v) in facts.items():
+        setup_options["ansible_%s" % k.replace('-', '_')] = v
+
+    # Look for the path to the facter and ohai binary and set
+    # the variable to that path.
+    facter_path = module.get_bin_path('facter')
+    ohai_path = module.get_bin_path('ohai')
+
+    # if facter is installed, and we can use --json because
+    # ruby-json is ALSO installed, include facter data in the JSON
+    if facter_path is not None:
+        rc, out, err = module.run_command(facter_path + " --puppet --json")
+        facter = True
+        try:
+            facter_ds = json.loads(out)
+        except:
+            facter = False
+        if facter:
+            for (k,v) in facter_ds.items():
+                setup_options["facter_%s" % k] = v
+
+    # ditto for ohai
+    if ohai_path is not None:
+        rc, out, err = module.run_command(ohai_path)
+        ohai = True
+        try:
+            ohai_ds = json.loads(out)
+        except:
+            ohai = False
+        if ohai:
+            for (k,v) in ohai_ds.items():
+                k2 = "ohai_%s" % k.replace('-', '_')
+                setup_options[k2] = v
+
+    setup_result = { 'ansible_facts': {} }
+
+    for (k,v) in setup_options.items():
+        if module.params['filter'] == '*' or fnmatch.fnmatch(k, module.params['filter']):
+            setup_result['ansible_facts'][k] = v
+
+    # hack to keep --verbose from showing all the setup module results
+    setup_result['verbose_override'] = True
+
+    return setup_result
+
+
+def get_custom_facts(module, data):
+    data['machine_audit'] = dict()
+
+    # Tomcat webapps
+    tomcat_apps_array = []
+    tomcat_dirs_present = []
+    tomcat_dirs = ['/var/lib/tomcat7/webapps','/usr/share/tomcat6/webapps','/usr/local/tomcat/webapps']
+    for thistomcatdir in tomcat_dirs:
+        if os.path.exists(thistomcatdir):
+          tomcat_dirs_present.append(thistomcatdir)
+          rc, out, err = module.run_command("ls -1 " + thistomcatdir)
+          if rc == 0:
+              for line in out.split('\n'):
+                tomcat_apps_array.append(line)
+    data['machine_audit']['tomcat_dirs'] = tomcat_dirs_present
+    data['machine_audit']['tomcat_apps'] = tomcat_apps_array
+
+    # Tomcat version
+    if len(tomcat_dirs_present) > 0:
+      if os.path.exists('/usr/share/tomcat7/bin/version.sh'):
+        rc, out, err = module.run_command('/usr/share/tomcat7/bin/version.sh')
+      elif os.path.exists('/usr/share/tomcat6/bin/version.sh'):
+        rc, out, err = module.run_command('/usr/share/tomcat6/bin/version.sh')
+      else:
+        # no version.sh so try ServerInfo
+        # remove /webapps from webapp dir path to get root dir
+        tomcat_root_dir = tomcat_dirs_present[0][0:-8]
+        rc, out, err = module.run_command("java -cp {rdir}/lib/catalina.jar org.apache.catalina.util.ServerInfo".format(rdir=tomcat_root_dir))
+      if rc == 0:
+          for line in out.split('\n'):
+              if 'Server version' in line:
+                  # Server version: Apache Tomcat/6.0.24
+                  data['machine_audit']['tomcat_version'] = line[16:]
+              elif 'JVM Version' in line:
+                  # JVM Version:    1.7.0_72-b14
+                  # ...but in IBM it looks like this:
+                  # JVM Version:    pxa6460sr8fp1-20100624_01 (SR8 FP1)
+                  try:
+                      float(line[0:2])
+                      data['machine_audit']['java_version'] = line[16:]
+                  except ValueError:
+                      pass
+
+              elif 'JVM Vendor' in line:
+                  # JVM Vendor:     Oracle Corporation
+                  data['machine_audit']['java_vendor'] = line[16:]
+
+    # RAM allocation for Tomcat instances
+
+
+    if 'java_version' not in data['machine_audit']:
+      # Java version installed
+      rc, out, err = module.run_command("which java")
+      # if Java is installed, get the version
+      if rc == 0:
+        rc, out, err = module.run_command("java -version")
+        # note java version output goes to stderr (!)
+        rawjavaversionlines = err.split('\n')
+        if len(rawjavaversionlines) > 0 and len(rawjavaversionlines[0]) > 0 and '\"' in rawjavaversionlines[0]:
+          data['machine_audit']['java_version'] = rawjavaversionlines[0].split('\"')[1]
+        # Java vendor (variant will be Oracle 6, 7 or the dreaded IBM JDK)
+        if 'IBM ' in err:
+          data['machine_audit']['java_vendor'] = 'IBM'
+    # java -XshowSettings:properties -version
+    if 'java_vendor' not in data['machine_audit']:
+      rc, out, err = module.run_command("which java")
+      if rc == 0:
+        rc, out, err = module.run_command("java -XshowSettings:properties -version")
+        # note java version output goes to stderr (!)
+        rawjavaversionlines = err.split('\n')
+        for thisline in rawjavaversionlines:
+          if 'java.vm.vendor' in thisline:
+            # java.vm.vendor = Oracle Corporation
+            data['machine_audit']['java_vendor'] = thisline.split('=')[1][1:]
+    # If we still don't have the vendor, throw in a guess
+    if 'java_vendor' not in data['machine_audit'] and 'java_version' in data['machine_audit']:
+      javaminorversion = data['machine_audit']['java_version'].split('.')[1]
+      if javaminorversion == '6':
+         data['machine_audit']['java_vendor'] = 'Sun?'
+      elif javaminorversion == '7':
+         data['machine_audit']['java_vendor'] = 'Oracle?'
+
+
+    # DBs installed (MySQL, Postgres, Cassandra, MongoDB)
+
+    # Additional running processes (ActiveMQ, Jenkins)
+
+    # Open ports
+
+    return data
+
+
+def main():
+    global module
+    module = AnsibleModule(
+        argument_spec = dict(
+            filter=dict(default="*", required=False),
+            fact_path=dict(default='/etc/ansible/facts.d', required=False),
+        ),
+        supports_check_mode = True,
+    )
+    data = run_setup(module)
+    data = get_custom_facts(module, data)
+    module.exit_json(**data)
+
+# import module snippets
+
+from ansible.module_utils.basic import *
+
+from ansible.module_utils.facts import *
+
+main()

--- a/ansible/machine_audit.yml
+++ b/ansible/machine_audit.yml
@@ -1,0 +1,6 @@
+---
+- hosts: ala
+  gather_facts: no
+  tasks:
+  - name: machine audit
+    machine_audit: filter=*


### PR DESCRIPTION
This adds "machine audit", which consists of a playbook, an inventory, a callback plugin and a module.  It gathers facts about servers and outputs a .csv file (in the machine_audit dir) with the results.

Soon to come:
- get Tomcat 5 info (currently only 6 and 7)
- get Solr info