### PR TITLE
Consistent ala-hub var with demo & workshop inventories

### DIFF
--- a/ansible/roles/image-service/templates/config/config.properties
+++ b/ansible/roles/image-service/templates/config/config.properties
@@ -22,7 +22,7 @@ skin.layout={{ skin_layout | default('main') }}
 skin.favicon={{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon-16x16.png') }}
 orgNameLong={{ orgNameLong | default('Atlas') }}
 collectory.baseURL = {{ collectory_url | default('https://collections.ala.org.au')}}
-biocache.baseURL = {{ biocache_url | default('https://biocache.ala.org.au')}}
+biocache.baseURL = {{ (biocache_hub_url | default(biocache_url)) | default('https://biocache.ala.org.au')}}
 
 #header block
 headerAndFooter.baseURL={{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs2')}}


### PR DESCRIPTION
`biocache_url` is not used in demo and workshop inventories but `biocache_hub_url` so I added trying to not to break other inventories.
```
$ grep biocache_hub_url ansible/inventories/workshop/demo-livingatlas.yml ansible/inventories/living-atlas
ansible/inventories/workshop/demo-livingatlas.yml:biocache_hub_url = http://demo.livingatlas.org/ala-hub
ansible/inventories/living-atlas:biocache_hub_url = http://living-atlas.org/ala-hub
$ grep biocache_url ansible/inventories/workshop/demo-livingatlas.yml ansible/inventories/living-atlas 
$ echo $?
1
```