### PR TITLE
Biocache service url instead of biocache-hub for alerts

### DIFF
--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -30,7 +30,7 @@ dataSource.properties.validationQuery=SELECT 1
 #External services
 
 biocache.baseURL = {{ biocache_url | default('https://biocache.ala.org.au') }}
-biocacheService.baseURL = {{ biocache_url | default('https://biocache.ala.org.au') }}
+biocacheService.baseURL = {{ biocache_service_url | default('https://biocache.ala.org.au') }}
 spatial.baseURL = {{ spatial_url | default('https://spatial.ala.org.au') }}
 collectory.baseURL = {{ collectory_url | default('https://collections.ala.org.au') }}
 ala.userDetailsURL = {{ userdetails_url | default('https://auth.ala.org.au/userdetails') }}/userDetails/getUserListFull

--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -30,7 +30,7 @@ dataSource.properties.validationQuery=SELECT 1
 #External services
 
 biocache.baseURL = {{ biocache_url | default('https://biocache.ala.org.au') }}
-biocacheService.baseURL = {{ biocache_service_url | default('https://biocache.ala.org.au') }}
+biocacheService.baseURL = {{ biocache_service_url | default('https://biocache-ws.ala.org.au') }}
 spatial.baseURL = {{ spatial_url | default('https://spatial.ala.org.au') }}
 collectory.baseURL = {{ collectory_url | default('https://collections.ala.org.au') }}
 ala.userDetailsURL = {{ userdetails_url | default('https://auth.ala.org.au/userdetails') }}/userDetails/getUserListFull


### PR DESCRIPTION
This patch have relation with: 
https://github.com/AtlasOfLivingAustralia/alerts/pull/52
to allow to use the biocache-service url in alerts (instead of biocache-hub + hardcoded `/ws/`).

This role default value (and also of the `application.yml` in Alerts) should not affect to ALA alerts service.