### PR TITLE
Allow self-signed certs in geoserver check

### DIFF
--- a/ansible/roles/geoserver/tasks/main.yml
+++ b/ansible/roles/geoserver/tasks/main.yml
@@ -114,6 +114,7 @@
   uri:
     url: "{{ geoserver_url }}"
     status_code: 200
+    validate_certs: false
   register: result
   until: result.status is defined and result.status == 200
   retries: 200


### PR DESCRIPTION
When using self-signed certs the `geoserver` uri check task fails. Adding this var I can install the spatial playbook correctly using this `ssl` certs.

This is part of a plan to add `ssl` support to the yeoman generator, so it's more easy to configure ssl in new nodes.

I can improve this PR adding a new variable like `ssl_validate_certs` that defaults to `true`, that is the default uri behavior:
https://docs.ansible.com/ansible/latest/modules/uri_module.html
if you prefer...

