### PR TITLE
Ensure CAS services are running

### DIFF
--- a/ansible/roles/cas-management/tasks/main.yml
+++ b/ansible/roles/cas-management/tasks/main.yml
@@ -73,6 +73,18 @@
     - service
     - cas-management
 
+- name: Ensure cas-management is in a running state
+  service:
+    name: cas-management
+    state: started
+  register: casManagementService
+  until: casManagementService.status.ActiveState == "active"
+  retries: 15
+  delay: 30
+  tags:
+    - cas-management
+    - db
+
 - name: add nginx vhost
   include_role:
     name: nginx_vhost

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -93,6 +93,18 @@
     - service
     - cas
 
+- name: Ensure cas is in a running state
+  service:
+    name: cas
+    state: started
+  register: casService
+  until: casService.status.ActiveState == "active"
+  retries: 15
+  delay: 30
+  tags:
+    - cas
+    - db
+
 - name: wait for cas is running to create the first admin user
   wait_for: host=127.0.0.1 port={{ cas_port | default('9000') }} delay=30
   when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -75,6 +75,18 @@
     - service
     - userdetails
 
+- name: Ensure userdetails is in a running state
+  service:
+    name: userdetails
+    state: started
+  register: userdetailsService
+  until: userdetailsService.status.ActiveState == "active"
+  retries: 15
+  delay: 30
+  tags:
+    - userdetails
+    - db
+
 - name: copy all SQL auth ip scripts
   template: src={{ item }} dest={{data_dir}}/userdetails/setup/
   with_items:
@@ -90,6 +102,7 @@
   loop: "{{ (userdetails_authorize_ip_list | regex_replace(' ', '')).split(',') }}"
   when: userdetails_authorize_ip_list is defined
   ignore_errors: no
+
   tags:
     - userdetails
     - db

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -102,7 +102,6 @@
   loop: "{{ (userdetails_authorize_ip_list | regex_replace(' ', '')).split(',') }}"
   when: userdetails_authorize_ip_list is defined
   ignore_errors: no
-
   tags:
     - userdetails
     - db


### PR DESCRIPTION
Contining with conversation in https://github.com/AtlasOfLivingAustralia/ala-install/pull/462 these tasks ensure that CAS services are running at first install something that currently we do manually:
https://github.com/AtlasOfLivingAustralia/documentation/wiki/CAS-postinstall-steps#restart-of-services-after-first-run

Some logs of these tasks:
```
TASK [Ensure cas is in a running state] ************************************************************************************************************************************************************************
Wednesday 03 February 2021  18:31:16 +0100 (0:00:00.086)       0:00:26.394 **** 
FAILED - RETRYING: Ensure cas is in a running state (15 retries left).
ok: [ala-install-test-1]
```