### PR TITLE
CAS mongo users creation proper fix

### DIFF
--- a/ansible/aws-cas-5.yml
+++ b/ansible/aws-cas-5.yml
@@ -100,6 +100,8 @@
     - { user: "{{ cas_flyway_username }}", password: "{{ cas_flyway_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:ALL", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
     - { user: "{{ cas_db_username }}", password: "{{ cas_db_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:INSERT,SELECT,UPDATE,DELETE,EXECUTE,TRIGGER/mysql.proc:SELECT", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
     - { user: "{{ apikey_db_username }}", password: "{{ apikey_db_password }}", priv: "{{ apikey_db_name | default('apikey') }}.*:ALL", host: "{{ apikey_mysql_src_host }}", login_host: "{{ apikey_db_hostname }}", login_port: "{{ apikey_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+  - debug:
+      msg: "Should be the mongo users created? {{ cas_add_mongo_users }}"
   - mongodb_user:
       user: "{{ item.user }}"
       password: "{{ item.password }}"

--- a/ansible/cas5-standalone.yml
+++ b/ansible/cas5-standalone.yml
@@ -1,6 +1,4 @@
 - hosts: cas-servers
-  vars:
-    cas_add_mongo_users: true
   tasks:
   - name: Include common
     include_role:
@@ -26,4 +24,6 @@
     vars:
       mongodb_version: 4.0
 - name: include default cas 5 steps
+  vars:
+    cas_add_mongo_users: true
   import_playbook: aws-cas-5.yml

--- a/ansible/roles/mongodb-org/tasks/main.yml
+++ b/ansible/roles/mongodb-org/tasks/main.yml
@@ -51,7 +51,7 @@
   tags: mongodb-org
 
 # https://github.com/ansible/ansible/issues/33832
-- name: Check if some admin user is already configured
+- name: Check if some admin user is already configured (if admin already exists this fails and can be ignored)
   shell: /usr/bin/mongo --eval 'db.getUsers()' admin
   ignore_errors: true
   register: get_mongo_admin_users


### PR DESCRIPTION
The mongo users were not created by default with https://github.com/AtlasOfLivingAustralia/ala-install/pull/318 because the var is not correctly configured. See: 
```
TASK [mongodb_user] *************************************************************************************************************************************************************************
skipping: [auth.vtatlasoflife.org] => (item={u'login_port': u'27017', u'roles': u'readWrite', u'database': u'cas-ticket-registry', u'login_user': u'admin', u'login_host': u'localhost', u'loskipping: [auth.vtatlasoflife.org] => (item={u'login_port': u'27017', u'roles': u'readWrite', u'database': u'cas-service-registry', u'login_user': u'admin', u'login_host': u'localhost', u'login_password': u'password', u'ssl': u'false', u'user': u'services', u'login_database': u'admin', u'password': u'password', u'replica_set': u''})
```
with this small fix:
```
TASK [debug] ********************************************************************************************************************************************************************************
    "msg": "Should be the mongo users created? True"
}
TASK [mongodb_user] *************************************************************************************************************************************************************************
changed: [auth.vtatlasoflife.org] => (item={u'login_port': u'27017', u'roles': u'readWrite', u'database': u'cas-ticket-registry', u'login_user': u'admin', u'login_host': u'localhost', u'logchanged: [auth.vtatlasoflife.org] => (item={u'login_port': u'27017', u'roles': u'readWrite', u'database': u'cas-service-registry', u'login_user': u'admin', u'login_host': u'localhost', u'login_password': u'password', u'ssl': u'false', u'user': u'services', u'login_database': u'admin', u'password': u'password', u'replica_set': u''})
```
