### PR TITLE
Update webapi role

### DIFF
--- a/ansible/roles/webapi_instance/templates/webapi-config.properties
+++ b/ansible/roles/webapi_instance/templates/webapi-config.properties
@@ -1,7 +1,9 @@
 # CAS Config
 casProperties=casServerLoginUrl,serverName,centralServer,casServerName,uriFilterPattern,uriExclusionFilter,authenticateOnlyIfLoggedInFilterPattern,casServerLoginUrlPrefix,gateway,casServerUrlPrefix,contextPath
 casServerName={{ auth_base_url }}
+security.cas.casServerName={{ auth_base_url }}
 casServerUrlPrefix={{ auth_cas_url }}/
+security.cas.casServerUrlPrefix={{ auth_cas_url }}
 casServerLoginUrl={{ auth_cas_url }}/login
 security.cas.loginUrl={{ auth_cas_url }}/login
 security.cas.logoutUrl={{ auth_cas_url }}/logout
@@ -16,7 +18,9 @@ contextPath={{ webapi_context_path }}
 
 authenticateOnlyIfLoggedInFilterPattern=/,/apps,/category
 uriFilterPattern=/admin/.*
+security.cas.uriFilterPattern=/admin/.*
 uriExclusionFilterPattern=/images.*,/css.*,/js.*,/less.*
+security.cas.uriExclusionFilterPattern=/images.*,/css.*,/js.*,/less.*
 
 skin.layout={{ skin_layout | default('generic') }}
 skin.fluidLayout={{fluidLayout | default(true)}}
@@ -30,11 +34,11 @@ dataSource.url=jdbc:mysql://{{ webapi_db_hostname }}/{{ webapi_db_name }}?autoRe
 dataSource.username={{ webapi_db_username }}
 dataSource.password={{ webapi_db_password }}
 
-grails.mail.host={{ mail_host }}
+grails.mail.host={{ mail_host | default('localhost') }}
 grails.mail.disabled={{ mail_disabled|default(true) }}
 
 # Header and footer
 headerAndFooter.baseURL={{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3') }}
 ala.baseURL={{ ala_base_url | default('https://www.ala.org.au') }}
-bie.baseURL={{ bie_hub_url | default('https://bie.ala.org.au')}}
+bie.baseURL={{ (bie_url | default(bie_base_url)) | default('https://bie.ala.org.au')}}
 bie.searchPath={{ bie_search_path | default('/search') }}

--- a/ansible/roles/webapi_instance/vars/main.yml
+++ b/ansible/roles/webapi_instance/vars/main.yml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "{{ webapi_version | default('2.0-SNAPSHOT') }}"
 artifactId: "webapi"
 classifier: ''
 packaging: "war"

--- a/ansible/webapi_standalone.yml
+++ b/ansible/webapi_standalone.yml
@@ -2,7 +2,7 @@
   roles:
     - common
     - java
-    - mysql
+    - mysql-5.7
     - webserver
     - tomcat
     - webapi_instance


### PR DESCRIPTION
I've updated the webapi role to install https://api.gbif.es
I updated also the ansible generator to support webapi service, so other portals can use it also: https://github.com/vjrj/generator-living-atlas/commit/788a8698dcfba41abd2950d708915e6f84a4047c

So I update that role with the problems I found (CAS issues, old mysql version, old war used, etc).
