### PR TITLE
Standardize logger webservice url in specieslist

### DIFF
--- a/ansible/roles/bie-hub/templates/bie-hub-config.properties
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.properties
@@ -51,15 +51,15 @@ biocacheService.baseURL={{ biocache_service_url }}
 
 # Other ALA Services
 profileService.baseURL={{ profile_service_url  }}
-spatial.baseURL={{ spatial_url }}
+spatial.baseURL={{ spatial_base_url | default(spatial_url) }}
 collectory.baseURL={{ collectory_url }}
 speciesList.baseURL={{ species_list_url }}
 speciesList.preferredSpeciesListDruid={{ specieslist_preferredDruid }}
 speciesList.preferredListName={{ specieslist_preferredListName }}
 alerts.baseUrl={{ alerts_url }}
-regions.baseURL={{ regions_url }}
+regions.baseURL={{ regions_base_url | default(regions_url) }}
 sightings.url={{ sightings_url }}
-layersService.baseURL={{ layers_url }}
+layersService.baseURL={{ layers_service_url | default(layers_url) }}
 imageServiceBaseURL={{ image_service_url }}
 image.thumbnailUrl={{ image_service_url }}/image/proxyImageThumbnail?imageId=
 image.baseURL={{ image_service_url }}

--- a/ansible/roles/bie-index/templates/bie-index-config.yml
+++ b/ansible/roles/bie-index/templates/bie-index-config.yml
@@ -89,7 +89,7 @@ solr:
 skin:
   layout: {{ skin_layout | default('main') }}
   fluidLayout: {{ skin_fluid_layout | default('') }}
-  orgNameLong: Atlas of Living Australia
+  orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
   favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
 headerAndFooter:
   baseURL: {{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3') }}


### PR DESCRIPTION
Minor change to use the same base urls than other roles, with backward compatibility.

Org name configurable when yml configuration used.