### PR TITLE
The use of www.ala.org.au is intentional for long-term URL preservation

### DIFF
--- a/ansible/roles/biocache-service/templates/config/download-doi-email.html
+++ b/ansible/roles/biocache-service/templates/config/download-doi-email.html
@@ -25,7 +25,7 @@
         </p>
         <p>
             Also cite the contributing data providers which are listed in the included "citation.csv" file.
-            More information can be found at <a href="{{ citing_the_atlas | default('https://support.ala.org.au/support/solutions/articles/6000195866-how-to-cite-the-ala') }}">
+            More information can be found at <a href="{{ citing_the_atlas | default('https://www.ala.org.au/about-the-atlas/terms-of-use/citing-the-atlas/') }}">
             citing the {{ orgNameShort | default('ALA') }}</a>.
         </p>
         <p>

--- a/ansible/roles/biocache-service/templates/config/download-doi-readme.html
+++ b/ansible/roles/biocache-service/templates/config/download-doi-readme.html
@@ -69,6 +69,6 @@ When using this dataset please use the following citation:<br><br>
 The DOI for this download is available at <a href='[url]'>[url]</a><br><br>
 Data contributed by the following providers:<br>
 [dataProviders]<br>
-More information can be found at <a href="{{ citing_the_atlas | default('https://support.ala.org.au/support/solutions/articles/6000195866-how-to-cite-the-ala') }}">citing the {{ orgNameShort | default('ALA') }}</a>.<br><br>
+More information can be found at <a href="{{ citing_the_atlas | default('https://www.ala.org.au/about-the-atlas/terms-of-use/citing-the-atlas/') }}">citing the {{ orgNameShort | default('ALA') }}</a>.<br><br>
 </body>
 </html>

--- a/ansible/roles/biocache-service/templates/config/download-email.html
+++ b/ansible/roles/biocache-service/templates/config/download-email.html
@@ -22,7 +22,7 @@
         </p>
         <p>
             Also cite the contributing data providers which are listed in the included "citation.csv" file. More information
-            can be found at <a href="{{ citing_the_atlas | default('https://support.ala.org.au/support/solutions/articles/6000195866-how-to-cite-the-ala') }}">
+            can be found at <a href="{{ citing_the_atlas | default('https://www.ala.org.au/about-the-atlas/terms-of-use/citing-the-atlas/') }}">
             citing the {{ orgNameShort | default('ALA') }}</a>.
         </p>
         <p>

--- a/ansible/roles/biocache-service/templates/config/download-readme.html
+++ b/ansible/roles/biocache-service/templates/config/download-readme.html
@@ -20,6 +20,6 @@ When using this dataset please use the following citation:<br><br>
 <cite>{{ orgNameLong | default('Atlas of Living Australia') }} occurrence download at <a href='[searchUrl]'>[searchUrl]</a> accessed on [date].</cite> <br><br>
 Data contributed by the following providers:<br>
 [dataProviders]<br>
-More information can be found at <a href="{{ citing_the_atlas | default('https://support.ala.org.au/support/solutions/articles/6000195866-how-to-cite-the-ala') }}">citing the {{ orgNameShort | default('ALA') }}</a>.<br><br>
+More information can be found at <a href="{{ citing_the_atlas | default('https://www.ala.org.au/about-the-atlas/terms-of-use/citing-the-atlas/') }}">citing the {{ orgNameShort | default('ALA') }}</a>.<br><br>
 </body>
 </html>


### PR DESCRIPTION
We have a long-term strategy to support this and other similar www.ala.org.au URLs regardless of the way they are physically implemented. We are likely to move from Freshdesk to another system in the future at some point, and we want to preserve the ability to manage the citation link.

Reverts AtlasOfLivingAustralia/ala-install#415