### PR TITLE
Fix postgis var definition checks

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -25,14 +25,13 @@
     - info
 
 - include: ./postgis.yml
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   tags:
     - postgresql
     - postgis
 
 - include: ./gdal.yml
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   tags:
     - postgresql
     - postgis
-

--- a/ansible/roles/postgresql/tasks/postgis.yml
+++ b/ansible/roles/postgresql/tasks/postgis.yml
@@ -2,7 +2,7 @@
   become: yes
   apt:
     pkg: acl
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   tags:
     - postgresql
     - postgis
@@ -12,7 +12,7 @@
     pkg: "{{ item }}"
     state: present
     update_cache: yes
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   with_items:
     - "postgresql-{{pg_version}}-postgis-{{postgis_version}}"
   tags:
@@ -23,7 +23,7 @@
   postgresql_db:
     db: postgis_template
     state: present
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   become: yes
   become_user: postgres
   tags:
@@ -32,7 +32,7 @@
 
 - name: make postgis_template a template
   action: command psql -d postgis_template -c "UPDATE pg_database SET datistemplate=true WHERE datname='postgis_template';"
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   become: yes
   become_user: postgres
   tags:
@@ -41,7 +41,7 @@
 
 - name: run the postgis SQL scripts
   action: command psql -d postgis_template -f {{ item }}
-  when: postgis_version is defined and postgis_version | length > 0
+  when: postgis_version
   become: yes
   become_user: postgres
   with_items:


### PR DESCRIPTION
After https://github.com/AtlasOfLivingAustralia/ala-install/commit/f079973be51fe2c198c89d67eaa4bcbac2526ccf new `postgis` var check fails with:

```
fatal: [core.biodiversityatlas.at]: FAILED! => {"msg": "The conditional check 'postgis_version is defined and postgis_version | length > 0' failed. The error was: Unexpected templating type error occurred on ({% if postgis_version is defined and postgis_version | length > 0 %} True {% else %} False {% endif %}): object of type 'float' has no len()\n\nThe error appears to be in '/home/ubuntu/Desktop/bio.at/ala-install/ansible/roles/postgresql/tasks/postgis.yml': line 1, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: install setfacl support\n  ^ here\n"}
```

or in summary, with `'float' has no len()` when using `postgis_version = 2.4`.

I just follow `ansiblelint` [suggestions](https://github.com/ansible/ansible-lint/blob/master/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py) but please double check.

cc @ansell 
