### PR TITLE
Include userdetails url

### DIFF
--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -34,6 +34,7 @@ biocacheService.baseURL = {{ biocache_url | default('https://biocache.ala.org.au
 spatial.baseURL = {{ spatial_url | default('https://spatial.ala.org.au') }}
 collectory.baseURL = {{ collectory_url | default('https://collections.ala.org.au') }}
 ala.userDetailsURL = {{ userdetails_url | default('https://auth.ala.org.au/userdetails') }}/userDetails/getUserListFull
+userDetails.url={{ userdetails_base_url }}{{ userdetails_context_path }}
 
 # Emails
 postie.emailSender={{ email_sender | default('atlas-alerts@ala.org.au') }}


### PR DESCRIPTION
Otherwise userdetails-service-client defaults to using auth.ala.org.au/userdetails which fails for non-ALA setups, locking all users in the alerts database.