### PR TITLE
More configurable maps and layers urls

### DIFF
--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -66,8 +66,8 @@ collections.baseUrl={{collectory_url}}
 collectory.resources={{collectory_url}}/public/resources.json
 spatial.baseUrl={{spatial_base_url | default('https://spatial.ala.org.au')}}
 spatial.baseURL={{spatial_base_url | default('https://spatial.ala.org.au')}}
-layersservice.baseUrl={{spatial_base_url | default('https://spatial.ala.org.au/ws')}}
-layersservice.url={{spatial_base_url | default('https://spatial.ala.org.au/ws')}}
+layersservice.baseUrl={{(layers_base_url | default(spatial_base_url)) | default('https://spatial.ala.org.au/ws')}}
+layersservice.url={{(layers_base_url | default(spatial_base_url)) | default('https://spatial.ala.org.au/ws')}}
 userDetails.url={{userdetails_base_url | default('https://auth.ala.org.au/userdetails')}}
 userdetails.baseUrl={{userdetails_base_url | default('https://auth.ala.org.au/userdetails')}}
 alerts.baseUrl={{ alerts_url | default('https://alerts.ala.org.au') }}
@@ -131,7 +131,7 @@ map.height={{map_height|default('600')}}
 geocode.region={{geocode_region | default('AU')}}
 
 map.minimal.url={{ map_mininal_url | default('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png') }}
-map.overlay.url={{spatial_base_url | default('https://spatial.ala.org.au')}}/geoserver/ALA/wms
+map.overlay.url={{ (map_overlay_base_url | default(spatial_base_url)) | default('https://spatial.ala.org.au')}}/geoserver/ALA/wms
 
 mapdownloads.baseLayers.states.name={{mapdownloads_baselayers_states_name | default('aus1')}}
 mapdownloads.baseLayers.states.i18nCode={{mapdownloads_baselayers_states_i18ncode | default('baselayer.states')}}


### PR DESCRIPTION
This small patch allow to use different urls for you layers and/or geoserver service if they are different from `spatial_base_url`.

If `layers_base_url` is not defined it uses `spatial_base_url` as before, etc. Same with `map_overlay_base_url`.