### PR TITLE
Deploy collectory-test with mysql-5.7

### DIFF
--- a/ansible/collectory-standalone.yml
+++ b/ansible/collectory-standalone.yml
@@ -1,8 +1,8 @@
 - hosts: collectory
   roles:
     - common
-    - java
-    - mysql
-    - tomcat
+    - java8
+    - mysql-5.7
+    - tomcat7-java8
     - apache
     - collectory

--- a/ansible/roles/java8/tasks/main.yml
+++ b/ansible/roles/java8/tasks/main.yml
@@ -2,6 +2,14 @@
   tags:
     - java8
 
+# OpenJDK-8 is needed to fulfill the default JRE role so Tomcat can be installed
+# Note, oracle-java8-set-default is installed later on so it is used by default
+- name: install openjdk 8 java (Debian)
+  apt: pkg=openjdk-8-jdk state=present update_cache=yes
+  when: ansible_os_family == "Debian"
+  tags:
+    - java
+
 - name: Install add-apt-repostory
   sudo: yes
   apt: name=software-properties-common state=latest

--- a/ansible/roles/mysql-5.7/handlers/main.yml
+++ b/ansible/roles/mysql-5.7/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart mysql
+  service: name={{mysql_service}} state=restarted

--- a/ansible/roles/mysql-5.7/tasks/main.yml
+++ b/ansible/roles/mysql-5.7/tasks/main.yml
@@ -1,0 +1,54 @@
+- include: ../../common/tasks/setfacts.yml
+
+- name: install mysql (RedHat)
+  yum: name={{item}} state=present
+  with_items:
+    - mysql-server
+    - MySQL-python
+  tags:
+    - packages 
+  register: mysql_installed
+  notify: 
+    - restart mysql
+  when: ansible_os_family == "RedHat"
+
+- name: install mysql (Debian)
+  apt: pkg={{item}} state=present
+  with_items:
+    - mysql-server-5.7
+    - python-mysqldb
+  tags:
+    - packages 
+  register: mysql_installed
+  notify: 
+    - restart mysql
+  when: ansible_os_family == "Debian"
+
+- name: warn about using the default root user password
+  debug: msg="You are installing MySQL with a default root password of 'password'. Are you sure you want to do that? Specify a real password in your inventory file using the variable mysql_root_password."
+  when: mysql_installed.changed and  mysql_root_password is not defined
+
+- name: change root user password on first run
+  mysql_user: name=root password={{ mysql_root_password | default('password') }} priv=*.*:ALL,GRANT host={{ item }}
+  with_items:
+    - "{{ ansible_hostname }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
+  when: mysql_installed.changed
+
+- name: delete anonymous MySQL user for the host
+  mysql_user: user="" host="{{ansible_hostname}}" login_user="root" login_password={{ mysql_root_password | default('password') }} state="absent"
+  when: mysql_installed.changed
+
+- name: delete anyonmous MySQL user for localhost
+  mysql_user: user="" login_user="root" login_password={{ mysql_root_password | default('password') }} state="absent"
+  when: mysql_installed.changed
+
+- name: drop test database
+  mysql_db: name="test" login_user="root" login_password={{ mysql_root_password | default('password') }} state="absent"
+  when: mysql_installed.changed
+
+- name: create my.cnf file 
+  template: src=my.cnf dest=/root/.my.cnf owner=root mode=0600
+  when: mysql_installed.changed

--- a/ansible/roles/mysql-5.7/templates/my.cnf
+++ b/ansible/roles/mysql-5.7/templates/my.cnf
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_password | default('password') }}

--- a/ansible/roles/nameindex/tasks/main.yml
+++ b/ansible/roles/nameindex/tasks/main.yml
@@ -52,6 +52,12 @@
   tags:
     - "nameindex"
 
+- name: Download lucene index (ALA)
+  get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene force={{ force_nameindex_download | default(false) }}
+  when: nameindex_variant == "ala"
+  tags:
+    - "nameindex"
+
 - name: unpackage the lucene index if it was newly copied
   unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/namematching copy=no
   when: nameindex_variant != "ala"


### PR DESCRIPTION
Fixes #131 , #132 and #133 to get collectory-test deploying successfully to ubuntu 16.04. This does not include the collectory code changes that @charvolant is doing separately, it only includes ansible changes necessary to get the ansible scripts running again.