### PR TITLE
Set images port in demo playbook and service configuration

### DIFF
--- a/ansible/ala-demo.yml
+++ b/ansible/ala-demo.yml
@@ -27,5 +27,5 @@
     - { role: biocache-hub,     biocache_hub: ala-hub, biocache_hub_version: "3.1.0" }
     - { role: bie-index,        bie_index_version: "1.4.2.2" }
     - { role: bie-hub,          bie_hub: ala-bie, bie_hub_version: "1.4.13" }
-    - { role: image-service,    image_service_version: "1.0.9" }
+    - { role: image-service,    image_service_version: "1.0.9", image_service_port: 9101 }
     - demo

--- a/ansible/roles/image-service/defaults/main.yml
+++ b/ansible/roles/image-service/defaults/main.yml
@@ -1,0 +1,3 @@
+# default images variables
+image_service_port: 8080
+

--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -53,7 +53,7 @@
       - path: "{{ image_service_context_path }}"
         sort_label: "1_ws"
         is_proxy: true
-        proxy_pass: "http://127.0.0.1:{{ image_service_port | default('8080') }}{{ image_service_context_path }}"
+        proxy_pass: "http://127.0.0.1:{{ image_service_port }}{{ image_service_context_path }}"
       - path: "/store"
         sort_label: "2_store"
         is_proxy: false

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -1,6 +1,9 @@
 grails:
   serverURL: "{{image_service_base_url}}{{image_service_context_path}}"
 
+server:
+  port: {{image_service_port}}
+
 security:
   cas:
     appServerName: "{{image_service_base_url}}{{image_service_context_path}}"


### PR DESCRIPTION
To not conflict with tomcat 8080 port we set some default port for image service in the demo playbook but also in the service configuration (so embedded tomcat not uses 8080 by default).

PS: I updated also the generator  to use the new image service:
https://github.com/vjrj/generator-living-atlas/commit/2ac96bd68498e739c8b9c292d03f48166713e102