### PR TITLE
Allow ip list insertion tasks in userdetails and logger

### DIFF
--- a/ansible/roles/logger-service/tasks/main.yml
+++ b/ansible/roles/logger-service/tasks/main.yml
@@ -81,7 +81,6 @@
   when: logger_authorize_ip_list is defined
   tags:
     - logger-service
-    - test
     - db
     - properties
 
@@ -92,7 +91,6 @@
   ignore_errors: no
   tags:
     - logger-service
-    - test
     - db
 
 - name: set nginx proxy target if configured

--- a/ansible/roles/logger-service/tasks/main.yml
+++ b/ansible/roles/logger-service/tasks/main.yml
@@ -74,6 +74,27 @@
     - apache_vhost
   when: not webserver_nginx
 
+- name: copy all SQL auth ip scripts
+  template: src={{ item }} dest={{data_dir}}/logger/setup/
+  with_items:
+    - "sql/auth-ip.sql"
+  when: logger_authorize_ip_list is defined
+  tags:
+    - logger-service
+    - test
+    - db
+    - properties
+
+- name: create auth ip in db if does not exists
+  shell: "mysql --host={{ logger_db_hostname }} --user={{ logger_db_username }} --password={{ logger_db_password }} {{ logger_db_name }} -e \"set @ip='{{ item }}'; set @host_name='{{ item }}'; source {{data_dir}}/logger/setup/auth-ip.sql;\""
+  loop: "{{ (logger_authorize_ip_list | regex_replace(' ', '')).split(',') }}"
+  when: logger_authorize_ip_list is defined
+  ignore_errors: no
+  tags:
+    - logger-service
+    - test
+    - db
+
 - name: set nginx proxy target if configured
   set_fact:
     logger_proxy_target: "{{logger_context_path}}"

--- a/ansible/roles/logger-service/templates/sql/auth-ip.sql
+++ b/ansible/roles/logger-service/templates/sql/auth-ip.sql
@@ -1,0 +1,5 @@
+-- Insert remote address if do no exists
+INSERT INTO remote_address (ip, host_name)
+    SELECT ip, host_name
+    FROM (SELECT @ip as ip, @host_name as host_name) t
+    WHERE NOT EXISTS (SELECT 1 FROM remote_address r WHERE r.ip = t.ip);

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -75,6 +75,25 @@
     - service
     - userdetails
 
+- name: copy all SQL auth ip scripts
+  template: src={{ item }} dest={{data_dir}}/userdetails/setup/
+  with_items:
+    - "sql/auth-ip.sql"
+  when: userdetails_authorize_ip_list is defined
+  tags:
+    - userdetails
+    - db
+    - properties
+
+- name: create auth ip in db if does not exists
+  shell: "mysql --host={{ cas_db_hostname | default('localhost') }} --port={{ cas_db_port | default('3306') }}  --user={{ cas_db_username | default('cas') }} --password={{ cas_db_password | default('password') }} {{ cas_db_name | default('emmet')  }} -e \"set @ip='{{ item }}'; set @description=''; source {{data_dir}}/userdetails/setup/auth-ip.sql;\""
+  loop: "{{ (userdetails_authorize_ip_list | regex_replace(' ', '')).split(',') }}"
+  when: userdetails_authorize_ip_list is defined
+  ignore_errors: no
+  tags:
+    - userdetails
+    - db
+
 - name: add nginx vhost
   include_role:
     name: nginx_vhost

--- a/ansible/roles/userdetails/templates/sql/auth-ip.sql
+++ b/ansible/roles/userdetails/templates/sql/auth-ip.sql
@@ -1,0 +1,5 @@
+-- Authorize IP inserting a register if does not exists yet
+INSERT INTO authorised_system (host, description, version)
+    SELECT host, description, version
+    FROM (SELECT @ip as host, @description as description, 1 as version) t
+    WHERE NOT EXISTS (SELECT 1 FROM authorised_system a WHERE a.host = t.host);


### PR DESCRIPTION
Following #460 #461 and #462 and continue coding in ala-install current manual tasks, this PR adds IPs to the allow lists of `userdetails` and `logger`: 
https://github.com/AtlasOfLivingAustralia/documentation/wiki/Secure-your-LA-infrastructure#allowlist-ip-address
if some variables exists:

```
userdetails_authorize_ip_list=192.168.0.1, 192.168.0.2, 192.168.0.3
logger_authorize_ip_list=192.168.0.1, 192.168.0.2, 192.168.0.3
```

Some screenshots of the results:

![2021-11-04-11-07-47-screenshot](https://user-images.githubusercontent.com/180085/106880145-4fa53f00-66dc-11eb-9935-8a512e38f6c1.png)
![2021-10-04-10-55-28-screenshot](https://user-images.githubusercontent.com/180085/106880148-50d66c00-66dc-11eb-85af-d9a2f3a4f7ff.png)
