### PR TITLE
Fix some configuration names that makes cas-management not to start

### DIFF
--- a/ansible/roles/cas-management/templates/application.properties
+++ b/ansible/roles/cas-management/templates/application.properties
@@ -3,10 +3,10 @@
 cas.server.name={{ cas_server_name }}
 cas.server.prefix=${cas.server.name}/{{ cas_context_path | default('cas') }}
 
-cas.mgmt.serverName={{ cas_management_server_name }}
-cas.mgmt.adminRoles[0]=ROLE_ADMIN
-cas.mgmt.authzAttributes[0]=role
-cas.mgmt.userPropertiesFile=file:/data/cas-management/config/users.properties
+mgmt.serverName={{ cas_management_server_name }}
+mgmt.adminRoles[0]=ROLE_ADMIN
+mgmt.authzAttributes[0]=role
+mgmt.userPropertiesFile=file:/data/cas-management/config/users.properties
 
 server.context-path=/{{ cas_management_context_path | default('cas-management') }}
 server.port={{ cas_management_server_port | default(8070) }}


### PR DESCRIPTION
The current configuration with `cas-management` `5.3.1-1-SNAPSHOT` fails with errors like:
```
mgmt[userPropertiesFile is not readable or has an invalid getter method
```
renaming that params `cas-management` starts without errors.