### PR TITLE
Standardize vars in specieslist and logger

### DIFF
--- a/ansible/roles/logger-service/templates/logger-config.properties
+++ b/ansible/roles/logger-service/templates/logger-config.properties
@@ -1,8 +1,11 @@
 # CAS Config
 casProperties=casServerLoginUrl,serverName,centralServer,casServerName,uriFilterPattern,uriExclusionFilter,authenticateOnlyIfLoggedInFilterPattern,casServerLoginUrlPrefix,gateway,casServerUrlPrefix,contextPath
 casServerName={{ auth_base_url }}
+security.cas.casServerName={{ auth_base_url }}
 casServerUrlPrefix={{ auth_cas_url }}
+security.cas.casServerUrlPrefix={{ auth_cas_url }}
 casServerLoginUrl={{ auth_cas_url }}/login
+
 security.cas.loginUrl={{ auth_cas_url }}/login
 security.cas.logoutUrl={{ auth_cas_url }}/logout
 gateway=false
@@ -14,8 +17,10 @@ serverName={{ logger_base_url }}
 security.cas.appServerName={{ logger_base_url }}
 contextPath={{ logger_context_path }}
 uriExclusionFilterPattern=/images.*,/css.*,/js.*,/less.*
+security.cas.uriExclusionFilterPattern=/images.*,/css.*,/js.*,/less.*
 security.cas.bypass={{ bypass_cas | default(true) }}
 uriFilterPattern={{ logger_uri_filter_pattern | default('/admin.*') }}
+security.cas.uriFilterPattern={{ logger_uri_filter_pattern | default('/admin.*') }}
 disableCAS={{ bypass_cas | default(true) }}
 
 # Data Source properties

--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -39,7 +39,7 @@ skin.favicon = {{ skin_favicon | default('https://www.ala.org.au/app/uploads/201
 bieService.baseURL={{ bie_service_base_url }}
 bie.download=/data/bie-staging/species-list
 bie.nameIndexLocation={{ name_index_dir | default('/data/lucene/namematching') }}
-logger.baseUrl={{ logger_service_url | default('https://logger.ala.org.au/service')}}
+logger.baseUrl={{ (logger_service_url | default(logger_webservice_url)) | default('https://logger.ala.org.au/service')}}
 
 fieldGuide.baseURL={{field_guide_base_url }}
 batchSize=500


### PR DESCRIPTION
Minor change to use the same logger webservice url and new CAS vars than other roles, with backward compatibility.