### PR TITLE
Mysql root password configured correctly. Fix for #495

### DIFF
--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -31,6 +31,7 @@
     - "{{ mysql }}"
     - python3-mysqldb
     state: present
+  register: mysql_installed
   tags:
     - packages
     - mysql


### PR DESCRIPTION
Fix for #495. After that, mysql root password is configured correctly:
```
TASK [mysql : warn about using the default root user password] *****************
Thursday 01 July 2021  16:15:42 +0200 (0:00:00.082)       0:01:37.818 ********* 
skipping: [ala-install-test-1]

TASK [mysql : change root user password on first run] **************************
Thursday 01 July 2021  16:15:43 +0200 (0:00:00.083)       0:01:37.902 ********* 
changed: [ala-install-test-1] => (item=ala-install-test-1)
changed: [ala-install-test-1] => (item=127.0.0.1)
changed: [ala-install-test-1] => (item=::1)
changed: [ala-install-test-1] => (item=localhost)

TASK [mysql : delete anonymous MySQL user for the host] ************************
Thursday 01 July 2021  16:15:45 +0200 (0:00:02.371)       0:01:40.273 ********* 
ok: [ala-install-test-1]

TASK [mysql : delete anyonmous MySQL user for localhost] ***********************
Thursday 01 July 2021  16:15:46 +0200 (0:00:00.550)       0:01:40.823 ********* 
ok: [ala-install-test-1]

TASK [mysql : drop test database] **********************************************
Thursday 01 July 2021  16:15:46 +0200 (0:00:00.546)       0:01:41.370 ********* 
[WARNING]: Module did not set no_log for unsafe_login_password
ok: [ala-install-test-1]

TASK [mysql : create my.cnf file] **********************************************
Thursday 01 July 2021  16:15:47 +0200 (0:00:00.858)       0:01:42.229 ********* 
changed: [ala-install-test-1]
```