### PR TITLE
Added login/logout CAS urls to collectory config

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -9,6 +9,11 @@ security.cas.authenticateOnlyIfLoggedInFilterPattern={{ collectory_authenticate_
 security.cas.uriExclusionFilterPattern={{ collectory_exclusion_filter_pattern | default('/images.*,/css.*,/js.*') }}
 security.cas.appServerName={{ collectory_base_url }}
 security.cas.casServerUrlPrefix={{ auth_base_url }}/cas
+security.cas.casServerLoginUrl={{ auth_base_url }}/cas/login
+security.cas.casServerLogoutUrl={{ auth_base_url }}/cas/logout
+security.cas.loginUrl={{ auth_base_url }}/cas/login
+security.cas.logoutUrl={{ auth_base_url }}/cas/logout
+
 security.cas.contextPath={{ collectory_context_path }}
 
 security.apikey.serviceUrl={{ apikey_service_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=')}}


### PR DESCRIPTION
Added some CAS login/logout urls to collectory config so its not redirect to `auth.ala.org.au` in non-ALA nodes using CAS.