### PR TITLE
Fix cassandra keys url

### DIFF
--- a/ansible/roles/cassandra3/tasks/main.yml
+++ b/ansible/roles/cassandra3/tasks/main.yml
@@ -66,7 +66,7 @@
     - cassandra
 
 - name: add repository key (Debian)
-  shell: 'curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -'
+  shell: 'curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -'
   when: ansible_os_family == "Debian"
   tags:
     - packages


### PR DESCRIPTION
Running cassandra3 role, we experienced some errors related with the gpg keys:

```
fatal: [biocache-store.snib.conap.gob.gt]: FAILED! => {"changed": true, "cmd": "curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -", "delta": "0:00:02.277836", "end": "2020-02-27 16:55:39.955248", "msg": "non-zero return code", "rc": 2, "start": "2020-02-27 16:55:37.677412", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0\r100   227  100   227    0     0    100      0  0:00:02  0:00:02 --:--:--   100\ngpg: no valid OpenPGP data found.", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: apt-key output should     0    100      0  0:00:02  0:00:02 --:--:--   100", "gpg: no valid OpenPGP data found."], "stdout": "", "stdout_lines": []}                                                                                                              

biocache-store.snib.conap.gob.gt : ok=47   changed=2    unreachable=0    failed=1    skipped=45   rescued=0    ignored=0
```
This fix the URL of the cassandra keys to `https://downloads.apache.org/cassandra/KEYS` as described in:
http://cassandra.apache.org/download/

In fact, the previous `https://www.apache.org/dist/cassandra/KEYS` redirect to this URL.