### PR TITLE
Update trove API url

### DIFF
--- a/ansible/roles/bie-hub/defaults/main.yml
+++ b/ansible/roles/bie-hub/defaults/main.yml
@@ -48,5 +48,5 @@ specieslist_preferredDruid: dr4778
 specieslist_preferredListName: ALA Preferred Species Images
 synonym_types: synonym,homotypicSynonym,objectiveSynonym,heterotypicSynonym,subjectiveSynonym,proParteSynonym,inferredSynonym
 trove_api_key:
-trove_service_url: https://api.trove.nla.gov.au
+trove_service_url: https://api.trove.nla.gov.au/v2
 trove_url: https://trove.nla.gov.au


### PR DESCRIPTION
Update of trove API url after deprecation of previous API. See: https://github.com/AtlasOfLivingAustralia/bie-plugin/issues/196