### PR TITLE
Added gpg missing dependency in nginx role

### DIFF
--- a/ansible/roles/nginx/tasks/setup-ubuntu.yml
+++ b/ansible/roles/nginx/tasks/setup-ubuntu.yml
@@ -1,4 +1,9 @@
 ---
+- name: Add gpg dep for nginx repo
+  apt:
+    name: gpg
+    state: present
+
 - name: Add PPA key for Nginx repository
   apt_key:
     keyserver: "hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
Both in ubuntu 18.04 and 20.04 I get an error:
```
fatal: [ala-install-test-1]: FAILED! => {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
```
during task " Add PPA key for Nginx repository".

I added `gpg` for these base ubuntu images that does not have gpg preinstalled.

Partially mentioned in #372.