### PR TITLE
Add a new Tomcat7 java8 role used by OZCAM, AMRIN, and ASBP

### DIFF
--- a/ansible/amrin-hub-standalone.yml
+++ b/ansible/amrin-hub-standalone.yml
@@ -1,7 +1,7 @@
 - hosts: amrin-hub-standalone
   roles:
     - common
-    - java
-    - tomcat
+    - java8
+    - tomcat7-java8
     - apache
     - { role: biocache-hub, biocache_hub: amrin-hub, grouped_facets_json: grouped_facets_amrin.json }

--- a/ansible/asbp-hub-standalone.yml
+++ b/ansible/asbp-hub-standalone.yml
@@ -1,7 +1,7 @@
 - hosts: asbp-hub-standalone
   roles:
     - common
-    - java
-    - tomcat
+    - java8
+    - tomcat7-java8
     - apache
     - { role: biocache-hub, biocache_hub: asbp-hub, grouped_facets_json: grouped_facets_asbp.json }

--- a/ansible/ozcam-hub-standalone.yml
+++ b/ansible/ozcam-hub-standalone.yml
@@ -1,7 +1,7 @@
 - hosts: ozcam-hub-standalone
   roles:
     - common
-    - java
-    - tomcat
+    - java8
+    - tomcat7-java8
     - apache
     - { role: biocache-hub, biocache_hub: ozcam-hub, grouped_facets_json: grouped_facets_ozcam.json }

--- a/ansible/roles/tomcat7-java8/defaults/main.yml
+++ b/ansible/roles/tomcat7-java8/defaults/main.yml
@@ -1,0 +1,11 @@
+# common variables across all roles
+tomcat_java_opts: -Xmx2g -Xms2g -XX:MaxPermSize=256m -Xss256k -Djava.awt.headless=true
+tomcat_control_port: 8005
+tomcat_http: true
+tomcat_http_port: 8080
+tomcat_ajp: false
+tomcat_ajp_port: 8009
+tomcat_apr: true
+tomcat_users: true
+tomcat_autoDeploy: true
+tomcat_bind_addr: 0.0.0.0

--- a/ansible/roles/tomcat7-java8/handlers/main.yml
+++ b/ansible/roles/tomcat7-java8/handlers/main.yml
@@ -1,0 +1,14 @@
+# common handlers that various roles can call
+
+# variable controls version (@see common/vars)
+- name: restart tomcat
+  service: name={{tomcat}} state=restarted
+
+- name: restart httpd
+  service: name={{apache}} state=restarted
+
+- name: restart apache
+  service: name={{apache}} state=restarted
+
+- name: restart mysql
+  service: name=mysqld state=restarted

--- a/ansible/roles/tomcat7-java8/meta/main.yml
+++ b/ansible/roles/tomcat7-java8/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - { role: augeas }
+  - { role: java8 }

--- a/ansible/roles/tomcat7-java8/tasks/main.yml
+++ b/ansible/roles/tomcat7-java8/tasks/main.yml
@@ -1,0 +1,80 @@
+# set up tomcat consistently whenever needed.  Used as:
+# - include: ../common/tasks/tomcat.yml 
+# "tomcat" variable controls version (@see common/vars)
+- include: ../../common/tasks/setfacts.yml 
+  tags:
+    - packages
+    - tomcat7-java8
+
+- name: install libtcnative-1 (RedHat)
+  yum: pkg={{libtcnative}} state=present
+  when: ansible_os_family == "RedHat" and tomcat_apr == true
+  tags:
+    - packages
+    - tomcat7-java8
+
+- name: install tomcat (RedHat)
+  yum: name={{tomcat}} state=present
+  notify: 
+    - restart tomcat
+  when: ansible_os_family == "RedHat"
+  tags:
+    - packages
+    - tomcat7-java8
+
+- name: install libtcnative-1 (Debian)
+  apt: pkg={{libtcnative}} state=present update_cache=yes
+  when: ansible_os_family == "Debian" and tomcat_apr == true
+  tags:
+    - packages
+    - tomcat7-java8
+
+- name: install tomcat (Debian)
+  apt: pkg={{tomcat}} state=present update_cache=yes
+  when: ansible_os_family == "Debian"
+  register: tomcat_installed
+  tags:
+    - packages
+    - tomcat7-java8
+
+- name: enable the AJP 1.3 connector
+  tomcat_connector: name="AJP/1.3"
+  tags: 
+    - tomcat7-java8
+  notify:
+    - restart tomcat
+
+# replace the commented out java_opts that ships with the CentOS install which is:
+# JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"        
+- name: configure tomcat memory (RedHat)
+  lineinfile: 
+    dest={{tomcat_conf}}
+    regexp="^JAVA_OPTS"
+    line='JAVA_OPTS="{{tomcat_java_opts}} -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory"'
+  notify: 
+    - restart tomcat
+  when: ansible_os_family == "RedHat"
+  tags:
+    - tomcat7-java8
+
+- name: configure tomcat memory (Debian)
+  lineinfile: 
+    dest={{tomcat_conf}}
+    regexp="^JAVA_OPTS"
+    line='JAVA_OPTS="{{tomcat_java_opts}}"'
+  notify: 
+    - restart tomcat
+  when: ansible_os_family == "Debian"
+  tags:
+    - tomcat7-java8
+
+- name: Set JAVA_HOME  (Debian)
+  lineinfile: " 
+    dest={{tomcat_conf}}
+    regexp=^JAVA_HOME
+    line='JAVA_HOME=/usr/lib/jvm/java-8-oracle'"
+  notify: 
+    - restart tomcat    
+  when: ansible_os_family == "Debian"
+  tags:
+    - tomcat7-java8

--- a/ansible/roles/tomcat7-java8/vars/main.yml
+++ b/ansible/roles/tomcat7-java8/vars/main.yml
@@ -1,0 +1,1 @@
+# common variables across all roles


### PR DESCRIPTION
Deploying these three thin hubs required updating them to Java-8 per the removal of the Oracle Java-7 JDK from unauthenticated access and the lack of OpenJDK-7 in Ubuntu-16.04.

I wasn't able to completely automate the process, as the apt-get install for tomcat7 failed when restarting tomcat and didn't allow ansible to proceed until I manually edited the /etc/default/tomcat7 file to add the desired JAVA_HOME location.

At least one suggested solution for this is just to always edit the file yourself, but not sure how it could otherwise be automated, as it fails during the ansible call to "apt-get install tomcat7", and the /etc/default/tomcat7 file is not present before that call, so not clear how you could otherwise edit it using an automated script.

https://askubuntu.com/questions/154953/specify-jdk-for-tomcat7