### PR TITLE
Fix missing gpg and deprecated apt-key for elasticsearch. #438

### DIFF
--- a/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
@@ -47,9 +47,10 @@
       state: present
 
   - name: Debian - Add Elasticsearch repository key
-    apt_key:
+    get_url:
       url: '{{ es_apt_key }}'
-      state: present
+      dest: /etc/apt/trusted.gpg.d/elasticsearch.asc
+      mode: 0644
     when: es_add_repository and es_apt_key | string
 
   - name: Debian - Add elasticsearch repository


### PR DESCRIPTION
Installing the `image-service` playbook alone in a VM I get:

```
TASK [ansible-elasticsearch : Debian - Add Elasticsearch repository key] *******
Tuesday 06 October 2020  16:45:48 +0200 (0:00:01.709)       0:00:47.266 ******* 
fatal: [ala-install-test-2]: FAILED! => {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
```

so I patched following https://github.com/AtlasOfLivingAustralia/ala-install/pull/430#issuecomment-702634670 and #438 and the `image-service` playbook worked.

I used a plain .asc file instead of a keyring that probably required also the gpg package.

