### PR TITLE
Install different deps if using ansible python 2 or 3

### DIFF
--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -15,6 +15,16 @@
     - python-mysqldb
     - python-pymongo
 
+- name: Install pip when necessary
+  apt:
+    name: python-pip
+  when: ansible_python.version.major==2
+
+- name: Install pip3 when necessary
+  apt:
+    name: python3-pip
+  when: ansible_python.version.major==3
+
 - name: Copy cas db dump
   copy:
     src: "{{ cas_db_dump }}"

--- a/ansible/roles/exec-jar/tasks/main.yml
+++ b/ansible/roles/exec-jar/tasks/main.yml
@@ -8,12 +8,20 @@
   tags:
   - service
 
-- name: Install dependencies
+- name: Install dependencies for ansible python 2
   apt:
-    name: 
-      - python3-lxml
+    name: python-lxml
     state: present
-  tags: 
+  when: ansible_python.version.major==2
+  tags:
+  - service
+
+- name: Install dependencies for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+  tags:
   - service
 
 - name: "Create system user for {{service_name}}"

--- a/ansible/roles/mongodb-org/tasks/main.yml
+++ b/ansible/roles/mongodb-org/tasks/main.yml
@@ -31,8 +31,18 @@
 
 - name: Install mongodb.org packages and related
   apt:
-    name: ['mongodb-org-shell', 'mongodb-org-server', 'mongodb-org-tools', 'python3-pip']
+    name: ['mongodb-org-shell', 'mongodb-org-server', 'mongodb-org-tools' ]
   tags: mongodb-org
+
+- name: Install pip2 when necessary
+  apt:
+    name: python-pip
+  when: ansible_python.version.major==2
+
+- name: Install python3 when necessary
+  apt:
+    name: python3-pip
+  when: ansible_python.version.major==3
 
 # https://github.com/ansible/ansible/issues/36585
 - name: force systemd to reread configs
@@ -73,7 +83,6 @@
     name: mongod
     enabled: yes
   tags: mongodb-org
-
 
 
 # https://github.com/ansible/ansible/issues/33832

--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -14,7 +14,7 @@
     - restart mysql
   when: ansible_os_family == "RedHat"
 
-- name: install mysql deps for ansible and python 2 (Debian)
+- name: install mysql for ansible and python 2 (Debian)
   apt:
     pkg:
     - "{{ mysql }}"
@@ -25,7 +25,7 @@
     - mysql
   when: ansible_os_family == "Debian" and ansible_python.version.major==2
 
-- name: install mysql deps for ansible and python 3 (Debian)
+- name: install mysql for ansible and python 3 (Debian)
   apt:
     pkg:
     - "{{ mysql }}"

--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -14,7 +14,18 @@
     - restart mysql
   when: ansible_os_family == "RedHat"
 
-- name: install mysql (Debian)
+- name: install mysql deps for ansible and python 2 (Debian)
+  apt:
+    pkg:
+    - "{{ mysql }}"
+    - python-mysqldb
+    state: present
+  tags:
+    - packages
+    - mysql
+  when: ansible_os_family == "Debian" and ansible_python.version.major==2
+
+- name: install mysql deps for ansible and python 3 (Debian)
   apt:
     pkg:
     - "{{ mysql }}"
@@ -23,10 +34,7 @@
   tags:
     - packages
     - mysql
-  register: mysql_installed
-  notify: 
-    - restart mysql
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and ansible_python.version.major==3
 
 - name: set mysql variable - sql-mode for mysql-5.7
   mysql_variables:

--- a/ansible/roles/postgresql/tasks/apt.yaml
+++ b/ansible/roles/postgresql/tasks/apt.yaml
@@ -21,9 +21,24 @@
   when: psycopg2_package is defined
   tags: postgresql
 
+- name: Install pip2 when necessary
+  apt:
+    name: python-pip
+  when: ansible_python.version.major==2
+
+- name: Install python3 when necessary
+  apt:
+    name: python3-pip
+  when: ansible_python.version.major==3
+
 - name: pip psycopg2
   command: pip install psycopg2
-  when: psycopg2_package is not defined
+  when: ansible_python.version.major==2
+  tags: postgresql
+
+- name: pip3 psycopg2
+  command: pip3 install psycopg2
+  when: ansible_python.version.major==3
   tags: postgresql
 
 - name: install python-software-properties (Debian)


### PR DESCRIPTION
This PR solve several errors when using python 3 and ansible like:
```
The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required.
```

or 
```
Failed to import the required Python library (psycopg2) on ala-install-test-2's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter
```

https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html