### PR TITLE
Fix / role:nameindexer / souces path

### DIFF
--- a/ansible/roles/nameindexer/tasks/main.yml
+++ b/ansible/roles/nameindexer/tasks/main.yml
@@ -4,7 +4,7 @@
     - "nameindexer"
 
 - name: ensure lucene sources directory exists
-  file: path=/data/lucene/sources state=directory
+  file: path={{data_dir}}/lucene/sources state=directory
   tags:  
     - "data_archives"  
     - "nameindexer"  


### PR DESCRIPTION
**Reason:** This role not work when `data_dir` variable is different of `/data`.
