### PR TITLE
Use def namematching directory in demo inventory after #222 fix

### DIFF
--- a/ansible/inventories/living-atlas
+++ b/ansible/inventories/living-atlas
@@ -26,7 +26,6 @@ skin_home_url = http://living-atlas.org
 
 custom_namematching_url = https://s3.amazonaws.com/ala-nameindexes/latest/namematching-gbif-lucene5.tgz
 nameindex_to_use = custom
-name_index_dir=/data/lucene/namematching/namematching
 
 ####################### Biocache ##############################################
 


### PR DESCRIPTION
Removed `name_index_dir` from demo inventory so configures `biocache-service` to use:
```
name.index.dir=/data/lucene/namematching
```
default value instead of:
```
name.index.dir=/data/lucene/namematching/namematching
```
after #222 fix.