### PR TITLE
Tuning for cassandra

### DIFF
--- a/ansible/roles/cassandra/templates/cassandra.yaml
+++ b/ansible/roles/cassandra/templates/cassandra.yaml
@@ -485,7 +485,7 @@ compaction_throughput_mb_per_sec: 16
 # Track cached row keys during compaction, and re-cache their new
 # positions in the compacted sstable.  Disable if you use really large
 # key caches.
-compaction_preheat_key_cache: true
+compaction_preheat_key_cache: false
 
 # Throttles all outbound streaming file transfers on this node to the
 # given total throughput in Mbps. This is necessary because Cassandra does


### PR DESCRIPTION
This Pull Request is to track changes to the cassandra-1.2 configuration to prevent it getting bottlenecked on cassandra-b4. Cassandra was bottlenecked multiple times in the past 2-3 weeks during both processing (loading) and reindexing.

The following are some JMX traces obtained that illustrate the times where Cassandra bottlenecks and is unable to release memory when the stack becomes 99.99% full, but generally continues to do attempt to do so instead of crashing. In order to also track the Solr activity when crashes occurred, some of the screen shots below also include the solr-b3 JMX heap traces. They are distinguishable based on the heap size, as Solr has a 90+GB heap, where Cassandra has a less than 20GB heap:
![screen shot 2016-11-10 at 4 08 44 pm](https://cloud.githubusercontent.com/assets/82365/20468018/03787c3e-afe6-11e6-9898-b2056600e476.png)
![screen shot 2016-11-14 at 1 37 21 pm](https://cloud.githubusercontent.com/assets/82365/20468036/35ce2d46-afe6-11e6-8e5d-c9aec26f2629.png)
![screen shot 2016-11-15 at 1 11 07 pm](https://cloud.githubusercontent.com/assets/82365/20468042/504e257c-afe6-11e6-83e1-e748a8766a94.png)


Not all of these changes have actually been tested yet, but they are candidates.

# Increase Java heap memory to 16GB

Java heap memory was limited to 12GB. This was showing issues when processing (loading) large (1-2M record) datasets, but on its own isn't a full fix, as issues also occurred over the weekend during a complete reindex, which only reads from Cassandra.

# Disable compaction_preheat_key_cache in cassandra:

compaction_preheat_key_cache doesn't seem to fit our bulk loading or bulk indexing workflows. 

In the bulk loading scenario, once a record with a given key has been written to once, it isn't expected to be read again within the next few seconds, so if compaction occurs during that time it doesn't need to result in the key cache staying up to date.

In the bulk indexing scenario, if compaction occurs for any reason on some part of the database, it is likely a section that has already been read, so if it is compacted by the automatic compaction process, it isn't likely to be needed in the next few seconds again.