### PR TITLE
Added more download vars to collectory. Standardized alerts_url

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -99,7 +99,7 @@ rifcs.excludeBounds={{ rifcs_exclude_bounds | default('false') }}
 loggerURL={{ (logger_webservice_url | default(logger_url)) }}
 
 # External services
-alertUrl={{ alert_url | default('') }}
+alertUrl={{ (alerts_url | default(alert_url)) | default('') }}
 speciesListToolUrl={{ species_list_tool_url | default('https://lists.ala.org.au/speciesListItem/list/') }}
 
 # GBIF base URL for webservices
@@ -122,3 +122,6 @@ gbifOrphansPublisherID={{ gbif_orphans_publisher_id | default('') }}
 # URL paths for archives
 resource.publicArchive.url.template = {{ public_archive_url | default('https://biocache.ala.org.au/archives/gbif/@UID@/@UID@.zip') }}
 resource.gbifExport.url.template = {{ gbif_archive_url | default('https://biocache.ala.org.au/archives/gbif/@UID@/@UID@.zip') }}
+
+citation.template = {{ citation_template | default('Records provided by @entityName@, accessed through ALA website.') }}
+citation.link.template = {{ citation_link_template | default('For more information: @link@') }}


### PR DESCRIPTION
I've exposed some variables from:
https://github.com/AtlasOfLivingAustralia/ala-collectory/blob/84aa9aace9c384c2d178321cdf24142db3ad30a1/grails-app/conf/Config.groovy#L110

Also I've added the `alerts_url` variable similar to the rest of roles trying not to affect to ALA inventories.