### PR TITLE
First admin user creation as optional cas5 task for new LA deployments

### DIFF
--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -93,6 +93,45 @@
     - service
     - cas
 
+- name: wait for cas is running to create the first admin user
+  wait_for: host=127.0.0.1 port={{ cas_port | default('9000') }} delay=30
+  when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined
+  tags:
+    - cas
+    - db
+
+- name: ensure target sql directory exist
+  file: path={{item}} state=directory owner=cas group=cas
+  with_items:
+    - "{{data_dir}}/cas/setup"
+  when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined
+  tags:
+    - cas
+    - db
+    - properties
+
+- name: copy all SQL first admin scripts
+  template: src={{ item }} dest={{data_dir}}/cas/setup/
+  with_items:
+    - "sql/role-editor.sql"
+    - "sql/admin-add.sql"
+  when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined
+  tags:
+    - cas
+    - db
+    - properties
+
+- name: create role editor and first admin user if do not exist
+  shell: "mysql --host={{ cas_db_hostname | default('localhost') }} --port={{ cas_db_port | default('3306') }}  --user={{ cas_db_username | default('cas') }} --password={{ cas_db_password | default('password') }} {{ cas_db_name | default('emmet')  }} < {{data_dir}}/cas/setup/{{ item }}"
+  with_items:
+    - "role-editor.sql"
+    - "admin-add.sql"
+  when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined
+  ignore_errors: no
+  tags:
+    - cas
+    - db
+
 - name: add nginx vhost
   include_role:
     name: nginx_vhost

--- a/ansible/roles/cas5/templates/sql/admin-add.sql
+++ b/ansible/roles/cas5/templates/sql/admin-add.sql
@@ -1,0 +1,98 @@
+--
+-- First admin user creation if not exists
+--
+-- cas_first_admin_email should be an email
+-- cas_first_admin_temp_auth_key is generated in userdetails with:
+--   user.tempAuthKey = UUID.randomUUID().toString()
+-- Tools like 'uuidgen' can be used in the command line
+--
+-- About creation if does not exists in mysql: https://stackoverflow.com/a/25996186
+--
+INSERT INTO users (userid, username, firstname, lastname, email, activated, locked, temp_auth_key)
+    SELECT userid, username, firstname, lastname, email, activated, locked, temp_auth_key
+    FROM (SELECT 1 as userid, '{{ cas_first_admin_email }}' as username, 'Admin' as firstname, 'User' as lastname, '{{ cas_first_admin_email }}' as email, '1' as activated, '0' as locked, '{{ cas_first_admin_temp_auth_key }}' as temp_auth_key) t
+    WHERE NOT EXISTS (SELECT 1 FROM users u WHERE u.userid = t.userid);
+--
+-- Password (should be a bcrypt hash)
+-- See:
+-- https://github.com/AtlasOfLivingAustralia/userdetails/blob/master/src/main/java/au/org/ala/cas/encoding/BcryptPasswordEncoder.java
+-- Can be easy created with:
+--
+--   htpasswd -bnBC 10 "" password | tr -d ':\n' | sed 's/$2y/$2a/'
+--
+-- or in node:
+--
+--   bcrypt.genSalt(saltRounds, "a", function (err, salt) {
+--     bcrypt.hash(myPlaintextPassword, salt2, function (err, hash) {
+--       console.log(salt);
+--     });
+--   });
+--
+INSERT INTO passwords (userid, password, type, status)
+    SELECT userid, password, type, status
+    FROM (SELECT 1 as userid,'{{ cas_first_admin_bcrypt_password }}' as password, 'bcrypt' as type, 'CURRENT' as status) t
+    WHERE NOT EXISTS (SELECT 1 FROM passwords p WHERE p.userid = t.userid);
+--
+-- User Profiles
+--
+INSERT INTO profiles (userid, property, value)
+    SELECT userid, property, value
+    FROM (SELECT 1 as userId, 'city' as property, '' as value) t
+    WHERE NOT EXISTS (SELECT 1 FROM profiles u WHERE u.userid = t.userid AND u.property = t.property);
+--
+INSERT INTO profiles (userid, property, value)
+    SELECT userid, property, value
+    FROM (SELECT 1 as userId, 'country' as property, '' as value) t
+    WHERE NOT EXISTS (SELECT 1 FROM profiles u WHERE u.userid = t.userid AND u.property = t.property);
+--
+INSERT INTO profiles (userid, property, value)
+    SELECT userid, property, value
+    FROM (SELECT 1 as userId, 'organisation' as property, '' as value) t
+    WHERE NOT EXISTS (SELECT 1 FROM profiles u WHERE u.userid = t.userid AND u.property = t.property);
+--
+INSERT INTO profiles (userid, property, value)
+    SELECT userid, property, value
+    FROM (SELECT 1 as userId, 'state' as property, '' as value) t
+    WHERE NOT EXISTS (SELECT 1 FROM profiles u WHERE u.userid = t.userid AND u.property = t.property);
+--
+-- Admin roles
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_ADMIN' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_COLLECTION_ADMIN' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_COLLECTION_EDITOR' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_EDITOR' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_IMAGE_ADMIN' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_SPATIAL_ADMIN' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_SYSTEM_ADMIN' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+--
+INSERT INTO user_role (user_id, role_id)
+    SELECT user_id, role_id
+    FROM (SELECT 1 as user_id, 'ROLE_USER' as role_id) t
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);

--- a/ansible/roles/cas5/templates/sql/role-editor.sql
+++ b/ansible/roles/cas5/templates/sql/role-editor.sql
@@ -1,0 +1,6 @@
+-- INSERT role if does not exits
+-- ROLE_EDITOR is not added  by default by CAS but used in some ALA modules 
+INSERT INTO role (role, description)
+    SELECT role, description
+    FROM (SELECT 'ROLE_EDITOR' as role, '' as description) t
+    WHERE NOT EXISTS (SELECT 1 FROM role r WHERE r.role = t.role);


### PR DESCRIPTION
I'm trying to minimize the additional steps required to setup properly a new LA portal. 
https://github.com/AtlasOfLivingAustralia/documentation/wiki/LA-Quick-Start-Guide#post-install
Some of these are the `CAS` postinstall steps:
https://github.com/AtlasOfLivingAustralia/documentation/wiki/CAS-postinstall-steps
and many other additional steps depends on these.

This optional task creates an admin user if some optional variables are present:
```
cas_first_admin_email=admin@example.com
# hashed password, that can be easy created for instance with:
#   htpasswd -bnBC 10 "" password | tr -d ':\n' | sed 's/$2y/$2a/'
# or during the inventories generation.
cas_first_admin_bcrypt_password=$2a$10$PdZ9NacTV8GiqbTMzkd2bORXPmm2NobnCc387NVE6TEYwQacIznq.
# Random uuid used for email validation. It can be created with  'uuidgen' or similar:
cas_first_admin_temp_auth_key=7a07168e-1a5d-4924-83d2-bb06297348dc
```
It also creates the `ROLE_EDITOR` if not exists (some role that is used by some modules like the `collectory` but not present in new LA `CAS` deployments.

PS: Related with this I'm auto-generating the CAS5 secret keys https://gist.github.com/vjrj/3b9c0a3cf36b9c37db71609f5eac5203