### PR TITLE
Change Ansible instructions to install from PIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@ NOTE: many linux packages have an older version of Ansible (1.7 or even 1.5). Yo
 For APT:
 ```
 $ sudo apt-get install software-properties-common python-dev git python-pip
-$ git clone https://github.com/ansible/ansible.git
-$ cd ansible
-$ git checkout v1.8.4
-$ git submodule update --init --recursive
-$ sudo make install
+$ sudo pip install -I ansible==1.8.4
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ NOTE: many linux packages have an older version of Ansible (1.7 or even 1.5). Yo
 
 For APT:
 ```
-$ sudo apt-get install software-properties-common
-$ sudo apt-add-repository ppa:ansible/ansible
-$ sudo apt-get update
-$ sudo apt-get install ansible
+$ sudo apt-get install software-properties-common python-dev git python-pip
+$ git clone https://github.com/ansible/ansible.git
+$ cd ansible
+$ git checkout v1.8.4
+$ sudo make install
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ $ sudo apt-get install software-properties-common python-dev git python-pip
 $ git clone https://github.com/ansible/ansible.git
 $ cd ansible
 $ git checkout v1.8.4
+$ git submodule update --init --recursive
 $ sudo make install
 ```
 


### PR DESCRIPTION
The PPA that was referenced is currently hosting ansible-2.0, and may bump to ansible-2.1 in the near future. Checking out ansible-1.8.4 from Git is the safest way to ensure that it is used consistently instead of the newer versions.