### PR TITLE
Fix solr url in demo role

### DIFF
--- a/ansible/roles/demo/templates/index.html
+++ b/ansible/roles/demo/templates/index.html
@@ -35,7 +35,7 @@
               <li><a href="{{biocache_hub_url}}">Occurrence search</a> - Reskinnable front end UI</li>
               <li><a href="{{biocache_hub_url}}/explore/your-area?default=true">Explore your area</a>  - Reskinnable front end UI</li>
           	  <li><a href="{{biocache_service_url}}">Web services</a> - the JSON/WMS webservices</li>
-                  <li><a href="http://{{ solr_base_url }}">Apache SOLR</a>
+                  <li><a href="{{ solr_base_url }}">Apache SOLR</a>
                   - the index used for searching
                   <smaller>(note port 8983 needs to be open for this link to work) </smaller></li>
           	</ul>


### PR DESCRIPTION
Currently the role generates this url in the `index.html`:

`<a href="http://http://index.gbif.pt:8983">Apache SOLR</a>`

