### PR TITLE
issue #253 : Test clearing vhost fragments

### DIFF
--- a/ansible/inventories/workshop/demo-livingatlas.yml
+++ b/ansible/inventories/workshop/demo-livingatlas.yml
@@ -294,3 +294,6 @@ postgis_version=9.6
 pg_service=postgresql-9.6
 pg_version=9.6
 postgis_version=2.4
+# Needed for installing on Ubuntu-18.04
+# https://github.com/AtlasOfLivingAustralia/biocache-service/issues/363
+tomcat=tomcat7

--- a/ansible/inventories/workshop/demo-livingatlas.yml
+++ b/ansible/inventories/workshop/demo-livingatlas.yml
@@ -211,6 +211,7 @@ caches_layers_enabled=false
 
 webserver_nginx=true
 ssl=false
+nginx_vhost_fragments_to_clear=["demo.livingatlas.org"]
 
 nameindex_variant=ala
 nameindex_datestamp=20171012


### PR DESCRIPTION
Test clearing vhost fragments for demo.livingatlas.org

It is possible that the cause of issue #253 was a change in the name of the fragment file. The only known fix for this is to clear the vhost fragments completely at the start of the ansible run.

IMPORTANT: This unfortunately breaks the ability to use tags to skip any `nginx_vhost` role calls as doing so will result in an incomplete nginx configuration.

CC @vjrj 