### PR TITLE
Limit hosts in spatial and ala-demo playbook to respective groups

### DIFF
--- a/ansible/ala-demo-basic.yml
+++ b/ansible/ala-demo-basic.yml
@@ -1,5 +1,5 @@
 - name: demo basic
-  hosts: all
+  hosts: ala-demo
   roles:
     - common
     - java

--- a/ansible/spatial.yml
+++ b/ansible/spatial.yml
@@ -1,5 +1,5 @@
 - name: spatial
-  hosts: all
+  hosts: spatial
   roles:
     - common
     - java


### PR DESCRIPTION
Currently these two playbooks has `all` as `hosts`  so we have to use `--limit` everytime we use these playbooks. We use the respective host group for each playbook instead of  `all`.

These is useful for generated inventories with multiple hosts, services and groups in their inventories and should not affect to ALA spatial inventories (for instance).