### PR TITLE
Added tomcat dep to ala-demo-basic

### DIFF
--- a/ansible/ala-demo-basic.yml
+++ b/ansible/ala-demo-basic.yml
@@ -7,5 +7,7 @@
 - hosts: all
   roles:
     - common
+    - java
+    - tomcat
     - webserver
     - demo


### PR DESCRIPTION
I add java and tomcat role to the `ala-demo-basic` playbook, as the demo role uses [tomcat user in some task](https://github.com/AtlasOfLivingAustralia/ala-install/blob/fac927e5e78d650c83da52ef5e98b1a8f07152a5/ansible/roles/demo/tasks/main.yml#L9).