### PR TITLE
Revert "Added gpg missing dependency in nginx role"

### DIFF
--- a/ansible/roles/nginx/tasks/setup-ubuntu.yml
+++ b/ansible/roles/nginx/tasks/setup-ubuntu.yml
@@ -1,9 +1,4 @@
 ---
-- name: Add gpg dep for nginx repo
-  apt:
-    name: gpg
-    state: present
-
 - name: Add PPA key for Nginx repository
   apt_key:
     keyserver: "hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
Reverts AtlasOfLivingAustralia/ala-install#430