### PR TITLE
Add newserver ansible playbook to run once on new servers

### DIFF
--- a/ansible/newserver.yml
+++ b/ansible/newserver.yml
@@ -1,0 +1,14 @@
+---
+# Use this playbook once on a new server to install python2 and python3
+# must pass target var e.g. ansible-playbook newserver.yml -i /path/to/inventories/your-inventory-file -u ${USER} --private-key=~/.ssh/id_rsa --extra-vars 'target=bla-bla'
+- hosts: '{{ target }}'
+  gather_facts: false
+  pre_tasks:
+  - name: Install python2 and python3 for Ansible
+    raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qqy python3-minimal 'python2.*-minimal')"
+    register: output
+    changed_when: output.stdout != ""
+  - name: Gathering Facts
+    setup:
+  become: yes
+


### PR DESCRIPTION
Add a newserver ansible playbook to install both python2 and python3 on new servers.

This avoids forcing users to install python2 if they do not want it present on newer systems, and also avoids having to reinstall it in future instances.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>