### PR TITLE
python 2 dependency compatible with 18.04 and 20.04

### DIFF
--- a/ansible/ala-demo-basic.yml
+++ b/ansible/ala-demo-basic.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: all
   roles:

--- a/ansible/ala-demo.yml
+++ b/ansible/ala-demo.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: all
   roles:

--- a/ansible/biocache-cli.yml
+++ b/ansible/biocache-cli.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: biocache-cli
   roles:

--- a/ansible/biocache-db.yml
+++ b/ansible/biocache-db.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: biocache-db
   roles:

--- a/ansible/mysql.yml
+++ b/ansible/mysql.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: all
   roles:

--- a/ansible/nameindexer-standalone.yml
+++ b/ansible/nameindexer-standalone.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: nameindexer
   roles:

--- a/ansible/phylolink.yml
+++ b/ansible/phylolink.yml
@@ -1,8 +1,8 @@
 - hosts: all
   gather_facts: False
   tasks:
-    - name: install python 2
-      raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal python-apt)"
+  - name: install python 2
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal' python-apt)"
 
 - hosts: phylolink
   roles:

--- a/ansible/solr6-standalone.yml
+++ b/ansible/solr6-standalone.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal python-apt)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal' python-apt)"
 
 - hosts: solr6-server
   roles:

--- a/ansible/solr7-standalone.yml
+++ b/ansible/solr7-standalone.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal python-apt)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal' python-apt)"
 
 - hosts: solr7-server
   roles:

--- a/ansible/spatial-standalone.yml
+++ b/ansible/spatial-standalone.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 - hosts: spatial
   roles:

--- a/ansible/spatial.yml
+++ b/ansible/spatial.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+    raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qy 'python2.*-minimal')"
 
 -  hosts: all
    roles:


### PR DESCRIPTION
I used a wildcard to install some python2*-minimal present in any of the ubuntu releases because python-minimal is not present in 20.04.
