### PR TITLE
Consistent logger vars with demo&workshop playbooks

### DIFF
--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -72,8 +72,8 @@ userDetails.url={{userdetails_base_url | default('https://auth.ala.org.au/userde
 userdetails.baseUrl={{userdetails_base_url | default('https://auth.ala.org.au/userdetails')}}
 alerts.baseUrl={{ alerts_url | default('https://alerts.ala.org.au') }}
 doiService.baseUrl={{ doi_service_url | default('https://doi.ala.org.au')}}
-logger.baseUrl={{ logger_service_url | default('https://logger.ala.org.au/service')}}
-loggerURL={{ logger_service_url | default('https://logger.ala.org.au/service')}}
+logger.baseUrl={{ (logger_service_url | default(logger_webservice_url)) | default('https://logger.ala.org.au/service')}}
+loggerURL={{ (logger_service_url | default(logger_webservice_url)) | default('https://logger.ala.org.au/service')}}
 sightings.baseUrl={{ sightings_base_url | default('https://sightings.ala.org.au')}}
 
 # Image viewer

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -85,7 +85,7 @@ disableLoggerLinks={{ disable_logger | default('true') }}
 rifcs.excludeBounds={{ rifcs_exclude_bounds | default('false') }}
 
 # Logger URL
-loggerURL={{ logger_url }}
+loggerURL={{ (logger_webservice_url | default(logger_url)) }}
 
 # External services
 alertUrl={{ alert_url | default('') }}


### PR DESCRIPTION
Added `logger_webservice_url` used in demo&workshop playbooks trying to not break things in other playbooks that do not use this var.