### PR TITLE
Basic ala-demo playbook with only webserver task

### DIFF
--- a/ansible/ala-demo-basic.yml
+++ b/ansible/ala-demo-basic.yml
@@ -1,0 +1,11 @@
+- hosts: all
+  gather_facts: False
+  tasks:
+  - name: install python 2
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+
+- hosts: all
+  roles:
+    - common
+    - webserver
+    - demo


### PR DESCRIPTION
A basic demo playbook without services (only webserver), for using in
https://github.com/vjrj/generator-living-atlas with multiple hosts, so each service is installed in the selected hostname.