### PR TITLE
Consistent bie vars with demo&workshop inventories

### DIFF
--- a/ansible/roles/biocache-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache-properties/templates/biocache-config.properties
@@ -135,10 +135,10 @@ registry.api.key={{ registry_api_key | default('') }}
 allow.registry.updates={{ allow_registry_updates | default('true') }}
 
 # Base URL for taxon services (BIE)
-service.bie.ws.url={{ bie_service_url | default('https://bie-ws.ala.org.au/ws') }}
+service.bie.ws.url={{ (bie_service_url | default(bie_service_base_url)) | default('https://bie-ws.ala.org.au/ws') }}
 
 # Base URL for taxon pages (BIE)
-service.bie.ui.url={{ bie_url | default('https://bie.ala.org.au') }}
+service.bie.ui.url={{ (bie_url | default(bie_base_url)) | default('https://bie.ala.org.au') }}
 
 # Allow service to be disabled via config (enabled by default)
 service.bie.enabled={{ bie_service_enabled | default('false') }}


### PR DESCRIPTION
Same here, `bie_service_url` and `bie_url` is not used in demo&workshop inventories:

```
$ egrep "bie_service_url|bie_url" ansible/inventories/living-atlas ansible/inventories/workshop/demo-livingatlas.yml
$ echo $?
1
$ egrep "bie_service_base_url|bie_base_url" ansible/inventories/living-atlas ansible/inventories/workshop/demo-livingatlas.yml
ansible/inventories/living-atlas:bie_service_base_url = http://living-atlas.org/bie-index
ansible/inventories/living-atlas:bie_base_url = http://living-atlas.org/ala-bie
ansible/inventories/workshop/demo-livingatlas.yml:bie_service_base_url=http://demo.livingatlas.org/bie-index
ansible/inventories/workshop/demo-livingatlas.yml:bie_base_url=http://demo.livingatlas.org/ala-bie
ansible/inventories/workshop/demo-livingatlas.yml:bie_base_url = http://demo.livingatlas.org/ala-bie
```
