### PR TITLE
Added when to some handlers so can be skipped with -e skip_handlers=true

### DIFF
--- a/ansible/roles/apikey/handlers/main.yml
+++ b/ansible/roles/apikey/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart apikey
   service: name=apikey state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/cas-management/handlers/main.yml
+++ b/ansible/roles/cas-management/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart cas-management
   service: name=cas-management state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/cas5/handlers/main.yml
+++ b/ansible/roles/cas5/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart cas
   service: name=cas state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/doi-service/handlers/main.yml
+++ b/ansible/roles/doi-service/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart doi-service
   service: name=doi-service state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/image-service/handlers/main.yml
+++ b/ansible/roles/image-service/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart image-service
   service: name=image-service state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/tomcat/handlers/main.yml
+++ b/ansible/roles/tomcat/handlers/main.yml
@@ -3,12 +3,20 @@
 # variable controls version (@see common/vars)
 - name: restart tomcat
   service: name={{tomcat}} state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"
 
 - name: restart httpd
   service: name={{apache}} state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"
 
 - name: restart apache
   service: name={{apache}} state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"
 
 - name: restart mysql
   service: name=mysqld state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") == "false"

--- a/ansible/roles/userdetails/handlers/main.yml
+++ b/ansible/roles/userdetails/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart userdetails
   service: name=userdetails state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") == "false"


### PR DESCRIPTION
Following https://stackoverflow.com/a/57677835 I added some extra var `skip_handlers` to allow prevent some handler to run (for instance if we want to update properties without restart a service).

This should not affect the current usage of `ala-install` and only skip the restart of some services when `-e skip_handlers=true` is added to `ansible-playbook`.