### PR TITLE
Allow skin.homeUrl configuration in several roles

### DIFF
--- a/ansible/roles/bie-index/templates/bie-index-config.yml
+++ b/ansible/roles/bie-index/templates/bie-index-config.yml
@@ -91,6 +91,7 @@ skin:
   fluidLayout: {{ skin_fluid_layout | default('') }}
   orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
   favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+  homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}
 headerAndFooter:
   baseURL: {{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3') }}
 useLegacyAuto: false

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -53,6 +53,7 @@ skin:
   layout: {{ skin_layout | default('main') }}
   favicon: "{{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon-16x16.png') }}"
   orgNameLong: {{ orgNameLong | default('Atlas') }}
+  homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}
 
 collectory:
   baseURL: "{{ collectory_url | default('https://collections.ala.org.au')}}"

--- a/ansible/roles/spatial-service/templates/spatial-service-config.yml
+++ b/ansible/roles/spatial-service/templates/spatial-service-config.yml
@@ -172,6 +172,7 @@ grails.app.context: {{spatial_service_context_path}}
 
 skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort: {{ orgNameShort | default('ALA') }}
+skin.homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}
 
 grails.controllers.upload.maxFileSize: {{ max_request_size | default(524288000) }}
 grails.controllers.upload.maxRequestSize: {{ max_request_size | default(524288000) }}

--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -40,6 +40,7 @@ biocache.baseURL={{ biocache_base_url }}
 skin.fluidLayout = {{ skin_fluid_layout | default(' false') }}
 skin.layout = {{ skin_layout | default('main') }}
 skin.favicon = {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
 termsOfUseUrl = {{ downloads_terms_of_use | default('https://www.ala.org.au/about-the-atlas/terms-of-use/') }}
 skin.orgNameLong = {{ orgNameLong | default('Atlas of Living Australia') }}
 

--- a/ansible/roles/userdetails/templates/userdetails-config.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config.yml
@@ -109,6 +109,7 @@ skin.fluidLayout: {{ skin_fluid_layout | default('false') }}
 skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort: {{ orgNameShort | default('ALA') }}
 skin.favicon: {{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon-16x16.png') }}
+skin.homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}
 
 # API key for external apps
 webservice.apiKey: {{ api_key }}


### PR DESCRIPTION
Some roles don't have the skin.homeUrl in their config templates. 

Because of that the breadcrumbs **[Home](https://www.ala.org.au) >** links of these services points to www.ala.org.au. This patch add that variable to several roles to make this var also configurable (as other modules like [collectory do](https://github.com/AtlasOfLivingAustralia/ala-install/blob/cae407ac0c9173105f54c51da9e8265a27ef6bd1/ansible/roles/collectory/templates/config/collectory-config.properties#L72)).
