### PR TITLE
Configurable skin layouts per services

### DIFF
--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -57,7 +57,7 @@ ala.baseURL={{ ala_base_url | default('https://www.ala.org.au')}}
 bie.baseURL={{ bie_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath={{ bie_search_path | default('/search') }}
 
-skin.layout={{ skin_layout | default('main') }}
+skin.layout={{ (alerts_skin_layout | default(skin_layout)) | default('main') }}
 skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
 skin.orgNameLong={{ skin_orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort={{ orgNameShort | default('Atlas') }}

--- a/ansible/roles/apikey/templates/apikey-config.yml
+++ b/ansible/roles/apikey/templates/apikey-config.yml
@@ -71,7 +71,7 @@ bie.baseURL: {{ bie_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath: {{ bie_search_path | default('/search') }}
 
 # Skin options
-skin.layout: {{ skin_layout | default('ala-main') }}
+skin.layout: {{ (apikey_skin_layout | default(skin_layout)) | default('ala-main') }}
 skin.fluidLayout: {{ skin_fluid_layout | default('false') }}
 skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort: {{ orgNameShort | default('ALA') }}

--- a/ansible/roles/bie-index/templates/bie-index-config.yml
+++ b/ansible/roles/bie-index/templates/bie-index-config.yml
@@ -87,7 +87,7 @@ solr:
     defType: {{ solr_deftype | default('edismax') }}
     qAlt: {{ solr_qlat | default('text:*') }}
 skin:
-  layout: {{ skin_layout | default('main') }}
+  layout: {{ (bie_index_skin_layout | default(skin_layout)) | default('main') }}
   fluidLayout: {{ skin_fluid_layout | default('') }}
   orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
   favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}

--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -44,7 +44,7 @@ organisation.baseUrl={{org_url|default('https://www.ala.org.au')}}
 
 # skin
 skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
-skin.layout={{ skin_layout | default('generic') }}
+skin.layout={{ (biocache_hub_skin_layout | default(skin_layout)) | default('generic') }}
 skin.favicon={{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
 skin.fluidLayout={{fluidLayout | default(true)}}
 skin.orgNameLong={{orgNameLong|default('Occurrence portal')}}

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -41,8 +41,11 @@ biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
 
 # Skinning
+# ala.skin is deprecated after:
+# https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
+# configure skin.layout instead
 ala.skin={{ skin | default('main') }}
-skin.layout={{ skin_layout | default('generic') }}
+skin.layout={{ (collectory_skin_layout | default(skin_layout)) | default('ala') }}
 skin.fluidLayout={{ fluidLayout | default('')}}
 chartsBgColour={{ charts_bg_colour | default('#fffef7') }}
 

--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -56,7 +56,7 @@ ala:
     url: https://www.ala.org.au
 
 skin:
-  layout: {{ skin_layout | default('main') }}
+  layout: {{ (doi_skin_layout | default(skin_layout)) | default('main') }}
   fluidLayout: {{ skin_fluid_layout | default('') }}
   orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
   orgNameShort: {{ orgNameShort | default('ALA') }}

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -50,7 +50,7 @@ imageservice:
 
 # skin
 skin:
-  layout: {{ skin_layout | default('main') }}
+  layout: {{ (image_skin_layout | default(skin_layout)) | default('main') }}
   favicon: "{{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon-16x16.png') }}"
   orgNameLong: {{ orgNameLong | default('Atlas') }}
   homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}

--- a/ansible/roles/logger-service/templates/logger-config.properties
+++ b/ansible/roles/logger-service/templates/logger-config.properties
@@ -36,5 +36,5 @@ ala.baseURL={{ ala_base_url | default('https://www.ala.org.au')}}
 bie.baseURL={{ bie_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath={{ bie_search_path | default('/search') }}
 
-skin.layout={{ skin_layout | default('main') }}
+skin.layout={{ (logger_skin_layout | default(skin_layout)) | default('main') }}
 skin.orgNameLong={{ skin_orgNameLong | default('Atlas of Living Australia') }}

--- a/ansible/roles/regions/templates/regions-config.properties
+++ b/ansible/roles/regions/templates/regions-config.properties
@@ -41,7 +41,7 @@ skin.favicon={{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/
 allowedHosts={{ spatial_ws_hostname | default('spatial.ala.org.au')  }}
 
 ala.skin={{ skin_layout | default('main') }}
-skin.layout={{ skin_layout | default('main') }}
+skin.layout={{ (regions_skin_layout | default(skin_layout)) | default('main') }}
 layout.skin={{ skin_layout | default('main') }}
 skin.fluidLayout={{ skin_fluid_layout | default('false') }}
 

--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -39,7 +39,7 @@ biocacheService.baseURL={{ biocache_service_base_url }}
 biocache.baseURL={{ biocache_base_url }}
 
 skin.fluidLayout = {{ skin_fluid_layout | default(' false') }}
-skin.layout = {{ skin_layout | default('main') }}
+skin.layout = {{ (specieslist_skin_layout | default(skin_layout)) | default('main') }}
 skin.favicon = {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
 skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
 termsOfUseUrl = {{ downloads_terms_of_use | default('https://www.ala.org.au/about-the-atlas/terms-of-use/') }}

--- a/ansible/roles/userdetails/templates/userdetails-config.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config.yml
@@ -104,7 +104,7 @@ bie.baseURL: {{ bie_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath: {{ bie_search_path | default('/search') }}
 
 # Skin options
-skin.layout: {{ skin_layout | default('ala-main') }}
+skin.layout: {{ (userdetails_skin_layout | default(skin_layout)) | default('ala-main') }}
 skin.fluidLayout: {{ skin_fluid_layout | default('false') }}
 skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort: {{ orgNameShort | default('ALA') }}


### PR DESCRIPTION
When several services are deployed in the same VM, the variable `skin_layout` are not set correctly for each different service.

For some reason we lost this commit https://github.com/AtlasOfLivingAustralia/ala-install/commit/7f2ede9f2ebfe1eacf7b6711b145f974659b2183 in the collectory configuration that address this problem partially.

But I also added similar variables to the rest of main services as I noticed that this was not working when mixing services in a VM.

This should not affect previous inventories (like the ALA inventories) that do not use these new variables and still use a basic `skin_layout` in each of their inventories.

The LA inventories generator it's ready to use these variables https://github.com/living-atlases/generator-living-atlas/commit/27724bf3062d41f2f21e2bd1fc8310ec2bd8de13 and I tested the deployment in `18.04` VMs.

PS: I did a summary of layouts used in: https://docs.google.com/spreadsheets/d/19rs1GuxZX2tRfm2x8YYf83fAcBrIG1gObIqVOV6C870/edit?usp=sharing