### PR TITLE
Correct skin.homeUrl instead of skin.homeURL in regions

### DIFF
--- a/ansible/roles/regions/templates/regions-config.properties
+++ b/ansible/roles/regions/templates/regions-config.properties
@@ -36,7 +36,7 @@ biocacheService.baseURL={{ biocache_service_base_url }}
 biocache.records.url={{ biocache_records_url }}
 biocache.search=occurrences/search
 biocache.occurrences.json=ws/occurrences/search.json
-skin.homeURL={{ skin_home_url | default('https://www.ala.org.au') }}
+skin.homeUrl={{ skin_home_url | default('https://www.ala.org.au') }}
 skin.favicon={{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
 allowedHosts={{ spatial_ws_hostname | default('spatial.ala.org.au')  }}
 


### PR DESCRIPTION
Small fix to allow a correct configuration of the home link using `skin.homeUrl` instead of `skin.homeURL` see:
https://github.com/AtlasOfLivingAustralia/ala-bootstrap3/blob/82ebda28f7cd53c81cdfe587894816dc6d2e373d/grails-app/views/layouts/_main.gsp#L80

Compare:
 `grep -r skin.homeUrl ala-install`
 with:
` grep -r skin.homeURL ala-install`  