### PR TITLE
issue #232 : Initial support for max_conns in nginx configuration

### DIFF
--- a/ansible/roles/nginx_vhost/defaults/main.yml
+++ b/ansible/roles/nginx_vhost/defaults/main.yml
@@ -49,3 +49,8 @@ nginx_cache_valid_time: "60m"
 nginx_cache_invalid_time: "0s"
 # Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time
 clear_vhost_fragments: false
+# Set this to true to enable support for 'upstream' load balancing features
+nginx_load_balancing: false
+# When load balancing is enabled, this is used to specify the maximum number of connections from nginx to the upstream load balanced server
+# This is used to avoid denial of service on the upstream server when it is under load
+nginx_max_conns: 50

--- a/ansible/roles/nginx_vhost/tasks/defaulthost.yml
+++ b/ansible/roles/nginx_vhost/tasks/defaulthost.yml
@@ -41,6 +41,16 @@
   tags:
     - nginx_vhost
 
+- name: add upstream fragment
+  template:
+    src: "fragment_02_upstream.j2"
+    dest: "{{nginx_conf_dir}}/vhost_fragments/ala_default/02_upstream_ala_default_127.0.0.1_{{ tomcat_server_port | default('8080', True) }}"
+  when: ala_default_vhost and vhost_required and nginx_load_balancing | bool == true and item.is_proxy and item.proxy_pass is defined
+  with_items:
+    - "{{ nginx_paths}} "
+  tags:
+    - nginx_vhost
+
 - name: add start of default vhost for ala
   template:
     src: "ala_default_start.j2"

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -117,6 +117,16 @@
   tags:
     - nginx_vhost
 
+- name: add upstream fragment
+  template:
+    src: "fragment_02_upstream.j2"
+    dest: "{{nginx_conf_dir}}/vhost_fragments/{{hostname}}/http_02_upstream_{{ hostname }}_127.0.0.1_{{ tomcat_server_port | default('8080', True) }}"
+  when: vhost_required and nginx_load_balancing | bool == true and item.is_proxy and item.proxy_pass is defined
+  with_items:
+    - "{{ nginx_paths}} "
+  tags:
+    - nginx_vhost
+
 - name: add blocking fragment
   template:
     src: "fragment_03_blocking.j2"

--- a/ansible/roles/nginx_vhost/templates/fragment_02_upstream.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_02_upstream.j2
@@ -1,0 +1,9 @@
+{% if nginx_load_balancing | bool == true %}
+{% if item.is_proxy %}
+{% set upstream_proxy_pass_var = "127.0.0.1:" ~ tomcat_server_port | default('8080', True) %}
+# Load balancing configuration
+upstream {{ hostname }}_{{ upstream_proxy_pass_var | regex_replace(':', '_') }}_backend{{ '_ala_default' if ala_default_vhost is defined and ala_default_vhost else '' }} {
+    server {{ upstream_proxy_pass_var }} max_conns={{ nginx_max_conns }};
+}
+{% endif %}
+{% endif %}

--- a/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
@@ -42,7 +42,12 @@
         proxy_ignore_client_abort on;
     {% endif %}
   {% endif %}
+{% if nginx_load_balancing | bool == true %}
+        # This backend is defined in the upstream section of the same name
+        proxy_pass http://{{ hostname }}_127.0.0.1_{{tomcat_server_port | default('8080', True)}}_backend{{ '_ala_default' if ala_default_vhost is defined and ala_default_vhost else '' }}{% if item.path|length == 0 %}/{% elif item.path|first == '/' %}{{ item.path }}{% else %}/{{ item.path }}{% endif %};
+{% else %}
         proxy_pass {{ item.proxy_pass }};
+{% endif %}
 {% elif item.is_proxy_rewrite is defined and item.is_proxy_rewrite %}
         rewrite ^{{ item.path }}/?(.*) /$1 break;
         proxy_pass {{ item.proxy_pass }};


### PR DESCRIPTION
If there is at least one item in the `nginx_paths` list with `is_proxy=True`, this will create an `upstream` unique to the `hostname` and the proxied IP (currently hardcoded to `127.0.0.1` which matches the rest of the configuration) and the proxied port.

By default it allows 50 concurrent connections to the proxied server, but this is configurable. Testing for this was done on `test-bhub-b5-2` and `test-bws-b5-2`, with `nginx_max_conns` set to `8` to verify that it blocks on multiple queries.

No stress testing was performed as those instances are connected to the production solr cloud.

The `nginx_load_balancing` setting must be switched on to opt-in to the new features so they won't influence current servers that are not trialing this. Eventually, it may be switched on by default.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>