### PR TITLE
Additional vars in specieslists role

### DIFF
--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -39,12 +39,16 @@ biocache.baseURL={{ biocache_base_url }}
 skin.fluidLayout = {{ skin_fluid_layout | default(' false') }}
 skin.layout = {{ skin_layout | default('main') }}
 skin.favicon = {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+termsOfUseUrl = {{ downloads_terms_of_use | default('https://www.ala.org.au/about-the-atlas/terms-of-use/') }}
+skin.orgNameLong = {{ orgNameLong | default('Atlas of Living Australia') }}
 
 bieService.baseURL={{ bie_service_base_url }}
 bie.download=/data/bie-staging/species-list
 bie.nameIndexLocation={{ name_index_dir | default('/data/lucene/namematching') }}
 logger.baseURL={{ (logger_service_url | default(logger_webservice_url)) | default('https://logger.ala.org.au/service')}}
 logger.baseUrl={{ (logger_service_url | default(logger_webservice_url)) | default('https://logger.ala.org.au/service')}}
+
+outboundhttp.timeout={{ specieslist_outboundhttp_timeout | default(8000) }}
 
 fieldGuide.baseURL={{field_guide_base_url }}
 batchSize=500


### PR DESCRIPTION
Some additional vars in species lists role. One is to prevent some:
`Unable to obtain species details from BIE - Read timed out`
configuring [this var](https://github.com/AtlasOfLivingAustralia/specieslist-webapp/blob/d4c0cb4f02bf79718dec0b9246b6706175182393/grails-app/conf/application.yml#L159).