### PR TITLE
Prevent overwrite vhost configurations when deploying in same server

### DIFF
--- a/ansible/aws-cas-5.yml
+++ b/ansible/aws-cas-5.yml
@@ -66,6 +66,7 @@
       login_port: "{{ item.login_port }}"
       login_user: "{{ item.login_user }}"
       login_password: "{{ item.login_password }}"
+      encoding: "{{ cas_db_encoding | default('utf8') }}"
     run_once: true
     with_items:
     - { name: "{{ cas_db_name | default('emmet') }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }

--- a/ansible/collectory-standalone.yml
+++ b/ansible/collectory-standalone.yml
@@ -5,5 +5,6 @@
     - webserver
     - mysql-5.7
     - tomcat
+    - i18n
     - collectory
   become: yes

--- a/ansible/roles/apikey/templates/apikey-config.yml
+++ b/ansible/roles/apikey/templates/apikey-config.yml
@@ -36,7 +36,7 @@ server:
 # Data source configuration
 dataSource:
   dbCreate: "none"
-  url: jdbc:mysql://{{ apikey_db_hostname | default('localhost') }}:{{ apikey_db_port | default('3306') }}/{{ apikey_db_name | default('apikey') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull
+  url: jdbc:mysql://{{ apikey_db_hostname | default('localhost') }}:{{ apikey_db_port | default('3306') }}/{{ apikey_db_name | default('apikey') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8
   username: {{ apikey_db_username }}
   password: {{ apikey_db_password }}
 flyway:

--- a/ansible/roles/biocache-db/files/cassandra/cassandra3-schema.txt
+++ b/ansible/roles/biocache-db/files/cassandra/cassandra3-schema.txt
@@ -558,6 +558,8 @@ CREATE TABLE occ.occ (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE INDEX ON occ.occ ("dataResourceUid");
+
 CREATE TABLE occ.queryassert (
     rowkey text PRIMARY KEY
 ) WITH bloom_filter_fp_chance = 0.01
@@ -644,6 +646,8 @@ CREATE TABLE occ.occ_uuid (
     AND min_index_interval = 128
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
+
+CREATE INDEX ON occ.occ_uuid (value);
 
 CREATE TABLE occ.qid (
     rowkey text PRIMARY KEY,

--- a/ansible/roles/cas5/templates/application.yml
+++ b/ansible/roles/cas5/templates/application.yml
@@ -11,7 +11,7 @@ jndi:
   hikari:
     jdbccas:
       driverClass: com.mysql.jdbc.Driver
-      url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&logger=com.mysql.jdbc.log.Slf4JLogger&gatherPerfMetrics=true&logSlowQueries=true
+      url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&logger=com.mysql.jdbc.log.Slf4JLogger&gatherPerfMetrics=true&logSlowQueries=true&characterEncoding=UTF-8
       user: {{ cas_db_username | default('cas') }}
       password: {{ cas_db_password | default('password') }}
       dataSourceProperties:
@@ -20,7 +20,7 @@ jndi:
         prepStmtCacheSqlLimit: 2048
 flyway:
   baselineOnMigrate: {{ cas_db_migration_baseline | default('true') }}
-  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull
+  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8
   user: {{ cas_flyway_username | default('root') }}
   password: {{ cas_flyway_password | default('password') }}
 

--- a/ansible/roles/i18n/tasks/main.yml
+++ b/ansible/roles/i18n/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Install ala-i18n apt repository
+  apt_repository:
+    # We use this repo temporally
+    repo: deb [arch=amd64] https://demo.gbif.es/repo bionic main
+    state: present
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"
+
+- name: Add demo.gbif.es apt key
+  apt_key:
+    # We use this key from the above repo temporally
+    keyserver: hkp://keyserver.ubuntu.com:80
+    id: BD4E3B58E30599A9FD97331D9D93BC32983433D5
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"
+
+- name: Install ala-i18n package
+  apt:
+    pkg:
+    - ala-i18n
+    state: present
+    update_cache: yes
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"

--- a/ansible/roles/logger-service/tasks/main.yml
+++ b/ansible/roles/logger-service/tasks/main.yml
@@ -4,7 +4,7 @@
     - properties
 
 - name: create logger DB
-  mysql_db: name={{logger_db_name}} state=present
+  mysql_db: name={{logger_db_name}} state=present encoding=utf8
   register: dbschema
   tags:
     - logger-service

--- a/ansible/roles/nginx_vhost/defaults/main.yml
+++ b/ansible/roles/nginx_vhost/defaults/main.yml
@@ -51,8 +51,10 @@ nginx_cache_invalid_time: "0s"
 # Set this to true to have the nginx cache cleared when deployment completes
 nginx_clear_cache_on_deploy: False
 
-# Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time
+# Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time (not developed yet)
 clear_vhost_fragments: false
+# Set this to true in your inventory if you know that you are deploying for instance biocache and biocache/ws in the same server
+ws_same_host: false
 # Set this to true to enable support for 'upstream' load balancing features
 nginx_load_balancing: false
 # When load balancing is enabled, this is used to specify the maximum number of connections from nginx to the upstream load balanced server

--- a/ansible/roles/nginx_vhost/defaults/main.yml
+++ b/ansible/roles/nginx_vhost/defaults/main.yml
@@ -54,7 +54,7 @@ nginx_clear_cache_on_deploy: False
 # Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time (not developed yet)
 clear_vhost_fragments: false
 # Set this to true in your inventory if you know that you are deploying for instance biocache and biocache/ws in the same server
-ws_same_host: false
+vhost_with_appname_conf: false
 # Set this to true to enable support for 'upstream' load balancing features
 nginx_load_balancing: false
 # When load balancing is enabled, this is used to specify the maximum number of connections from nginx to the upstream load balanced server

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -62,6 +62,20 @@
   tags:
     - nginx_vhost
 
+- name: set vfragments_suffix when context_path is defined and we set ws_same_host
+  set_fact:
+    vfragments_suffix: "-{{ context_path | regex_replace ('/','') }}"
+  when: ws_same_host | bool == True and context_path is defined
+  tags:
+    - nginx_vhost
+
+- name: set empty vfragments_suffix when no context_path
+  set_fact:
+    vfragments_suffix: ""
+  when: context_path is not defined or (context_path | trim == '')
+  tags:
+    - nginx_vhost
+
 - name: set webserver_extra_servernames empty by default
   set_fact: 
     webserver_extra_servernames: []
@@ -353,23 +367,23 @@
   tags:
     - nginx_vhost
 
-# assemble servername fragments dir, put in sites-available as servername.conf
+# assemble servername fragments dir, put in sites-available as servername.conf or servername-path.conf
 - name: assemble fragments into nginx vhost config
   assemble:
     src: "{{nginx_conf_dir}}/vhost_fragments/{{hostname}}"
-    dest: "{{nginx_conf_dir}}/sites-available/{{hostname}}.conf"
+    dest: "{{nginx_conf_dir}}/sites-available/{{hostname}}{{vfragments_suffix}}.conf"
   when: vhost_required | bool == True
   notify:
    - reload nginx
   tags:
     - nginx_vhost
 
-# symlink servername.conf to sites-enabled
+# symlink servername.conf  or servername-path.conf to sites-enabled
 - name: symlink vhost to sites-enabled
   file:
     state: link
-    src: "{{nginx_conf_dir}}/sites-available/{{hostname}}.conf"
-    dest: "{{nginx_conf_dir}}/sites-enabled/{{hostname}}.conf"
+    src: "{{nginx_conf_dir}}/sites-available/{{hostname}}{{vfragments_suffix}}.conf"
+    dest: "{{nginx_conf_dir}}/sites-enabled/{{hostname}}{{vfragments_suffix}}.conf"
   when: vhost_required | bool == True
   notify:
    - reload nginx

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -62,17 +62,17 @@
   tags:
     - nginx_vhost
 
-- name: set vfragments_suffix when context_path is defined and we set ws_same_host
+- name: set vfragments_suffix when vhost_with_appname_conf is true
   set_fact:
-    vfragments_suffix: "-{{ context_path | regex_replace ('/','') }}"
-  when: ws_same_host | bool == True and context_path is defined
+    vfragments_suffix: "-{{appname}}"
+  when: vhost_with_appname_conf | bool == True
   tags:
     - nginx_vhost
 
-- name: set empty vfragments_suffix when no context_path
+- name: set empty vfragments_suffix when vhost_with_appname_conf is false
   set_fact:
     vfragments_suffix: ""
-  when: context_path is not defined or (context_path | trim == '')
+  when: vhost_with_appname_conf | bool == False
   tags:
     - nginx_vhost
 

--- a/ansible/roles/species-list/tasks/main.yml
+++ b/ansible/roles/species-list/tasks/main.yml
@@ -5,7 +5,7 @@
     - dbfix
 
 - name: create DB
-  mysql_db: name={{specieslist_db_name}} state=present
+  mysql_db: name={{specieslist_db_name}} state=present encoding=utf8
   tags:
     - specieslist
     - db

--- a/ansible/roles/userdetails/templates/userdetails-config.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config.yml
@@ -37,7 +37,7 @@ redirectAfterFirstLogin: ${grails.serverURL}/myprofile
 # Data source configuration
 dataSource:
   dbCreate: "none"
-  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull
+  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8
   username: {{ userdetails_db_username | default(cas_db_username) | default('cas') }}
   password: {{ userdetails_db_password | default(cas_db_password) | default('password') }}
 

--- a/ansible/species-list-standalone.yml
+++ b/ansible/species-list-standalone.yml
@@ -6,4 +6,5 @@
     - webserver
     - mysql-5.7
     - nameindex
+    - i18n
     - species-list


### PR DESCRIPTION
If you deploy `https://biocache.l-a.site/` and later `https://biocache.l-a.site/ws/` in the same server, at the end `ningx_vhost` ansible role will only configure the last one (because the first is overwritten).

This patch solved this adding a new ansible variable `ws_same_host` setted to false for backward compatibility and generating two nginx vhost like `biocache.l-a.site-ws.conf` and `biocache.l-a.site-ws.conf`.

PS: Thanks to @rukayaj from gbif.no for re-testing this patch.