### PR TITLE
DOI service vars fix and variables standardized

### DIFF
--- a/ansible/doi-service-standalone.yml
+++ b/ansible/doi-service-standalone.yml
@@ -3,9 +3,9 @@
     - common
     - java
     - postfix
-    - {role: db-backup, db: postgres}
+    - {role: db-backup, db: postgres, db_name: "{{ doi_db_name }}", db_user: "{{ doi_db_user }}", db_password: "{{ doi_db_password }}" }
     - {role: postgresql, pg_version: "9.6"}
-    - {role: pg_instance, extensions: ["citext", "pgcrypto"]}
-    - {role: ansible-elasticsearch, es_version: 5.5.3, es_templates:false,  es_instance_name: 'doi-elasticsearch', es_data_dirs: ['/data/elasticsearch'], tags: ['elasticsearch']}
+    - {role: pg_instance, extensions: ["citext", "pgcrypto"], db_name: "{{ doi_db_name }}", db_user: "{{ doi_db_user }}", db_password: "{{ doi_db_password }}" }
+    - {role: ansible-elasticsearch, es_version: 5.5.3, es_templates: false,  es_instance_name: 'doi-elasticsearch', es_data_dirs: ['/data/elasticsearch'], tags: ['elasticsearch']}
     - webserver
     - doi-service

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -40,8 +40,11 @@ biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
 
 # Skinning
+# ala.skin is deprecated after:
+# https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
+# configure skin.layout instead
 ala.skin={{ skin | default('main') }}
-skin.layout={{ skin_layout | default('generic') }}
+skin.layout={{ (collectory_skin_layout | default(skin_layout)) | default('ala') }}
 skin.fluidLayout={{ fluidLayout | default('')}}
 chartsBgColour={{ charts_bg_colour | default('#fffef7') }}
 

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -44,7 +44,7 @@ biocacheServicesUrl={{ biocache_service_url }}
 # https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
 # configure skin.layout instead
 ala.skin={{ skin | default('main') }}
-skin.layout={{ (collectory_skin_layout | default(skin_layout)) | default('ala') }}
+skin.layout={{ skin_layout | default('generic') }}
 skin.fluidLayout={{ fluidLayout | default('')}}
 chartsBgColour={{ charts_bg_colour | default('#fffef7') }}
 

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -40,9 +40,6 @@ biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
 
 # Skinning
-# ala.skin is deprecated after:
-# https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
-# configure skin.layout instead
 ala.skin={{ skin | default('main') }}
 skin.layout={{ skin_layout | default('generic') }}
 skin.fluidLayout={{ fluidLayout | default('')}}

--- a/ansible/roles/doi-service/tasks/main.yml
+++ b/ansible/roles/doi-service/tasks/main.yml
@@ -88,7 +88,7 @@
     nginx_paths:
       - path: "{{ doi_service_context_path }}"
         is_proxy: true
-        proxy_pass: "http://127.0.0.1:8080/{{ doi_service_context_path }}"
+        proxy_pass: "http://127.0.0.1:{{ doi_service_port }}/{{ doi_service_context_path }}"
   # notify:
   #   - reload nginx
   tags:

--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -25,6 +25,7 @@ serverURL: https://{{ doi_service_hostname }}
 serverName: https://{{ doi_service_hostname }}
 
 server:
+  port: {{ doi_service_port | default('8080') }}
   contextPath: {{ doi_service_context_path }}
 
 support:
@@ -70,12 +71,12 @@ file:
 googleAnalyticsId: UA-4355440-1
 
 dataSource:
-  url: jdbc:postgresql://{{db_hostname}}/{{db_name}}
-  username: {{db_user}}
-  password: {{db_password}}
+  url: jdbc:postgresql://{{ doi_db_hostname }}/{{ doi_db_name }}
+  username: {{ doi_db_user }}
+  password: {{ doi_db_password }}
 
 collections:
-  baseUrl: {{ collections_url | default('https://collections.ala.org.au') }}
+  baseUrl: {{ (collectory_url | default(collections_url)) | default('https://collections.ala.org.au') }}
 
 userDetails:
   url: {{ auth_base_url }}/userdetails/

--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -45,6 +45,13 @@ ala:
   base:
     url: https://www.ala.org.au
 
+skin:
+  layout: {{ skin_layout | default('main') }}
+  fluidLayout: {{ skin_fluid_layout | default('') }}
+  orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
+  orgNameShort: {{ orgNameShort | default('ALA') }}
+  favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+
 doi:
   storage:
     provider: {{ doi_storage_provider | default('LOCAL') }}

--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -52,6 +52,10 @@ skin:
   orgNameShort: {{ orgNameShort | default('ALA') }}
   favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
 
+headerAndFooter:
+  baseURL: {{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3') }}
+  version: 2
+
 doi:
   storage:
     provider: {{ doi_storage_provider | default('LOCAL') }}


### PR DESCRIPTION
This PR, fix some missing space in DOI playbook that gives this error:
```
ERROR! Syntax Error while loading YAML.
  found unexpected ':'

The error appears to be in '/home/vjrj/proyectos/gbif/dev/ala-install-up-to-date/ansible/doi-service-standalone.yml': line 9, column 68, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - {role: pg_instance, extensions: ["citext", "pgcrypto"]}
    - {role: ansible-elasticsearch, es_version: 5.5.3, es_templates:false,  es_instance_name: 'doi-elasticsearch', es_data_dirs: ['/data/elasticsearch'], tags: ['elasticsearch']}
                                                                   ^ here
```
and also standardize the variables used por DB name/user/password. Also add a new variable `doi_service_port` to allow running it in a different port than `8080`.

Tested in https://doi.l-a.site/ testing site.
