### PR TITLE
Use mysql latin collation in cas first install tasks

### DIFF
--- a/ansible/roles/apikey-add/templates/sql/add-key.sql
+++ b/ansible/roles/apikey-add/templates/sql/add-key.sql
@@ -2,9 +2,9 @@
 INSERT INTO app (name, date_created, user_email, user_id)
     SELECT name, date_created, user_email, user_id
     FROM (SELECT '{{ app }}' as name, NOW() as date_created, '{{ apikey_def_creator_email }}' as user_email, '{{ apikey_def_creator_userid }}' as user_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM app a WHERE a.name = t.name);
+    WHERE NOT EXISTS (SELECT 1 FROM app a WHERE a.name = CONVERT(t.name USING latin1));
 -- Add a new apikey for that app if not exist
 INSERT INTO apikey (apikey, app_id, date_created, user_email, user_id, enabled)
     SELECT apikey, app_id, date_created, user_email, user_id, enabled
     FROM (SELECT '{{ apikey }}' as apikey, '{{ app }}' as app_id, NOW() as date_created, '{{ apikey_def_creator_email }}' as user_email, '{{ apikey_def_creator_userid }}' as user_id, 1 as enabled) t
-    WHERE NOT EXISTS (SELECT 1 FROM apikey a WHERE a.apikey = t.apikey);
+    WHERE NOT EXISTS (SELECT 1 FROM apikey a WHERE a.apikey = CONVERT(t.apikey USING latin1));

--- a/ansible/roles/cas5/templates/sql/admin-add.sql
+++ b/ansible/roles/cas5/templates/sql/admin-add.sql
@@ -60,39 +60,39 @@ INSERT INTO profiles (userid, property, value)
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_ADMIN' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_COLLECTION_ADMIN' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_COLLECTION_EDITOR' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_EDITOR' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_IMAGE_ADMIN' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_SPATIAL_ADMIN' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_SYSTEM_ADMIN' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));
 --
 INSERT INTO user_role (user_id, role_id)
     SELECT user_id, role_id
     FROM (SELECT 1 as user_id, 'ROLE_USER' as role_id) t
-    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = t.role_id);
+    WHERE NOT EXISTS (SELECT 1 FROM user_role u WHERE u.user_id = t.user_id AND u.role_id = CONVERT(t.role_id USING latin1));

--- a/ansible/roles/cas5/templates/sql/role-editor.sql
+++ b/ansible/roles/cas5/templates/sql/role-editor.sql
@@ -3,4 +3,4 @@
 INSERT INTO role (role, description)
     SELECT role, description
     FROM (SELECT 'ROLE_EDITOR' as role, '' as description) t
-    WHERE NOT EXISTS (SELECT 1 FROM role r WHERE r.role = t.role);
+    WHERE NOT EXISTS (SELECT 1 FROM role r WHERE r.role = CONVERT(t.role USING latin1));


### PR DESCRIPTION
Flyway in cas creates tables with a [mix of utf-8](https://github.com/AtlasOfLivingAustralia/ala-cas-5/blob/d35f7549336f96dd425c1fde92fc386ad7fcce8e/src/main/resources/db/migration/V1__init.sql#L200) and [latin collation](https://github.com/AtlasOfLivingAustralia/ala-cas-5/blob/d35f7549336f96dd425c1fde92fc386ad7fcce8e/src/main/resources/db/migration/V1__init.sql#L151).

![2021-09-20-21-40-59-screenshot](https://user-images.githubusercontent.com/180085/119460001-83b17800-bd3e-11eb-9eb6-7bbd601de0d4.png)

I discovered that under some circumstances the creation of the fist admin user tasks or apikeys add tasks in new portals fail with: 

```

TASK [apikey-add : insert apikey in db if does not exists] *************************************************************
failed: [vt-2.l-a.site] (item=add-key.sql) => {"ansible_loop_var": "item", "changed": true, "cmd": "mysql --host=localhost --port=3306 --user=apikey --password=XXXXX apikey < /data/apikey/setup/add-key.sql", "delta": "0:00:00.015889", "end": "2021-05-19 13:41:34.911963", "item": "add-key.sql", "msg": "non-zero return code", "rc": 1, "start": "2021-05-19 13:41:34.896074", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.\nERROR 1267 (HY000) at line 2: Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8_general_ci,COERCIBLE) for operation '='", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure.", "ERROR 1267 (HY000) at line 2: Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8_general_ci,COERCIBLE) for operation '='"], "stdout": "", "stdout_lines": []}
```
This patch fix these errors although in some point we should migrate all these tables to a utf-8.

[More info about the error](https://stackoverflow.com/questions/3029321/troubleshooting-illegal-mix-of-collations-error-in-mysql).