### PR TITLE
Fix unarchiver perms error extracting sds layers

### DIFF
--- a/ansible/roles/biocache-properties/tasks/main.yml
+++ b/ansible/roles/biocache-properties/tasks/main.yml
@@ -30,7 +30,7 @@
     - biocache-layers   
 
 - name: Extract SDS layers
-  unarchive: src="{{data_dir}}/biocache/layers/sds-layers.tgz" dest="{{data_dir}}/biocache/layers/" copy=no
+  unarchive: src="{{data_dir}}/biocache/layers/sds-layers.tgz" dest="{{data_dir}}/biocache/layers/" copy=no owner=root group=root
   when: sds_enabled is defined and sds_enabled == "true"
   tags:
     - properties


### PR DESCRIPTION
Under some circumstances (`lxc` containers) when enabling sds the biocache service unarchive task of the sds layers fails with:
```
fatal: [ala-install-test-1]: FAILED! => {"changed": false, "dest": "/data/biocache/layers/", "extract_results": {"cmd": ["/bin/tar", "--extract", "-C", "/data/biocache/layers/", "-z", "--owner=tomcat8", "--group=tomcat8", "-f", "/data/biocache/layers/sds-layers.tgz"], "err": "/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus1.dbf: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus1.shp: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'LIBARCHIVE.creationtime'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus1.shx: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus2.dbf: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'LIBARCHIVE.creationtime'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus2.shp: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: aus2.shx: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'LIBARCHIVE.creationtime'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: cw_state_poly.dbf: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: cw_state_poly.prj: Cannot change ownership to uid 1847169192, gid 0: Invalid argument\n/bin/tar: Ignoring unknown extended header keyword 'LIBARCHIVE.creationtime'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.dev'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.ino'\n/bin/tar: Ignoring unknown extended header keyword 'SCHILY.nlink'\n/bin/tar: cw_state_poly.shp: Cannot change ownership to uid 1847169192, gid 0:
```

This patch `unarchive` the `tgz` as root to prevent this issue, as currently tries to do it with the user that created the tar.

PS: Thanks to @cpfaff for the feedback.