### PR TITLE
email download vars added to biocache template

### DIFF
--- a/ansible/roles/biocache-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache-properties/templates/biocache-config.properties
@@ -346,6 +346,10 @@ download.doi.failure.message={{ download_doi_failure_message | default('A DOI wa
 download.doi.email.template={{ download_doi_email_template | default('/data/biocache/config/download-doi-email.html')}}
 download.doi.readme.template={{ download_doi_readme_template | default('/data/biocache/config/download-doi-readme.html')}}
 
+email.sender={{ email_sender | default('support@ala.org.au') }}
+mail.smtp.host={{ mail_smtp_host | default('localhost') }}
+mail.smtp.port={{ mail_smtp_port | default('25') }}
+
 #DOI Default metadata
 doi.author={{ doi_author | default('Atlas Of Living Australia') }}
 doi.description={{ doi_description | default('ALA occurrence record download') }}


### PR DESCRIPTION
Just adding this email variables to `ala-install`:
https://github.com/AtlasOfLivingAustralia/biocache-service/blob/9f08a35b6b3735af5c69eace2d882a4bc367112d/src/main/java/au/org/ala/biocache/service/EmailService.java