### PR TITLE
Set output_encoding to iso-8859-1 for properties configs

### DIFF
--- a/ansible/roles/bie-hub/tasks/main.yml
+++ b/ansible/roles/bie-hub/tasks/main.yml
@@ -13,7 +13,7 @@
     - bie    
 
 - name: copy all config.properties
-  template: src=bie-hub-config.properties dest={{ data_dir }}/{{ bie_hub | default('generic-bie') }}/config/{{ bie_hub | default('generic-bie') }}-config.properties force=yes
+  template: src=bie-hub-config.properties dest={{ data_dir }}/{{ bie_hub | default('generic-bie') }}/config/{{ bie_hub | default('generic-bie') }}-config.properties force=yes output_encoding=iso-8859-1
   tags:
     - webapps
     - properties

--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -15,7 +15,7 @@
     - webapps
     - apache_vhost
     - deploy
-    - biocache_hub    
+    - biocache_hub
   when: not webserver_nginx
 
 - name: add nginx vhost if configured
@@ -99,7 +99,7 @@
     - facets_config
 
 - name: copy all config.properties
-  template: src=config/config.properties dest={{data_dir}}/{{biocache_hub}}/config/{{biocache_hub_config}} force=yes
+  template: src=config/config.properties dest={{data_dir}}/{{biocache_hub}}/config/{{biocache_hub_config}} force=yes output_encoding=iso-8859-1
   tags:
     - webapps
     - properties

--- a/ansible/roles/biocache-properties/tasks/main.yml
+++ b/ansible/roles/biocache-properties/tasks/main.yml
@@ -14,7 +14,7 @@
     - biocache-properties
 
 - name: copy biocache config properties template 
-  template: src={{item}} dest={{data_dir}}/biocache/config/{{item}} mode=0644
+  template: src={{item}} dest={{data_dir}}/biocache/config/{{item}} mode=0644 output_encoding=iso-8859-1
   with_items:
     - biocache-config.properties
   tags:

--- a/ansible/roles/collectory/tasks/main.yml
+++ b/ansible/roles/collectory/tasks/main.yml
@@ -45,7 +45,7 @@
     - collectory
 
 - name: copy all template configs
-  template: src={{item}} dest={{ collectory_data_dir }}/config/{{ collectory_app | default('generic-collectory') }}-config.properties
+  template: src={{item}} dest={{ collectory_data_dir }}/config/{{ collectory_app | default('generic-collectory') }}-config.properties output_encoding=iso-8859-1
   with_items:
     - config/collectory-config.properties
   tags:

--- a/ansible/roles/dashboard/tasks/main.yml
+++ b/ansible/roles/dashboard/tasks/main.yml
@@ -13,7 +13,7 @@
     - properties
 
 - name: copy all config.properties
-  template: src=dashboard-config.properties dest={{data_dir}}/dashboard/config/dashboard-config.properties
+  template: src=dashboard-config.properties dest={{data_dir}}/dashboard/config/dashboard-config.properties output_encoding=iso-8859-1
   tags:
     - dashboard
     - properties

--- a/ansible/roles/logger-service/tasks/main.yml
+++ b/ansible/roles/logger-service/tasks/main.yml
@@ -53,7 +53,7 @@
     - properties
 
 - name: copy all config.properties
-  template: src=logger-config.properties dest={{data_dir}}/logger/config/logger-config.properties
+  template: src=logger-config.properties dest={{data_dir}}/logger/config/logger-config.properties output_encoding=iso-8859-1
   tags:
     - logger-service
     - properties

--- a/ansible/roles/regions/tasks/main.yml
+++ b/ansible/roles/regions/tasks/main.yml
@@ -44,7 +44,7 @@
     - regions
 
 - name: copy all config.properties
-  template: src=regions-config.properties dest={{data_dir}}/{{regions}}/config/{{regions_config}} force=yes
+  template: src=regions-config.properties dest={{data_dir}}/{{regions}}/config/{{regions_config}} force=yes output_encoding=iso-8859-1
   tags:
     - properties
     - regions

--- a/ansible/roles/species-list/tasks/main.yml
+++ b/ansible/roles/species-list/tasks/main.yml
@@ -42,7 +42,7 @@
     - properties
 
 - name: copy all config.properties
-  template: src=specieslist-webapp-config.properties dest={{data_dir}}/specieslist-webapp/config/specieslist-webapp-config.properties
+  template: src=specieslist-webapp-config.properties dest={{data_dir}}/specieslist-webapp/config/specieslist-webapp-config.properties output_encoding=iso-8859-1
   tags:
     - specieslist
     - properties


### PR DESCRIPTION
In Guatemala deployment we notice that its organization name is not correctly encoded:
https://snib.conap.gob.gt/registros/#tab_simpleSearch
this is because `properties` should be encoded in `iso-8859-1` to allow use of non-latin characters, see
https://stackoverflow.com/questions/37436927/utf-8-encoding-of-application-properties-attributes-in-spring-boot
this doesn't happen with yml configs.

This patch add `output_encoding=iso-8859-1`  to the main ALA modules that still use `properties`  as config.

We didn't have this problem because, for instance, in Spain we use latin characters for our OrgName etc.

Tested with orgName in:
https://collections.l-a.site/
https://species.l-a.site/

Also related: https://github.com/AtlasOfLivingAustralia/ala-install/pull/381