### PR TITLE
Added missing appname to spatial-hub and spatial-service roles

### DIFF
--- a/ansible/roles/spatial-hub/tasks/main.yml
+++ b/ansible/roles/spatial-hub/tasks/main.yml
@@ -51,6 +51,7 @@
   include_role:
     name: nginx_vhost
   vars:
+    appname: "spatial-hub"
     hostname: "{{ spatial_hub_hostname }}"
     context_path: "{{ spatial_hub_context_path }}"
     nginx_paths:

--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -11,6 +11,7 @@
   include_role:
     name: nginx_vhost
   vars:
+    appname: "spatial-service"
     hostname: "{{ spatial_service_hostname }}"
     context_path: "{{ spatial_service_context_path }}"
   tags:


### PR DESCRIPTION
After https://github.com/AtlasOfLivingAustralia/ala-install/pull/368 we need to set missing `appname` in some tasks of`spatial-hub` and `spatial-service`.