### PR TITLE
Added missing default values for mdba list

### DIFF
--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -182,7 +182,7 @@ allowedImageEditingRoles={{ image_edit_roles | default('ROLE_ADMIN') }}
 
 # mdba config
 specieslist.baseUrl={{specieslist_base_url | default('https://lists.ala.org.au')}}/ws
-specieslist.uid={{specieslist_uid}}
+specieslist.uid={{specieslist_uid | default('dr4801') }}
 
 # Downloads
 useDownloadPlugin={{ use_download_plugin | default('')}}

--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -182,7 +182,9 @@ allowedImageEditingRoles={{ image_edit_roles | default('ROLE_ADMIN') }}
 
 # mdba config
 specieslist.baseUrl={{specieslist_base_url | default('https://lists.ala.org.au')}}/ws
-specieslist.uid={{specieslist_uid | default('dr4801') }}
+{% if specieslist_uid is defined and specieslist_uid|length > 0 %}
+specieslist.uid={{ specieslist_uid }}
+{% endif %}
 
 # Downloads
 useDownloadPlugin={{ use_download_plugin | default('')}}


### PR DESCRIPTION
Without default values we have some errors like:
``` 
fatal: [records.no.l-a.site]: FAILED! => {“changed”: false, “msg”: “AnsibleUndefinedVariable: ‘specieslist_uid’ is undefined”}
``` 
PS: Thanks to Rukaya from gbif.no for the feedback.