### PR TITLE
Intent to fix for #395

### DIFF
--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -42,7 +42,7 @@
         rewrite: "{{spatial_service_context_path}}/layers/index"
       - path: "/layers/more"
         is_proxy: true
-        proxy_pass: "{{spatial_service_context_path}}/layers/view/more"
+        proxy_pass: "http://127.0.0.1:8080{{spatial_service_context_path}}/layers/view/more"
   tags:
     - nginx_vhost
     - deploy


### PR DESCRIPTION
Spatial playbook fails because of a wrong location:
```
Sep 25 19:54:28 ala-install-test-3 nginx[20755]: nginx: [emerg] invalid URL prefix in /etc/nginx/sites-enabled/ala_default.conf:210
```
after this commit: https://github.com/AtlasOfLivingAustralia/ala-install/commit/60c6ddfc425a49a8bac5d42dea057d2ffb0acc4c

```
    location /layers/more {
(...)
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_read_timeout 10m;
                    proxy_pass /ws/layers/view/more;
```
I've tried to fix it adding the missing url.

