### PR TITLE
Added gnupg as nginx apt dep. Rewrite of #430

### DIFF
--- a/ansible/roles/nginx/tasks/setup-ubuntu.yml
+++ b/ansible/roles/nginx/tasks/setup-ubuntu.yml
@@ -1,4 +1,12 @@
 ---
+- name: Add gnupg dep for nginx repo
+  apt:
+    name: gnupg
+    state: present
+  when:
+    - nginx_ppa_use is defined and nginx_ppa_use | bool == True
+    - ansible_os_family == "Debian" and (ansible_distribution_version == "16.04" or ansible_distribution_version == "18.04" or ansible_distribution_version == "20.04")
+
 - name: Add PPA key for Nginx repository
   apt_key:
     keyserver: "hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
I've rewritten #430 and I've tested in 16.04, 18.04 and 20.04 nginx role and species lists playbook. More details in: https://github.com/AtlasOfLivingAustralia/ala-install/pull/430#issuecomment-702634670 .

`gnupg` is present in all these ubuntu versions:
https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=gnupg
while `gpg` is not in `16.04`.