### PR TITLE
Skip swapoff in LXC containers

### DIFF
--- a/ansible/roles/biocache-db/tasks/main.yml
+++ b/ansible/roles/biocache-db/tasks/main.yml
@@ -2,6 +2,9 @@
 
 - name: disable swap
   shell: "swapoff --all"
+  # This fails in LXC containers, see:
+  # https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/930652
+  ignore_errors: true
   tags:
     - biocache_db
 

--- a/ansible/roles/biocache-db/tasks/main.yml
+++ b/ansible/roles/biocache-db/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: "swapoff --all"
   # This fails in LXC containers, see:
   # https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/930652
-  ignore_errors: true
+  when: ansible_virtualization_type != 'lxc'
   tags:
     - biocache_db
 


### PR DESCRIPTION
`swapoff` fails in LXC containers so we can skip this task.