### PR TITLE
Add mongodb users by default

### DIFF
--- a/ansible/cas5-standalone.yml
+++ b/ansible/cas5-standalone.yml
@@ -1,4 +1,6 @@
 - hosts: cas-servers
+  vars:
+    cas_add_mongo_users: true
   tasks:
   - name: Include common
     include_role:


### PR DESCRIPTION
After the last CAS update, mongo users are not created by default in new CAS servers because the new variable `cas_add_mongo_users` is not configured. So the `cas` and related services fails to start on first deploy.

