### PR TITLE
Added i18n playbook and gpg dependency removed from role

### DIFF
--- a/ansible/i18n.yml
+++ b/ansible/i18n.yml
@@ -1,0 +1,5 @@
+- hosts: all
+  roles:
+    - common
+    - i18n
+  become: yes

--- a/ansible/roles/i18n/tasks/main.yml
+++ b/ansible/roles/i18n/tasks/main.yml
@@ -1,8 +1,9 @@
 - name: Add apt.gbif.es key
-  apt_key:
+  get_url:
     # We use this key from the above repo temporally
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: BD4E3B58E30599A9FD97331D9D93BC32983433D5
+    url: 'https://keyserver.ubuntu.com/pks/lookup?op=hget&search=7524d3b383016eab0ee47bfe253a51f7'
+    dest: /etc/apt/trusted.gpg.d/apt-gbif-es-demo.asc
+    mode: 0644
   when:
     - ansible_os_family == "Debian"
     - i18n_package_enabled | bool == True


### PR DESCRIPTION
A playbook just for install the `ala-i18n` deb package. I updated the `apt-get` part of the role.
