### PR TITLE
Correct order of tasks in ala-i18n role

### DIFF
--- a/ansible/roles/i18n/tasks/main.yml
+++ b/ansible/roles/i18n/tasks/main.yml
@@ -1,18 +1,18 @@
-- name: Install ala-i18n apt repository
-  apt_repository:
-    # We use this repo temporally
-    repo: deb [arch=amd64] https://demo.gbif.es/repo bionic main
-    state: present
-  tags:
-    - packages
-    - i18n
-  when: ansible_os_family == "Debian"
-
 - name: Add demo.gbif.es apt key
   apt_key:
     # We use this key from the above repo temporally
     keyserver: hkp://keyserver.ubuntu.com:80
     id: BD4E3B58E30599A9FD97331D9D93BC32983433D5
+  tags:
+    - packages
+    - i18n
+  when: ansible_os_family == "Debian"
+
+- name: Install ala-i18n apt repository
+  apt_repository:
+    # We use this repo temporally
+    repo: deb [arch=amd64] https://demo.gbif.es/repo bionic main
+    state: present
   tags:
     - packages
     - i18n


### PR DESCRIPTION
@jloomisVCE (Vermont) just send me a report of a error running the just merged `ala-i18n` role.

```
ASK [i18n : Install ala-i18n apt repository] ************************************************************************
fatal: [lists.vtatlasoflife.org]: FAILED! => {"changed": false, "module_stderr": "Shared connection to A.B.C.D closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1581363307.91-152234570568148/AnsiballZ_apt_repository.py\", line 114, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1581363307.91-152234570568148/AnsiballZ_apt_repository.py\", line 106, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1581363307.91-152234570568148/AnsiballZ_apt_repository.py\", line 49, in invoke_module\r\n    imp.load_module('__main__', mod, module, MOD_DESC)\r\n  File \"/tmp/ansible_apt_repository_payload_xh0IyY/__main__.py\", line 554, in <module>\r\n  File \"/tmp/ansible_apt_repository_payload_xh0IyY/__main__.py\", line 546, in main\r\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 586, in update\r\n    raise FetchFailedException(e)\r\napt.cache.FetchFailedException: W:GPG error: https://demo.gbif.es/repo bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F697D8D2ADB9E24A, E:The repository 'https://demo.gbif.es/repo bionic InRelease' is not signed.\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
I notice that the order of apt tasks was incorrect. 

So this fix this (first add the key, later the repo and at the end the package with `update_cache` to updated the repositories. I juste re-tested.

Sorry for that!