### PR TITLE
Removed apikey mysql init dump after flyway fix in apikey module

### DIFF
--- a/ansible/inventories/living-atlas-cas-5
+++ b/ansible/inventories/living-atlas-cas-5
@@ -120,7 +120,6 @@ apikey_hostname=auth.living-atlas.org
 apikey_context_path=apikey
 apikey_base_url=http://auth.living-atlas.org
 apikey_url=http://auth.living-atlas.org/apikey
-apikey_db_dump={{inventory_dir}}/../roles/apikey/files/apikey_schema.sql
 
 apikey_db_name=apikey
 apikey_db_username=apikey


### PR DESCRIPTION
After this commit https://github.com/AtlasOfLivingAustralia/apikey/commit/edff128fa799e3905f2276dde308e3163e4b6f11
this db initialization I used as a workaround is not needed anymore.