### PR TITLE
CAS playbooks and roles refactor

### DIFF
--- a/ansible/aws-cas-5.yml
+++ b/ansible/aws-cas-5.yml
@@ -8,195 +8,25 @@
   serial:
   - 1
   - "100%"
-  tasks:
-  - include_role:
-      name: common
-  - apt:
-      name: "{{ packages }}"
-    vars:
-      packages:
-      - mysql-client
-      - python-mysqldb
-      - python-pymongo
-  - include_role:
-      name: postfix
-  - include_role:
-      name: webserver
-  - copy:
-      src: "{{ cas_db_dump }}"
-      dest: /tmp/cas.sql
-    when: cas_db_dump is defined
-  - copy:
-      src: "{{ apikey_db_dump }}"
-      dest: /tmp/apikey.sql
-    when: apikey_db_dump is defined
-  - mysql_db:
-      state: absent
-      name: "{{ cas_db_name | default('emmet') }}"
-      login_host: "{{ cas_db_hostname }}"
-      login_port: "{{ cas_db_port | default('3306') }}"
-      login_user: "{{ mysql_root_username }}"
-      login_password: "{{ mysql_root_password }}"
-    when: cas_db_dump is defined
-    run_once: true
-  - mysql_db:
-      state: import
-      name: "{{ cas_db_name | default('emmet') }}"
-      target: /tmp/cas.sql
-      login_host: "{{ cas_db_hostname }}"
-      login_port: "{{ cas_db_port | default('3306') }}"
-      login_user: "{{ mysql_root_username }}"
-      login_password: "{{ mysql_root_password }}"
-    when: cas_db_dump is defined
-    run_once: true
-  - mysql_db:
-      state: import
-      name: "{{ apikey_db_name | default('apikey') }}"
-      target: /tmp/apikey.sql
-      login_host: "{{ apikey_db_hostname }}"
-      login_port: "{{ apikey_db_port | default('3306') }}"
-      login_user: "{{ mysql_root_username }}"
-      login_password: "{{ mysql_root_password }}"
-    when: apikey_db_dump is defined
-    run_once: true
-  - mysql_db:
-      state: present
-      name: "{{ item.name }}"
-      login_host: "{{ item.login_host }}"
-      login_port: "{{ item.login_port }}"
-      login_user: "{{ item.login_user }}"
-      login_password: "{{ item.login_password }}"
-      encoding: "{{ cas_db_encoding | default('utf8') }}"
-    run_once: true
-    with_items:
-    - { name: "{{ cas_db_name | default('emmet') }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
-    - { name: "{{ apikey_db_name | default('apikey') }}", login_host: "{{ apikey_db_hostname }}", login_port: "{{ apikey_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
-  # Need the external ipv4 address for mysql user when using external databse, otherwise localhost
-  - set_fact:
-      cas_mysql_src_host: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-    when:
-      cas_db_hostname != 'localhost'
-  - set_fact:
-      cas_mysql_src_host: localhost
-    when:
-      cas_db_hostname == 'localhost'
-  - set_fact:
-      apikey_mysql_src_host: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-    when:
-      apikey_db_hostname != 'localhost'
-  - set_fact:
-      apikey_mysql_src_host: localhost
-    when:
-      apikey_db_hostname == 'localhost'
-  - mysql_user:
-      login_host: "{{ item.login_host }}"
-      login_port: "{{ item.login_port }}"
-      login_user: "{{ item.login_user }}"
-      login_password: "{{ item.login_password }}"
-      user: "{{ item.user }}"
-      password: "{{ item.password }}"
-      priv: "{{ item.priv }}"
-      host: "{{ item.host }}"
-    with_items:
-    - { user: "{{ cas_flyway_username }}", password: "{{ cas_flyway_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:ALL", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
-    - { user: "{{ cas_db_username }}", password: "{{ cas_db_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:INSERT,SELECT,UPDATE,DELETE,EXECUTE,TRIGGER/mysql.proc:SELECT", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
-    - { user: "{{ apikey_db_username }}", password: "{{ apikey_db_password }}", priv: "{{ apikey_db_name | default('apikey') }}.*:ALL", host: "{{ apikey_mysql_src_host }}", login_host: "{{ apikey_db_hostname }}", login_port: "{{ apikey_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
-  - debug:
-      msg: "Should be the mongo users created? {{ cas_add_mongo_users | default(False) }}"
-  - mongodb_user:
-      user: "{{ item.user }}"
-      password: "{{ item.password }}"
-      database: "{{ item.database }}"
-      roles: "{{ item.roles }}"
-      replica_set: "{{ item.replica_set }}"
-      ssl: "{{ item.ssl }}"
-      state: present
-      login_host: "{{ item.login_host }}"
-      login_port: "{{ item.login_port }}"
-      login_database: "{{ item.login_database }}"
-      login_user: "{{ item.login_user }}"
-      login_password: "{{ item.login_password }}"
-    with_items:
-    - {
-      login_host: "{{ cas_tickets_host }}",
-      login_port: "{{ cas_tickets_port | default('27017') }}",
-      login_user: "{{ mongodb_root_username }}",
-      login_password: "{{ mongodb_root_password }}",
-      login_database: "{{ mongodb_root_database | default('admin') }}",
-      user: "{{ cas_tickets_username }}",
-      password: "{{ cas_tickets_password }}",
-      database: "{{ cas_tickets_db | default('cas-ticket-registry') }}",
-      replica_set: "{{ cas_tickets_replica_set | default('') }}",
-      ssl: "{{ cas_tickets_ssl_enabled | default('false') }}",
-      roles: 'readWrite' 
-    }
-    - {
-      login_host: "{{ cas_services_host }}",
-      login_port: "{{ cas_services_port | default('27017') }}",
-      login_user: "{{ mongodb_root_username }}",
-      login_password: "{{ mongodb_root_password }}",
-      login_database: "{{ mongodb_root_database | default('admin') }}",
-      user: "{{ cas_services_username }}",
-      password: "{{ cas_services_password }}",
-      database: "{{ cas_services_db | default('cas-service-registry' ) }}",
-      replica_set: "{{ cas_services_replica_set | default('') }}",
-      ssl: "{{ cas_services_ssl_enabled | default('false') }}",
-      roles: 'readWrite' 
-    }
-    - {
-      login_host: "{{ cas_audit_host | default('localhost') }}",
-      login_port: "{{ cas_audit_port | default('27017') }}",
-      login_user: "{{ mongodb_root_username }}",
-      login_password: "{{ mongodb_root_password }}",
-      login_database: "{{ mongodb_root_database | default('admin') }}",
-      user: "{{ cas_audit_username | default('cas') }}",
-      password: "{{ cas_audit_password | default('password') }}",
-      database: "{{ cas_audit_db | default('cas-audit-repository') }}",
-      replica_set: "{{ cas_audit_replica_set | default('') }}",
-      ssl: "{{ cas_audit_ssl_enabled | default('false') }}",
-      roles: 'readWrite' 
-    }
-    tags: mongodb-org
-    run_once: true
-    when: cas_add_mongo_users is defined and cas_add_mongo_users
-  - include_role:
-      name: cas5
-    vars:
-      min_memory: "{{ cas_min_memory | default('512m') }}"
-      max_memory: "{{ cas_max_memory | default('2g') }}"
-      service_registry_init_from_json: '{{ inventory_hostname == ansible_play_batch[0] }}'
-      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/'
-  - include_role:
-      name: cas-management
-    vars:
-      min_memory: "{{ cas_management_min_memory | default('256m') }}"
-      max_memory: "{{ cas_management_max_memory | default('1g') }}"
-      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/'
-  - include_role:
-      name: userdetails
-    vars:
-      min_memory: "{{ userdetails_min_memory | default('256m') }}"
-      max_memory: "{{ userdetails_max_memory | default('1g') }}"
-      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/'
-  - include_role:
-      name: apikey
-    vars:
-      min_memory: "{{ apikey_min_memory | default('256m') }}"
-      max_memory: "{{ apikey_max_memory | default('1g') }}"
-      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/'
-  - include_role:
-      name: nginx_vhost
-    vars:
-      appname: "{{ item.appname }}"
-      hostname: "{{ cas_host_name }}"
-      context_path: "{{ item.context }}"
-      nginx_paths:
-      - path: "/{{ item.context }}"
-        appname: "{{ item.appname }}"
-        is_proxy: true
-        proxy_pass: "http://127.0.0.1:{{item.port}}/{{ item.context }}"
-    with_items:
-    - { appname: "cas", context: "{{ cas_context_path | default('cas') }}", port: "{{ cas_port | default('9000') }}" }
-    - { appname: "cas-management", context: "{{ cas_management_context_path | default('cas-management') }}", port: "{{ cas_management_port | default('8070') }}" }
-    - { appname: "userdetails", context: "{{ userdetails_context_path | default('userdetails') }}", port: "{{ userdetails_port | default('9001') }}" }
-    - { appname: "apikey", context: "{{ apikey_context_path | default('apikey') }}", port: "{{ apikey_port | default('9002') }}" }
+  roles:
+    - common
+    - postfix
+    - webserver
+    - cas5-dbs
+    - { role: cas5,
+      min_memory: "{{ cas_min_memory | default('512m') }}",
+      max_memory: "{{ cas_max_memory | default('2g') }}",
+      service_registry_init_from_json: '{{ inventory_hostname == ansible_play_batch[0] }}',
+      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/' }
+    - { role: cas-management,
+      min_memory: "{{ cas_management_min_memory | default('256m') }}",
+      max_memory: "{{ cas_management_max_memory | default('1g') }}",
+      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/' }
+    - { role: userdetails,
+      min_memory: "{{ userdetails_min_memory | default('256m') }}",
+      max_memory: "{{ userdetails_max_memory | default('1g') }}",
+      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/' }
+    - { role: apikey,
+      min_memory: "{{ apikey_min_memory | default('256m') }}",
+      max_memory: "{{ apikey_max_memory | default('1g') }}",
+      bootadmin_client_base_url: 'https://{{ inventory_hostname}}/' }

--- a/ansible/cas5-standalone.yml
+++ b/ansible/cas5-standalone.yml
@@ -1,11 +1,10 @@
 - hosts: cas-servers
+  roles:
+    - common
+    - java
+    - mysql-5.7
+    - { role: mongodb-org, mongodb_version: 4.0 }
   tasks:
-  - name: Include common
-    include_role:
-      name: common
-  - name: Install java
-    include_role:
-      name: java
   - apt_repository:
       repo: ppa:chris-lea/redis-server
       update_cache: yes
@@ -15,14 +14,6 @@
     vars:
       packages:
       - redis-server
-  - name: Install mysql
-    include_role:
-      name: mysql-5.7
-  - name: Install mongo
-    include_role:
-      name: mongodb-org
-    vars:
-      mongodb_version: 4.0
 - name: include default cas 5 steps
   vars:
     cas_add_mongo_users: true

--- a/ansible/roles/apikey/tasks/main.yml
+++ b/ansible/roles/apikey/tasks/main.yml
@@ -3,6 +3,7 @@
     name: common
     tasks_from: setfacts
   tags:
+  - properties
   - setfacts
   - apikey
 
@@ -12,6 +13,7 @@
     state: present
     system: yes
   tags:
+  - properties
   - user
   - apikey
 
@@ -73,3 +75,20 @@
     - service
     - apikey
 
+- name: add nginx vhost
+  include_role:
+    name: nginx_vhost
+  vars:
+    appname: "apikey"
+    hostname: "{{ cas_host_name }}"
+    context_path: "{{ apikey_context_path | default('apikey') }}"
+    nginx_paths:
+      - path: "/{{ apikey_context_path | default('apikey') }}"
+        appname: "apikey"
+        is_proxy: true
+        proxy_pass: "http://127.0.0.1:{{ apikey_port | default('9002') }}/{{ apikey_context_path | default('apikey') }}"
+  tags:
+    - nginx_vhost
+    - deploy
+    - apikey
+  when: webserver_nginx

--- a/ansible/roles/cas-management/tasks/main.yml
+++ b/ansible/roles/cas-management/tasks/main.yml
@@ -5,6 +5,7 @@
   tags:
   - setfacts
   - cas-management
+  - properties
 
 - name: ensure target directories exist data subdirectories etc.
   file:
@@ -70,4 +71,22 @@
   tags:
     - deploy
     - service
-    - cas
+    - cas-management
+
+- name: add nginx vhost
+  include_role:
+    name: nginx_vhost
+  vars:
+    appname: "cas-management"
+    hostname: "{{ cas_host_name }}"
+    context_path: "{{  cas_management_context_path | default('cas-management') }}"
+    nginx_paths:
+      - path: "/{{  cas_management_context_path | default('cas-management') }}"
+        appname: "cas-management"
+        is_proxy: true
+        proxy_pass: "http://127.0.0.1:{{ cas_management_port | default('8070') }}/{{  cas_management_context_path | default('cas-management') }}"
+  tags:
+    - nginx_vhost
+    - deploy
+    - cas-management
+  when: webserver_nginx

--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -1,0 +1,178 @@
+- name: "set facts"
+  include_role:
+    name: common
+    tasks_from: setfacts
+  tags:
+  - setfacts
+  - cas
+
+- name: Install cas db dependencies
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - mysql-client
+    - python-mysqldb
+    - python-pymongo
+
+- name: Copy cas db dump
+  copy:
+    src: "{{ cas_db_dump }}"
+    dest: /tmp/cas.sql
+  when: cas_db_dump is defined
+
+- name: Copy apikey db dump
+  copy:
+    src: "{{ apikey_db_dump }}"
+    dest: /tmp/apikey.sql
+  when: apikey_db_dump is defined
+
+- name: Drop cas db if cas_db_dump is present
+  mysql_db:
+    state: absent
+    name: "{{ cas_db_name | default('emmet') }}"
+    login_host: "{{ cas_db_hostname }}"
+    login_port: "{{ cas_db_port | default('3306') }}"
+    login_user: "{{ mysql_root_username }}"
+    login_password: "{{ mysql_root_password }}"
+  when: cas_db_dump is defined
+  run_once: true
+
+- name: Import cas db if cas_db_dump is present
+  mysql_db:
+    state: import
+    name: "{{ cas_db_name | default('emmet') }}"
+    target: /tmp/cas.sql
+    login_host: "{{ cas_db_hostname }}"
+    login_port: "{{ cas_db_port | default('3306') }}"
+    login_user: "{{ mysql_root_username }}"
+    login_password: "{{ mysql_root_password }}"
+  when: cas_db_dump is defined
+  run_once: true
+
+- name: Import apikey db if apikey_db_dump is present
+  mysql_db:
+    state: import
+    name: "{{ apikey_db_name | default('apikey') }}"
+    target: /tmp/apikey.sql
+    login_host: "{{ apikey_db_hostname }}"
+    login_port: "{{ apikey_db_port | default('3306') }}"
+    login_user: "{{ mysql_root_username }}"
+    login_password: "{{ mysql_root_password }}"
+  when: apikey_db_dump is defined
+  run_once: true
+
+- name: Create cas and apikey db
+  mysql_db:
+    state: present
+    name: "{{ item.name }}"
+    login_host: "{{ item.login_host }}"
+    login_port: "{{ item.login_port }}"
+    login_user: "{{ item.login_user }}"
+    login_password: "{{ item.login_password }}"
+    encoding: "{{ cas_db_encoding | default('utf8') }}"
+  run_once: true
+  with_items:
+  - { name: "{{ cas_db_name | default('emmet') }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+  - { name: "{{ apikey_db_name | default('apikey') }}", login_host: "{{ apikey_db_hostname }}", login_port: "{{ apikey_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+
+- name: Need the external ipv4 address for mysql cas user when using external database
+  set_fact:
+    cas_mysql_src_host: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+  when:
+    cas_db_hostname != 'localhost'
+
+- name: otherwise localhost
+  set_fact:
+    cas_mysql_src_host: localhost
+  when:
+    cas_db_hostname == 'localhost'
+
+- name: Need the external ipv4 address for mysql apikey user when using external database
+  set_fact:
+    apikey_mysql_src_host: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+  when:
+    apikey_db_hostname != 'localhost'
+
+- name: otherwise localhost
+  set_fact:
+    apikey_mysql_src_host: localhost
+  when:
+    apikey_db_hostname == 'localhost'
+
+- name: Create cas and apikey mysql users
+  mysql_user:
+    login_host: "{{ item.login_host }}"
+    login_port: "{{ item.login_port }}"
+    login_user: "{{ item.login_user }}"
+    login_password: "{{ item.login_password }}"
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    priv: "{{ item.priv }}"
+    host: "{{ item.host }}"
+  with_items:
+    - { user: "{{ cas_flyway_username }}", password: "{{ cas_flyway_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:ALL", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+    - { user: "{{ cas_db_username }}", password: "{{ cas_db_password }}", priv: "{{ cas_db_name | default('emmet') }}.*:INSERT,SELECT,UPDATE,DELETE,EXECUTE,TRIGGER/mysql.proc:SELECT", host: "{{ cas_mysql_src_host }}", login_host: "{{ cas_db_hostname }}", login_port: "{{ cas_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+    - { user: "{{ apikey_db_username }}", password: "{{ apikey_db_password }}", priv: "{{ apikey_db_name | default('apikey') }}.*:ALL", host: "{{ apikey_mysql_src_host }}", login_host: "{{ apikey_db_hostname }}", login_port: "{{ apikey_db_port | default('3306') }}", login_user: "{{ mysql_root_username }}", login_password: "{{ mysql_root_password }}" }
+
+- name: "Check if mongo cas users should be created"
+  debug:
+    msg: "Should be the mongo users created? {{ cas_add_mongo_users | default(False) }}"
+
+- name: Create mongo cas users
+  mongodb_user:
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    database: "{{ item.database }}"
+    roles: "{{ item.roles }}"
+    replica_set: "{{ item.replica_set }}"
+    ssl: "{{ item.ssl }}"
+    state: present
+    login_host: "{{ item.login_host }}"
+    login_port: "{{ item.login_port }}"
+    login_database: "{{ item.login_database }}"
+    login_user: "{{ item.login_user }}"
+    login_password: "{{ item.login_password }}"
+  with_items:
+  - {
+    login_host: "{{ cas_tickets_host }}",
+    login_port: "{{ cas_tickets_port | default('27017') }}",
+    login_user: "{{ mongodb_root_username }}",
+    login_password: "{{ mongodb_root_password }}",
+    login_database: "{{ mongodb_root_database | default('admin') }}",
+    user: "{{ cas_tickets_username }}",
+    password: "{{ cas_tickets_password }}",
+    database: "{{ cas_tickets_db | default('cas-ticket-registry') }}",
+    replica_set: "{{ cas_tickets_replica_set | default('') }}",
+    ssl: "{{ cas_tickets_ssl_enabled | default('false') }}",
+    roles: 'readWrite'
+  }
+  - {
+    login_host: "{{ cas_services_host }}",
+    login_port: "{{ cas_services_port | default('27017') }}",
+    login_user: "{{ mongodb_root_username }}",
+    login_password: "{{ mongodb_root_password }}",
+    login_database: "{{ mongodb_root_database | default('admin') }}",
+    user: "{{ cas_services_username }}",
+    password: "{{ cas_services_password }}",
+    database: "{{ cas_services_db | default('cas-service-registry' ) }}",
+    replica_set: "{{ cas_services_replica_set | default('') }}",
+    ssl: "{{ cas_services_ssl_enabled | default('false') }}",
+    roles: 'readWrite'
+  }
+  - {
+    login_host: "{{ cas_audit_host | default('localhost') }}",
+    login_port: "{{ cas_audit_port | default('27017') }}",
+    login_user: "{{ mongodb_root_username }}",
+    login_password: "{{ mongodb_root_password }}",
+    login_database: "{{ mongodb_root_database | default('admin') }}",
+    user: "{{ cas_audit_username | default('cas') }}",
+    password: "{{ cas_audit_password | default('password') }}",
+    database: "{{ cas_audit_db | default('cas-audit-repository') }}",
+    replica_set: "{{ cas_audit_replica_set | default('') }}",
+    ssl: "{{ cas_audit_ssl_enabled | default('false') }}",
+    roles: 'readWrite'
+  }
+  tags: mongodb-org
+  run_once: true
+  when: cas_add_mongo_users is defined and cas_add_mongo_users

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -5,6 +5,7 @@
   tags:
   - setfacts
   - cas
+  - properties
 
 - name: "Ensure system user for CAS"
   user:
@@ -14,6 +15,7 @@
   tags:
   - service
   - cas
+  - properties
 
 - name: ensure target directories exist data subdirectories etc.
   file:
@@ -91,3 +93,20 @@
     - service
     - cas
 
+- name: add nginx vhost
+  include_role:
+    name: nginx_vhost
+  vars:
+    appname: "cas"
+    hostname: "{{ cas_host_name }}"
+    context_path: "{{ cas_context_path | default('cas') }}"
+    nginx_paths:
+      - path: "/{{ cas_context_path | default('cas') }}"
+        appname: "cas"
+        is_proxy: true
+        proxy_pass: "http://127.0.0.1:{{ cas_port | default('9000') }}/{{ cas_context_path | default('cas') }}"
+  tags:
+    - nginx_vhost
+    - deploy
+    - cas
+  when: webserver_nginx

--- a/ansible/roles/mongodb-org/tasks/main.yml
+++ b/ansible/roles/mongodb-org/tasks/main.yml
@@ -1,14 +1,16 @@
 - name: Add mongodb.org apt key for version 4.0
-  apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: 9DA31620334BD75D9DCB49F368818C72E52529D4
+  get_url:
+    url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x9DA31620334BD75D9DCB49F368818C72E52529D4'
+    dest: /etc/apt/trusted.gpg.d/mongodb.asc
+    mode: 0644
   when: mongodb_version == 4.0
   tags: mongodb-org
 
 - name: Add mongodb.org apt key for version 3.4
-  apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: 0c49f3730359a14518585931bc711f9ba15703c6
+  get_url:
+    url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x0c49f3730359a14518585931bc711f9ba15703c6'
+    dest: /etc/apt/trusted.gpg.d/mongodb.asc
+    mode: 0644
   when: mongodb_version == 3.4
   tags: mongodb-org
 

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -5,6 +5,7 @@
   tags:
   - setfacts
   - userdetails
+  - properties
 
 - name: "Create system user for userdetails"
   user:
@@ -14,6 +15,7 @@
   tags:
   - user
   - userdetails
+  - properties
 
 - name: ensure target directories exist data subdirectories etc.
   file:
@@ -73,3 +75,20 @@
     - service
     - userdetails
 
+- name: add nginx vhost
+  include_role:
+    name: nginx_vhost
+  vars:
+    appname: "userdetails"
+    hostname: "{{ cas_host_name }}"
+    context_path: "{{  userdetails_context_path | default('userdetails') }}"
+    nginx_paths:
+      - path: "/{{  userdetails_context_path | default('userdetails') }}"
+        appname: "userdetails"
+        is_proxy: true
+        proxy_pass: "http://127.0.0.1:{{ userdetails_port | default('9001') }}/{{  userdetails_context_path | default('userdetails') }}"
+  tags:
+    - nginx_vhost
+    - deploy
+    - userdetails
+  when: webserver_nginx


### PR DESCRIPTION
This PR do a refactorization of CAS playbooks and roles in order to:
- move tasks from playbooks to roles
- use of `roles` instead of `include_role` so we can use `--tags` properly with these playbooks
- maintain the same structure that the rest of playbooks and simplify the cas playbooks

This also solve: https://github.com/AtlasOfLivingAustralia/ala-install/issues/437

I've tested here (ubuntu `18.04` VMs):
https://auth-es.l-a.site/cas/login
https://auth-es.l-a.site/userdetails/
https://auth-es.l-a.site/apikey/

I'm working in this utility:
https://github.com/living-atlases/la-data-generator
that does not generate the properties for the `cas` services because of the current structure of the `cas` playbooks. So this also fix this `cas` properties generation (useful for LA based docker portals).

cc @djtfmartin 