### PR TITLE
Set default value for authenticateOnlyIfLoggedInFilterPattern in specieslists role

### DIFF
--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -7,7 +7,7 @@ security.cas.appServerName={{ specieslist_base_url }}
 security.cas.bypass={{ bypass_cas | default(true) }}
 security.cas.uriFilterPattern={{ specieslist_uri_filter_pattern | default('/admin.*') }}
 security.cas.uriExclusionFilterPattern={{ specieslist_uri_exclusion_filter_pattern | default('/images.*,/css.*,/js.*') }}
-security.cas.authenticateOnlyIfLoggedInFilterPattern={{ specieslist_authenticate_only_if_logged_in_filter_pattern }}
+security.cas.authenticateOnlyIfLoggedInFilterPattern={{ specieslist_authenticate_only_if_logged_in_filter_pattern | default('/speciesListItem/list,/speciesListItem/list/.*,/speciesListItem/listAuth,/speciesListItem/listAuth/.*') }}
 security.cas.contextPath={{ specieslist_context_path }}
 disableCAS={{ bypass_cas | default(true) }}
 


### PR DESCRIPTION
After this https://github.com/AtlasOfLivingAustralia/ala-install/commit/cda6a5c4209f6e248fc86c1c3de5d06ff72fbb26 commit to prevent this error:
```
fatal: [xxxxx]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'specieslist_authenticate_only_if_logged_in_filter_pattern' is undefined"}
```

