### PR TITLE
Use spatial 0.3 just released to prevent 404 when using old snapshots

### DIFF
--- a/ansible/roles/spatial-hub/vars/main.yml
+++ b/ansible/roles/spatial-hub/vars/main.yml
@@ -1,5 +1,5 @@
 # assets
-version: "{{ spatial_hub_version | default('0.3-SNAPSHOT') }}"
+version: "{{ spatial_hub_version | default('0.3') }}"
 artifactId: "{{ spatial_hub_artifact_id | default('spatial-hub') }}"
 classifier: "{{ spatial_hub_classifier | default('') }}"
 packaging: "war"

--- a/ansible/roles/spatial-service/vars/main.yml
+++ b/ansible/roles/spatial-service/vars/main.yml
@@ -1,5 +1,5 @@
 # assets
-version: "{{ spatial_service_version | default('0.3-SNAPSHOT') }}"
+version: "{{ spatial_service_version | default('0.3') }}"
 artifactId: "{{ spatial_service_artifact_id | default('spatial-service') }}"
 classifier: "{{ spatial_service_classifier | default('') }}"
 packaging: "war"


### PR DESCRIPTION
We get a 404 errors when trying to configure spatial in a demo for Tanzania:

```
TASK [spatial-service : download from maven repo] **********************************************************************************************************************│····················
fatal: [spatial.tanbif.or.tz]: FAILED! => {"changed": false, "dest": "/var/lib/tomcat7/webapps-spatial.tanbif.or.tz/ws.war", "elapsed": 2, "msg": "Request failed", "res│····················
ponse": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://nexus.ala.org.au/service/local/artifact/maven/redirect?r=public&g=au.org.ala&a=spatial-service&│····················
v=0.3-SNAPSHOT&e=war&c="}  
```
