### PR TITLE
Install lxml for python2 or python3 when necessary

### DIFF
--- a/ansible/roles/exec-jar-generic/tasks/main.yml
+++ b/ansible/roles/exec-jar-generic/tasks/main.yml
@@ -8,13 +8,21 @@
   tags:
   - service
 
-- name: Install dependencies
+- name: Install dependencies for ansible python 2
   apt:
-    name:
-      - python3-lxml
+    name: python-lxml
     state: present
+  when: ansible_python.version.major==2
   tags:
-    - service
+  - service
+
+- name: Install dependencies for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+  tags:
+  - service
 
 - name: "Create system user for {{service_name}}"
   user:

--- a/ansible/roles/geoserver/tasks/geoserver.yml
+++ b/ansible/roles/geoserver/tasks/geoserver.yml
@@ -8,9 +8,24 @@
   with_items:
     - curl
     - unzip
-    - python3-lxml
   tags:
     - geoserver
+
+- name: Install dependencies for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+  tags:
+  - geoserver
+
+- name: Install dependencies for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+  tags:
+  - geoserver
 
 - name: configure geoserver data dir
   lineinfile:


### PR DESCRIPTION
This patch install `python-lxml` depending of the python version that ansible is using, preventing errors like:

```
TASK [geoserver : update defaultVectorCacheFormats in gwc-gs.xml for vectortiles extension] ***
Tuesday 25 May 2021  09:55:58 +0200 (0:00:06.383)       0:06:00.711 *********** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named lxml
fatal: [ala-install-test-3]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (lxml) on ala-install-test-3's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```