### PR TITLE
Only download/untar nameindex when needed

### DIFF
--- a/ansible/roles/nameindex/tasks/main.yml
+++ b/ansible/roles/nameindex/tasks/main.yml
@@ -22,13 +22,6 @@
     - "nameindex-stage"
     - "nameindex-swap"
 
-- name: Backup existing
-  command: mv {{ data_dir }}/lucene/namematching {{ data_dir }}/lucene/namematching-{{ ansible_date_time.epoch}}
-  when: existing_name_dir_status.stat.exists == True
-  tags:
-    - "nameindex"
-    - "nameindex-swap"
-
 - name: set name index to use (COL)
   set_fact:
     lucene_namematching_url: "{{ col_namematching_url }}"
@@ -87,13 +80,29 @@
 - name: Download lucene index (ALA) - please note, this step takes a long time. If it causes an issue, use '--skip-tags nameindex' to bypass it
   get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene force={{ force_nameindex_download | default(false) }} timeout=10000
   when: nameindex_variant == "ala"
+  register: nameindex_downloaded
   tags:
     - "nameindex"
     - "nameindex-stage"
 
+- name: Download lucene index (non-ALA) - please note, this step takes a long time. If it causes an issue, use '--skip-tags nameindex' to bypass it, to complete an installation
+  get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene/namematching.tgz force={{ force_nameindex_download | default(false) }} timeout=10000
+  when: nameindex_variant != "ala"
+  register: nameindex_downloaded
+  tags:
+    - "nameindex"
+    - "nameindex-stage"
+
+- name: Backup existing
+  command: mv {{ data_dir }}/lucene/namematching {{ data_dir }}/lucene/namematching-{{ ansible_date_time.epoch}}
+  when: existing_name_dir_status.stat.exists == True and nameindex_downloaded.changed
+  tags:
+    - "nameindex"
+    - "nameindex-swap"
+
 - name: unpackage the lucene index if it was newly copied (ALA)
   unarchive: src={{ data_dir }}/lucene/namematching-{{ name_index_date }}.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
-  when: nameindex_variant == "ala"
+  when: nameindex_variant == "ala" and nameindex_downloaded.changed
   tags:
     - "nameindex"
     - "nameindex-stage"
@@ -122,16 +131,9 @@
     - "nameindex"
     - "nameindex-swap"
 
-- name: Download lucene index (non-ALA) - please note, this step takes a long time. If it causes an issue, use '--skip-tags nameindex' to bypass it, to complete an installation
-  get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene/namematching.tgz force={{ force_nameindex_download | default(false) }} timeout=10000
-  when: nameindex_variant != "ala"
-  tags:
-    - "nameindex"
-    - "nameindex-stage"
-
 - name: unpackage the lucene index if it was newly copied (not ALA)
   unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
-  when: nameindex_variant != "ala"
+  when: nameindex_variant != "ala" and nameindex_downloaded.changed
   tags:
     - "nameindex"
     - "nameindex-swap"


### PR DESCRIPTION
Probably the `nameindex` download tasks with the solr create cores task are the more annoying tasks in `ala-install` IMHO. The `nameindex` task because we have to skip it in order to not fill our disks with copies of the same downloaded nameindex on each playbook execution.

I patched this task to only backup an unarchive if the `nameindex` was downloaded.

Thanks to @cpfaff for the feedback.

In my tests only the task was needed in the last server, so in the first two ones the tasks are not executed:

![image](https://user-images.githubusercontent.com/180085/120794979-2f29ac00-c539-11eb-9cb2-c5e99ca79c5a.png)
