### PR TITLE
Generic tomcat using common facts to choose correct one

### DIFF
--- a/ansible/biocache-service-clusterdb.yml
+++ b/ansible/biocache-service-clusterdb.yml
@@ -2,7 +2,7 @@
   roles:
     - common
     - java
-    - { role: tomcat, tomcat: tomcat7 }
+    - tomcat
     - webserver
     - nameindex
     - biocache-properties


### PR DESCRIPTION
Testing in 18.04 and 20.04 I use the tomcat generic role with the tomcat version selected in facts.