### PR TITLE
Fix apt update so redis install don't give 404

### DIFF
--- a/ansible/cas5-standalone.yml
+++ b/ansible/cas5-standalone.yml
@@ -2,8 +2,10 @@
   tasks:
   - apt_repository:
       repo: ppa:chris-lea/redis-server
+      update_cache: yes
   - apt:
       name: "{{ packages }}"
+      update_cache: yes
     vars:
       packages:
       - redis-server


### PR DESCRIPTION
A basic repo update to prevent 404 errors trying to install redis from official repo.

```
fatal: [auth.living-atlas.org]: FAILED! => {"cache_update_time": 1559583292, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'redis-server'' failed: E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-tools_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]\nE: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-server_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, "stderr": "E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-tools_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]\nE: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-server_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-tools_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]", "E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/r/redis/redis-server_4.0.9-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.31 80]", "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libjemalloc1 redis-tools\nSuggested packages:\n  ruby-redis\nThe following NEW packages will be installed:\n  libjemalloc1 redis-server redis-tools\n0 upgraded, 3 newly installed, 0 to remove and 112 not upgraded.\nNeed to get 552 kB/634 kB of archives.\nAfter this operation, 3007 kB of additional disk space will be used.\nIgn:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-tools amd64 5:4.0.9-1ubuntu0.1\nIgn:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-server amd64 5:4.0.9-1ubuntu0.1\nErr:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-tools amd64 5:4.0.9-1ubuntu0.1\n  404  Not Found [IP: 91.189.88.31 80]\nErr:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-server amd64 5:4.0.9-1ubuntu0.1\n  404  Not Found [IP: 91.189.88.31 80]\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libjemalloc1 redis-tools", "Suggested packages:", "  ruby-redis", "The following NEW packages will be installed:", "  libjemalloc1 redis-server redis-tools", "0 upgraded, 3 newly installed, 0 to remove and 112 not upgraded.", "Need to get 552 kB/634 kB of archives.", "After this operation, 3007 kB of additional disk space will be used.", "Ign:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-tools amd64 5:4.0.9-1ubuntu0.1", "Ign:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-server amd64 5:4.0.9-1ubuntu0.1", "Err:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-tools amd64 5:4.0.9-1ubuntu0.1", "  404  Not Found [IP: 91.189.88.31 80]", "Err:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 redis-server amd64 5:4.0.9-1ubuntu0.1", "  404  Not Found [IP: 91.189.88.31 80]"]}
```