### PR TITLE
Fix for #481 enabling tls 1.0/1.1 for openjdk-8

### DIFF
--- a/ansible/roles/common/tasks/setfacts.yml
+++ b/ansible/roles/common/tasks/setfacts.yml
@@ -134,6 +134,7 @@
 
 - name: set java defaults for openjdk11
   set_fact:
+    java_security_opts:
     java_home: /usr/lib/jvm/java-11-openjdk-amd64
   when: use_openjdk11 is defined and use_openjdk11 | bool == True
   tags:
@@ -141,6 +142,7 @@
 
 - name: set java defaults for openjdk8
   set_fact:
+    java_security_opts: -Djava.security.properties=/etc/java-8-openjdk/security/enableLegacyTLS.security
     java_home: /usr/lib/jvm/java-8-openjdk-amd64
   when: use_openjdk8 is defined and use_openjdk8 | bool == True
   tags:
@@ -149,6 +151,7 @@
 - name: set java defaults for zulu8
   set_fact:
     java_home: /usr/lib/jvm/zulu-8-amd64/jre
+    java_security_opts:
   when: use_zulu8 is defined and use_zulu8 | bool == True
   tags:
     - setfacts

--- a/ansible/roles/exec-jar/templates/service.conf
+++ b/ansible/roles/exec-jar/templates/service.conf
@@ -1,7 +1,7 @@
 #jinja2:trim_blocks: False
 JAVA_HOME="{{ java_home }}"
 
-JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }} -XX:+UseConcMarkSweepGC{% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %}"
+JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }} -XX:+UseConcMarkSweepGC{% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %} {{java_security_opts}}"
 #JAVA_OPTS="${JAVA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
 
 export LOGGING_CONFIG=/data/{{service_name}}/config/{{log_config_filename | default('logback.groovy') }}

--- a/ansible/roles/java/tasks/openjdk-java-8.yml
+++ b/ansible/roles/java/tasks/openjdk-java-8.yml
@@ -29,3 +29,15 @@
   when: ansible_os_family == "Debian" and use_openjdk8 is defined and use_openjdk8
   tags:
     - java
+
+# Workaround to add legacy TLS
+# https://github.com/AtlasOfLivingAustralia/ala-install/issues/481
+- name: copy enableLegacyTLS.security
+  template:
+    src: enableLegacyTLS.security
+    dest: /etc/java-8-openjdk/security/enableLegacyTLS.security
+    owner: root
+    group: root
+  when: ansible_os_family == "Debian" and use_openjdk8 is defined and use_openjdk8
+  tags:
+    - java

--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -146,7 +146,7 @@
   blockinfile:
     path={{tomcat_conf}}
     marker="# {mark} Configure Tomcat Memory (Ansible managed)"
-    block='JAVA_OPTS="${JAVA_OPTS} {{tomcat_java_opts}}"'
+    block='JAVA_OPTS="${JAVA_OPTS} {{tomcat_java_opts}} {{java_security_opts}}"'
     backup=yes
   notify: 
     - restart tomcat

--- a/ansible/roles/userdetails/vars/main.yml
+++ b/ansible/roles/userdetails/vars/main.yml
@@ -6,4 +6,4 @@ packaging: "jar"
 groupId: "au.org.ala"
 userdetails_jar_url: "{{maven_repo_ws_url}}"
 
-tomcat_java_opts_override: "{{ tomcat_java_opts_override_value | default('-Xmx4g -Xms2g -Xss256k -XX:+UseG1GC') }}"
+tomcat_java_opts_override: "{{ tomcat_java_opts_override_value | default('-Xmx4g -Xms2g -Xss256k -XX:+UseG1GC') }} {{java_security_opts}}"


### PR DESCRIPTION
Fix for #481 following https://aws.amazon.com/blogs/opensource/tls-1-0-1-1-changes-in-openjdk-and-amazon-corretto/ first workaround option.

Maybe we should add this also for openjdk11 but I didn't have the opportunity to test it.