### PR TITLE
Added missing appname in cas playbook

### DIFF
--- a/ansible/aws-cas-5.yml
+++ b/ansible/aws-cas-5.yml
@@ -187,10 +187,12 @@
   - include_role:
       name: nginx_vhost
     vars:
+      appname: "{{ item.appname }}"
       hostname: "{{ cas_host_name }}"
       context_path: "{{ item.context }}"
       nginx_paths:
       - path: "/{{ item.context }}"
+        appname: "{{ item.appname }}"
         is_proxy: true
         proxy_pass: "http://127.0.0.1:{{item.port}}/{{ item.context }}"
     with_items:


### PR DESCRIPTION
Added missing `appname` after: https://github.com/AtlasOfLivingAustralia/ala-install/commit/012d187c98bf56309946880cb7af82395a3abb76

```
fatal: [ala-install-test-1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'appname' is undefined\n\nThe error appears to be in '/data-additional/jenkins/ala-install-test/ala-install/ansible/roles/nginx_vhost/tasks/main.yml': line 100, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: set vfragments_suffix when vhost_with_appname_conf is true\n  ^ here\n"}
```

and later:

```
failed: [ala-install-test-1] (item={u'path': u'/cas', u'proxy_pass': u'http://127.0.0.1:9000/cas', u'is_proxy': True}) => {"ansible_loop_var": "item",
 "changed": false, "item": {"is_proxy": true, "path": "/cas", "proxy_pass": "http://127.0.0.1:9000/cas"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'appname'"} 
```