### PR TITLE
Update of alerts properties (CAS, skin, mysql encoding, properties enc.)

### DIFF
--- a/ansible/roles/alerts/tasks/main.yml
+++ b/ansible/roles/alerts/tasks/main.yml
@@ -3,7 +3,7 @@
     - alerts
 
 - name: create alerts DB
-  mysql_db: name={{ alerts_db_name }} state=present
+  mysql_db: name={{ alerts_db_name }} state=present encoding={{ alerts_db_encoding | default('utf8') }}
   tags:
     - db
     - alerts
@@ -23,14 +23,14 @@
     - alerts
 
 - name: copy all config.properties
-  template: src=alerts-config.properties dest={{data_dir}}/alerts/config/alerts-config.properties
+  template: src=alerts-config.properties dest={{data_dir}}/alerts/config/alerts-config.properties output_encoding=iso-8859-1
   tags:
     - properties
     - alerts
 
 - name: set data ownership
   file: path={{data_dir}}/alerts owner={{tomcat_user}} group={{tomcat_user}} recurse=true
-  notify: 
+  notify:
     - restart tomcat
   tags:
     - properties

--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -46,6 +46,7 @@ userDetails.url={{ userdetails_base_url }}{{ userdetails_context_path }}
 postie.emailSender={{ email_sender | default('atlas-alerts@ala.org.au') }}
 postie.emailAlertAddressTitle={{ email_alert_address_title |  default('Atlas alerts') }}
 postie.emailInfoAddressTitle={{ email_info_address_title |  default('Atlas of Living Australia') }}
+postie.defaultResourceName={{ email_default_resource_name |  default('Atlas of Living Australia') }}
 postie.emailInfoSender={{ email_info_sender |  default('atlas-alerts@ala.org.au') }}
 postie.enableEmail={{  enable_email | default('') }}
 

--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -11,10 +11,16 @@ security.cas.authenticateOnlyIfLoggedInPattern=/unsubscribe.*
 security.cas.adminRole=ROLE_ADMIN
 security.apikey.check.serviceUrl={{ alerts_apikey_check_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=') }}
 security.apikey.ip.whitelist={{ alerts_apikey_whitelist | default('') }}
+security.cas.casServerName={{ auth_base_url }}
+security.cas.casServerUrlPrefix={{ auth_base_url }}/cas
+security.cas.casServerLoginUrl={{ auth_base_url }}/cas/login
+security.cas.casServerLogoutUrl={{ auth_base_url }}/cas/logout
+security.cas.loginUrl={{ auth_base_url }}/cas/login
+security.cas.logoutUrl={{ auth_base_url }}/cas/logout
 
 # DB config
 dataSource.driverClassName=com.mysql.jdbc.Driver
-dataSource.url=jdbc:mysql://{{ alerts_db_hostname }}/alerts
+dataSource.url=jdbc:mysql://{{ alerts_db_hostname }}/alerts?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8
 dataSource.username={{ alerts_db_username }}
 dataSource.password={{ alerts_db_password }}
 dataSource.dbCreate=update
@@ -45,12 +51,15 @@ postie.enableEmail={{  enable_email | default('') }}
 
 # Header and footer
 headerAndFooter.baseURL={{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3') }}
+headerAndFooter.version={{ header_and_footer_version | default('1') }}
 ala.baseURL={{ ala_base_url | default('https://www.ala.org.au')}}
 bie.baseURL={{ bie_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath={{ bie_search_path | default('/search') }}
 
 skin.layout={{ skin_layout | default('main') }}
+skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
 skin.orgNameLong={{ skin_orgNameLong | default('Atlas of Living Australia') }}
+skin.orgNameShort={{ orgNameShort | default('Atlas') }}
 #skin.favicon={{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon.ico') }}
 
 # Example search labels and URLs

--- a/ansible/roles/regions/templates/regions-config.properties
+++ b/ansible/roles/regions/templates/regions-config.properties
@@ -29,6 +29,7 @@ spatial.baseURL={{ spatial_base_url }}
 layersService.baseURL={{ spatial_base_url_ws }}
 logger.baseURL={{ logger_base_url }}
 alerts.baseURL={{ alerts_base_url }}
+alertsResourceName={{ alerts_resource_name | default('Atlas') }}
 geoserver.baseURL={{ geoserver_base_url }}
 bieService.baseURL={{ bie_service_base_url }}
 biocacheService.baseURL={{ biocache_service_base_url }}


### PR DESCRIPTION
I updated the alerts role with:
- CAS urls
- Missing skin typical variables
- properties encoding to `iso-8859-1` to allow use of non-latin characters in Alerts title sample variables (I think this should be the default is other roles still using properties, see the orgName in https://snib.conap.gob.gt/registros/#tab_simpleSearch)
https://stackoverflow.com/questions/37436927/utf-8-encoding-of-application-properties-attributes-in-spring-boot
- mysql default encoding to utf-8 (but configurable for backward compatibility) 
- Added `defaultResourceName` that is present in `application.yml`

Alerts samples with correct encoding:

![2020-11-14-23:17:42-screenshot-alerts](https://user-images.githubusercontent.com/180085/79275426-71f87280-7ea6-11ea-85b5-24cc01957032.png)
