### PR TITLE
Logger mysql driver for mysql8 and others previous versions

### DIFF
--- a/ansible/roles/logger-service/templates/logger-config.properties
+++ b/ansible/roles/logger-service/templates/logger-config.properties
@@ -26,8 +26,12 @@ ala.admin.systemMessage.path={{  ala_admin_system_message_path | default('/data/
 
 # Data Source properties
 dataSource.dbCreate=none
+{% if mysql == 'mysql-server-8.0' %}
 dataSource.driverClassName=com.mysql.cj.jdbc.Driver
 dataSource.dialect=org.hibernate.dialect.MySQL8Dialect
+{% else %}
+dataSource.driverClassName=com.mysql.jdbc.Driver
+{% endif %}
 dataSource.url=jdbc\:mysql\://{{logger_db_hostname}}/{{logger_db_name}}?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8
 dataSource.username={{logger_db_username}}
 dataSource.password={{logger_db_password}}


### PR DESCRIPTION
The last changes in logger config https://github.com/AtlasOfLivingAustralia/ala-install/commit/7ec553786938abd94147de96994a08ecb7f66508 https://github.com/AtlasOfLivingAustralia/ala-install/commit/7e1b6d62e229dc66554de447065b973d998ef661 breaks logger deploy on ubuntu 18.04. This PR add a condition in the config depending of the common mysql facts.