### PR TITLE
Added missing appname in image-service

### DIFF
--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -55,6 +55,7 @@
   include_role:
     name: nginx_vhost
   vars:
+    appname: "image-service"
     hostname: "{{ image_service_hostname }}"
     context_path: "{{ image_service_context_path }}"
     nginx_paths:


### PR DESCRIPTION
After https://github.com/AtlasOfLivingAustralia/ala-install/pull/368 we need to set missing `appname` in `image-service` as in the rest of roles, to prevent these kind of errors:

```
fatal: [imagenes.snib.conap.gob.gt]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'appname' is undefined\n\nThe error appears to be in '/home/gt/ala-install/ansible/roles/nginx_vhost/tasks/main.yml'
```