### PR TITLE
Added quotes to doi prefix so it's parsed as String and not a Float

### DIFF
--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -48,7 +48,7 @@ datacite:
       baseApiUrl: {{ doi_datacite_api_url | default('https://api.test.datacite.org/') }}
       user: {{ doi_datacite_user }}
       password: {{ doi_datacite_password }}
-      prefix: {{ doi_datacite_prefix }}
+      prefix: '{{ doi_datacite_prefix }}'
       shoulder: {{ doi_datacite_shoulder }}
 
 ala:


### PR DESCRIPTION
Testing the doi service I noticed that datacite prefix variable in the config is parsed as float although [we try to read as String](https://github.com/AtlasOfLivingAustralia/doi-service/blob/fc753cfe4cdad465dcbd356153306a741aa86d87/grails-app/services/au/org/ala/doi/providers/DataCiteService.groovy#L28). In practice, some doi prefix like `10.1230` is read as `10.123`. I added some quotes in the config template to force its type to `String`.