### PR TITLE
Basic branding role

### DIFF
--- a/ansible/branding.yml
+++ b/ansible/branding.yml
@@ -1,0 +1,6 @@
+- name: branding
+  hosts: branding
+  roles:
+    - common
+    - webserver
+    - branding

--- a/ansible/roles/branding/tasks/main.yml
+++ b/ansible/roles/branding/tasks/main.yml
@@ -1,0 +1,28 @@
+- include: ../../common/tasks/setfacts.yml
+  tags:
+    - branding
+
+- name: Ensure data directory exists
+  file: path=/srv/{{ branding_url }}/www/{{ item }} state=directory owner={{ansible_user}} group={{ansible_user}}
+  with_items:
+    - "{{ branding_path }}"
+  tags:
+    - branding
+
+- name: add nginx vhost if configured
+  include_role:
+    name: nginx_vhost
+  vars:
+    appname: "branding"
+    hostname: "{{ branding_hostname }}"
+    context_path: "/"
+    nginx_paths:
+      - path: "/"
+        sort_label: "1"
+        is_proxy: false
+        alias: "/srv/{{ branding_url }}/www/"
+  tags:
+    - nginx_vhost
+    - deploy
+    - branding
+  when: webserver_nginx


### PR DESCRIPTION
This is a simplified version of the `ala-demo` role to just setup a vhost to deploy later a LA branding.

It's safe to merge it.
