### PR TITLE
Prevent cassandra role to rm -rf its data in playbook reruns

### DIFF
--- a/ansible/roles/cassandra3/tasks/main.yml
+++ b/ansible/roles/cassandra3/tasks/main.yml
@@ -4,6 +4,17 @@
 
 ########## REDHAT ########## 
 
+- name: check if datastax package is installed
+  package:
+    name: "{{datastax}}"
+    state: present
+  check_mode: true
+  register: cassandra_first_install
+  when: ansible_os_family == "RedHat"
+  tags:
+    - packages
+    - cassandra
+
 - name: setup yum repo
   copy: src=yum/datastax.repo dest=/etc/yum.repos.d/datastax.repo
   when: ansible_os_family == "RedHat"   
@@ -29,6 +40,17 @@
   when: ansible_os_family == "RedHat" 
 
 ########## DEBIAN ########## 
+
+- name: check if cassandra package is installed
+  package:
+    name: cassandra
+    state: present
+  check_mode: true
+  register: cassandra_first_install
+  when: ansible_os_family == "Debian"
+  tags:
+    - packages
+    - cassandra
 
 - name: install curl (Debian)
   apt: name=curl state=latest
@@ -133,9 +155,16 @@
     - cassandra 
     - cassandra_yaml    
 
+- name: "Debug if this is the first cassandra installation in this host"
+  debug:
+    msg: "It's the first time we install cassandra in this host? {{cassandra_first_install.changed}}"
+  tags:
+    - packages
+    - cassandra
+
 - name: clean up directories that have been created by initial installation of cassandra 3
   shell: 'rm -Rf /data/cassandra3/data && rm -Rf /data/cassandra3/commitlog && rm -Rf /var/log/cassandra/* && rm -Rf /var/lib/cassandra/hints'
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and cassandra_first_install.changed | bool == True
   notify: 
     - restart cassandra  
   tags:


### PR DESCRIPTION
This week in Vermont, when they were updating their LA deployment to new LA versions, the cassandra role wiped all its data after rerun it.
https://github.com/AtlasOfLivingAustralia/ala-install/blob/d610dceee1b85ea494fa66c83af63d0025fdc23a/ansible/roles/cassandra3/tasks/main.yml#L103

This patch tries to prevent this to happen again but also to rerun the cassandra role safely (for upgrades).

Take into account that many LA deployments right now doesn't have a cassandra or solr cluster.

To detect if the cassandra remove task should be executed or not, I use a simple initial detection of the cassandra package installation status. 

If the cassandra package is the fist time is installed, the rm task is executed at the end:

![2020-10-24-22:27:23-screenshot-cassandra-rm](https://user-images.githubusercontent.com/180085/80254757-066b8d80-867c-11ea-9f55-0ed530497cfc.png)

but if the cassandra package is already installed, this rm tasks is skipped:

![2020-10-24-22:27:23-screenshot-cassandra-not-rm](https://user-images.githubusercontent.com/180085/80254821-2307c580-867c-11ea-96ff-db8f80f143ce.png)

cc @jloomisVCE 

PS: I added a similar detection for RedHat but the rm task is only used in Debian