### PR TITLE
Added default values for postgres version in image-service

### DIFF
--- a/ansible/image-service.yml
+++ b/ansible/image-service.yml
@@ -4,7 +4,7 @@
     - common
     - { role: ansible-elasticsearch, es_templates: false,  es_instance_name: 'images', tags: ['elasticsearch']}
     - { role: db-backup, db: postgres, db_name: "images", db_user: "{{ image_service_db_username }}", db_password: "{{ image_service_db_password }}" }
-    - { role: postgresql, pg_version: "{{ image_service_postgresql_version }}", postgis_version: "{{ image_service_postgis_version }}" }
+    - { role: postgresql, pg_version: "{{ image_service_postgresql_version | default('10') }}", postgis_version: "{{ image_service_postgis_version | default('2.4') }}" }
     - { role: pg_instance, extensions: ["citext", "pgcrypto"], db_name: "{{ image_service_db_name }}", db_user: "{{ image_service_db_username }}", db_password: "{{ image_service_db_password }}" }
     - webserver
     - image-service


### PR DESCRIPTION
Added missing default values for postgres and postgis versions in image-service. This was causing this error:

```
TASK [postgresql : Gather OS Specific Variables] *******************************
fatal: [ala-install-test-2]: FAILED! => {"msg": "The conditional check 'ansible_os_family == \"RedHat\" or pg_version is not defined' failed. The error was: error while evaluating conditional (ansible_os_family == \"RedHat\" or pg_version is not defined): 'image_service_postgresql_version' is undefined\n\nThe error appears to be in '/data-additional/jenkins/ala-install-test/ala-install/ansible/roles/postgresql/tasks/old.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# tasks file for ntp\n- name: Gather OS Specific Variables\n  ^ here\n"}
```
