### PR TITLE
Add play names to some playbooks

### DIFF
--- a/ansible/ala-demo-basic.yml
+++ b/ansible/ala-demo-basic.yml
@@ -1,4 +1,5 @@
-- hosts: all
+- name: demo basic
+  hosts: all
   roles:
     - common
     - java

--- a/ansible/newserver.yml
+++ b/ansible/newserver.yml
@@ -1,7 +1,8 @@
 ---
 # Use this playbook once on a new server to install python2 and python3
 # must pass target var e.g. ansible-playbook newserver.yml -i /path/to/inventories/your-inventory-file -u ${USER} --private-key=~/.ssh/id_rsa --extra-vars 'target=bla-bla'
-- hosts: '{{ target }}'
+- name: newserver
+  hosts: '{{ target }}'
   gather_facts: false
   pre_tasks:
   - name: Install python2 and python3 for Ansible

--- a/ansible/spatial.yml
+++ b/ansible/spatial.yml
@@ -1,5 +1,6 @@
--  hosts: all
-   roles:
+- name: spatial
+- hosts: all
+  roles:
     - common
     - java
     - tomcat
@@ -13,4 +14,3 @@
     - spatial-service
     - spatial-hub
     - geonetwork
-


### PR DESCRIPTION
This only adds a name to playbooks that use `all` as host group, so the ansible header logs are not very informative as they use `all` as header. This is useful for ansible logs post-processing.