### PR TITLE
Missing enableLegacyTLS.security

### DIFF
--- a/ansible/roles/java/templates/enableLegacyTLS.security
+++ b/ansible/roles/java/templates/enableLegacyTLS.security
@@ -1,0 +1,3 @@
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    include jdk.disabled.namedCurves


### PR DESCRIPTION
Added missing file in https://github.com/AtlasOfLivingAustralia/ala-install/pull/482 and https://github.com/AtlasOfLivingAustralia/ala-install/issues/481  sorry!

The difference:
``` 
< jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
---
> jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \
``` 