### PR TITLE
Remove NO_AUTO_CREATE_USER because was removed from 8.0.11

### DIFF
--- a/ansible/roles/mysql-8.0/tasks/main.yml
+++ b/ansible/roles/mysql-8.0/tasks/main.yml
@@ -27,7 +27,7 @@
   when: ansible_os_family == "Debian"
 
 - name: set mysql variable - sql-mode
-  mysql_variables: variable=sql_mode value={{ mysql_variable_sql_mode | default('STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION')}}
+  mysql_variables: variable=sql_mode value={{ mysql_variable_sql_mode | default('STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION')}}
   when: set_sql_mode is defined
 
 - name: warn about using the default root user password


### PR DESCRIPTION
`NO_AUTO_CREATE_USER` was removed in MySQL `8.0.11`
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-11.html#mysqld-8-0-11-deprecation-removal

This was causing this error:
```
fatal: [ala-install-test-1]: FAILED! => {"changed": false, "msg": "(1231, \"Variable 'sql_mode' can't be set to the value of 'NO_AUTO_CREATE_USER'\")"}
```
