### PR TITLE
Added i18n role with ala-i18n package

### DIFF
--- a/ansible/collectory-standalone.yml
+++ b/ansible/collectory-standalone.yml
@@ -5,5 +5,6 @@
     - webserver
     - mysql-5.7
     - tomcat
+    - i18n
     - collectory
   become: yes

--- a/ansible/roles/i18n/tasks/main.yml
+++ b/ansible/roles/i18n/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Install ala-i18n apt repository
+  apt_repository:
+    # We use this repo temporally
+    repo: deb [arch=amd64] https://demo.gbif.es/repo bionic main
+    state: present
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"
+
+- name: Add demo.gbif.es apt key
+  apt_key:
+    # We use this key from the above repo temporally
+    keyserver: hkp://keyserver.ubuntu.com:80
+    id: BD4E3B58E30599A9FD97331D9D93BC32983433D5
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"
+
+- name: Install ala-i18n package
+  apt:
+    pkg:
+    - ala-i18n
+    state: present
+    update_cache: yes
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"

--- a/ansible/species-list-standalone.yml
+++ b/ansible/species-list-standalone.yml
@@ -6,4 +6,5 @@
     - webserver
     - mysql-5.7
     - nameindex
+    - i18n
     - species-list


### PR DESCRIPTION
Now that [my ala-i18n PRs are merged](https://github.com/search?q=is%3Apr+author%3Avjrj+org%3AAtlasOfLivingAustralia+ala-i18n+external&type=Issues) I created a simple i18n role to install the [ala-i18n package](https://github.com/living-atlases/ala-i18n).

It will be nice that in some moment this repository, and jenkins jobs are transferred to ALA.

![Captura de pantalla de 2019-11-27 10-58-38](https://user-images.githubusercontent.com/180085/69713499-ec497580-1104-11ea-9287-49cea2701f46.png)

![Captura de pantalla de 2019-11-27 10-35-00](https://user-images.githubusercontent.com/180085/69713108-3da53500-1104-11ea-8013-32e405565273.png)
