### PR TITLE
Collectory layout variables updated

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -40,8 +40,11 @@ biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
 
 # Skinning
+# ala.skin is deprecated after:
+# https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
+# configure skin.layout instead
 ala.skin={{ skin | default('main') }}
-skin.layout={{ skin_layout | default('generic') }}
+skin.layout={{ (collectory_skin_layout | default(skin_layout)) | default('ala') }}
 skin.fluidLayout={{ fluidLayout | default('')}}
 chartsBgColour={{ charts_bg_colour | default('#fffef7') }}
 


### PR DESCRIPTION
I realized that `ala` layout is [more updated](https://github.com/AtlasOfLivingAustralia/ala-collectory/tree/master/grails-app/views/layouts) and collectory works better than with `generic` layout. 

This PR updates the default collectory skin layout and also creates a specific variable to configure it like other services (like `bie-hub`).

Also comments that `ala.skin` variable is [not in use now]( https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31) so people (like me) don't lose time trying to figure out which value to use there. I don't remove it for backward compatibility.
