### PR TITLE
Prevent overwrite vhost configurations when deploying in same server (rewritten with appname)

### DIFF
--- a/ansible/roles/nginx_vhost/defaults/main.yml
+++ b/ansible/roles/nginx_vhost/defaults/main.yml
@@ -51,8 +51,10 @@ nginx_cache_invalid_time: "0s"
 # Set this to true to have the nginx cache cleared when deployment completes
 nginx_clear_cache_on_deploy: False
 
-# Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time
+# Set this to true in your inventory if you know that you are only deploying a single nginx_vhost and you want to clear previous versions before deploying each time (not developed yet)
 clear_vhost_fragments: false
+# Set this to true in your inventory if you know that you are deploying for instance biocache and biocache/ws in the same server
+vhost_with_appname_conf: false
 # Set this to true to enable support for 'upstream' load balancing features
 nginx_load_balancing: false
 # When load balancing is enabled, this is used to specify the maximum number of connections from nginx to the upstream load balanced server

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -410,3 +410,9 @@
   tags:
     - nginx_vhost
 
+- name: unset vfragments_suffix
+  set_fact:
+    vfragments_suffix: ''
+  tags:
+    - nginx_vhost
+

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -62,6 +62,20 @@
   tags:
     - nginx_vhost
 
+- name: set vfragments_suffix when vhost_with_appname_conf is true
+  set_fact:
+    vfragments_suffix: "-{{appname}}"
+  when: vhost_with_appname_conf | bool == True
+  tags:
+    - nginx_vhost
+
+- name: set empty vfragments_suffix when vhost_with_appname_conf is false
+  set_fact:
+    vfragments_suffix: ""
+  when: vhost_with_appname_conf | bool == False
+  tags:
+    - nginx_vhost
+
 - name: set webserver_extra_servernames empty by default
   set_fact: 
     webserver_extra_servernames: []
@@ -353,23 +367,23 @@
   tags:
     - nginx_vhost
 
-# assemble servername fragments dir, put in sites-available as servername.conf
+# assemble servername fragments dir, put in sites-available as servername.conf or servername-appname.conf
 - name: assemble fragments into nginx vhost config
   assemble:
     src: "{{nginx_conf_dir}}/vhost_fragments/{{hostname}}"
-    dest: "{{nginx_conf_dir}}/sites-available/{{hostname}}.conf"
+    dest: "{{nginx_conf_dir}}/sites-available/{{hostname}}{{vfragments_suffix}}.conf"
   when: vhost_required | bool == True
   notify:
    - reload nginx
   tags:
     - nginx_vhost
 
-# symlink servername.conf to sites-enabled
+# symlink servername.conf  or servername-appname.conf to sites-enabled
 - name: symlink vhost to sites-enabled
   file:
     state: link
-    src: "{{nginx_conf_dir}}/sites-available/{{hostname}}.conf"
-    dest: "{{nginx_conf_dir}}/sites-enabled/{{hostname}}.conf"
+    src: "{{nginx_conf_dir}}/sites-available/{{hostname}}{{vfragments_suffix}}.conf"
+    dest: "{{nginx_conf_dir}}/sites-enabled/{{hostname}}{{vfragments_suffix}}.conf"
   when: vhost_required | bool == True
   notify:
    - reload nginx


### PR DESCRIPTION
I rewrote this https://github.com/AtlasOfLivingAustralia/ala-install/pull/366 following @ansell suggestion.

I tested in a demo site and with `true` in the new var `vhost_with_appname_conf` and I get:

```
biocache.l-a.site-ala-hub.conf
biocache.l-a.site-biocache-service.conf
```
as expected.