### PR TITLE
Tomcat deploy task doesn't try to backup inexistent files anymore.

### DIFF
--- a/ansible/roles/tomcat_deploy/tasks/main.yml
+++ b/ansible/roles/tomcat_deploy/tasks/main.yml
@@ -19,8 +19,13 @@
   notify:
     - restart tomcat
 
+- name: check war file existence
+  stat: path="{{ tomcat_deploy_dir }}/{{ war_filename }}"
+  register: war_exist
+
 - name: back up existing war file
   shell: "sudo cp {{ tomcat_deploy_dir }}/{{ war_filename }}.war {{ backup_dir | default('/data') }}/{{ war_filename }}_`date '+%Y%m%d%H%M%S'`.war"
+  when: war_exist.stat.exists == True
 
 - name: remove existing webapp (to ensure a clean redeployment)
   file: path="{{ tomcat_deploy_dir }}/{{ war_filename }}" state=absent


### PR DESCRIPTION
Hi guys,

When playing with the last version of the Ansible scripts, I noticed errors because Tomcat deploy launch the new backup task unconditionally. This fails the first time, since there's no war file to copy.

I seems this patch fix the issue, but I'm very new to Ansible.