### PR TITLE
Include again common and java role in CAS

### DIFF
--- a/ansible/cas5-standalone.yml
+++ b/ansible/cas5-standalone.yml
@@ -1,5 +1,11 @@
 - hosts: cas-servers
   tasks:
+  - name: Include common
+    include_role:
+      name: common
+  - name: Install java
+    include_role:
+      name: java
   - apt_repository:
       repo: ppa:chris-lea/redis-server
       update_cache: yes


### PR DESCRIPTION
After installing CAS in a new server CAS service don't start, I see that is because java is not installed:
```
root@auth:/var/log/atlas# /opt/atlas/cas/cas.jar
Unable to find Java
```
and this was removed from the last CAS roles refactorization.


