### PR TITLE
Auto add apikeys from apikey role

### DIFF
--- a/ansible/roles/apikey/tasks/main.yml
+++ b/ansible/roles/apikey/tasks/main.yml
@@ -75,6 +75,50 @@
     - service
     - apikey
 
+- name: Ensure apikey is in a running state
+  service:
+    name: apikey
+    state: started
+  register: apikeyService
+  until: apikeyService.status.ActiveState == "active"
+  retries: 15
+  delay: 30
+  tags:
+    - apikey
+    - db
+
+- name: wait for apikey is running to create the apikeys
+  wait_for: host=127.0.0.1 port={{ apikey_port | default('9002') }} delay=30
+  when: apikey_def_creator_email is defined and apikey_def_creator_userid is defined
+  tags:
+    - apikey
+    - db
+
+- name: add apikeys if do not exist
+  include_role:
+    name: apikey-add
+  vars:
+    app: "{{ oitem.app }}"
+    apikey: "{{ oitem.apikey }}"
+  with_items:
+    - { app: "alerts", apikey: "{{ alerts_apikey }}" }
+    - { app: "bie-index", apikey: "{{ bie_index_api_key }}" }
+    - { app: "biocache", apikey: "{{ biocache_api_key }}" }
+    - { app: "collectory", apikey: "{{ api_key }}" }
+    - { app: "collectory", apikey: "{{ registry_api_key }}" }
+    - { app: "doi-service", apikey: "{{ doi_service_apiKey }}" }
+    - { app: "image-service", apikey: "{{ image_service_apiKey }}" }
+    - { app: "spatialportal", apikey: "{{ spatial_service_api_key }}" }
+    - { app: "spatialportal", apikey: "{{ spatial_service_service_key }}" }
+    - { app: "spatialportal", apikey: "{{ spatial_service_slave_key }}" }
+    - { app: "specieslists", apikey: "{{ speciesList_api_key }}" }
+  loop_control:
+    loop_var: oitem
+  when: apikey_def_creator_email is defined and apikey_def_creator_userid is defined
+  tags:
+    - apikeys_add
+    - apikey
+
 - name: add nginx vhost
   include_role:
     name: nginx_vhost

--- a/ansible/roles/bie-hub/tasks/main.yml
+++ b/ansible/roles/bie-hub/tasks/main.yml
@@ -19,21 +19,6 @@
     - properties
     - bie
 
-- name: add apikeys if do not exist
-  include_role:
-    name: apikey-add
-  vars:
-    app: "{{ oitem.app }}"
-    apikey: "{{ oitem.apikey }}"
-  with_items:
-    - { app: "bie-index", apikey: "{{ bie_index_api_key }}" }
-    - { app: "specieslists", apikey: "{{ speciesList_api_key }}" }
-  loop_control:
-    loop_var: oitem
-  when: apikey_def_creator_email is defined and apikey_def_creator_userid is defined
-  tags:
-    - apikeys_add
-
 - name: copy eolContentToUpdate.properties
   template:
     src: eolContentToUpdate.properties

--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -152,22 +152,6 @@
     - biocache_hub
   when: biocache_hub == 'ala-hub'
 
-- name: add apikeys if do not exist
-  include_role:
-    name: apikey-add
-  vars:
-    app: "{{ oitem.app }}"
-    apikey: "{{ oitem.apikey }}"
-  with_items:
-    - { app: "alerts", apikey: "{{ alerts_apikey }}" }
-    - { app: "bie-index", apikey: "{{ bie_index_api_key }}" }
-    - { app: "biocache", apikey: "{{ biocache_api_key }}" }
-  loop_control:
-    loop_var: oitem
-  when: apikey_def_creator_email is defined and apikey_def_creator_userid is defined
-  tags:
-    - apikeys_add
-
 - name: set data ownership
   file: path={{data_dir}}/{{biocache_hub}} owner={{tomcat_user}} group={{tomcat_user}} recurse=true
   notify:


### PR DESCRIPTION
Following the issue detected in https://github.com/AtlasOfLivingAustralia/ala-install/pull/461#issuecomment-772457759 I reordered the tasks in the apikey role.

I also include a service check that it's something that is also needed because in new installations the CAS services are not started.
https://github.com/AtlasOfLivingAustralia/documentation/wiki/CAS-postinstall-steps#restart-of-services-after-first-run
I'll send a PR with the same check for the rest of CAS services.

The result of this PR and the previous one that auto-creates the admin user:
![2021-06-03-18-46-33-screenshot](https://user-images.githubusercontent.com/180085/106789534-a82ffa00-6652-11eb-9e72-572cbfc8502b.png)
![2021-06-03-18-54-57-screenshot](https://user-images.githubusercontent.com/180085/106789530-a6fecd00-6652-11eb-892d-89113d6854b0.png)
