### PR TITLE
Added optional artifact variables for hubs

### DIFF
--- a/ansible/roles/bie-hub/vars/main.yml
+++ b/ansible/roles/bie-hub/vars/main.yml
@@ -1,5 +1,5 @@
 version: "{{ bie_hub_version | default('LATEST') }}"
-artifactId: "{{ bie_hub | default('generic-bie') }}"
+artifactId: "{{ (bie_hub_artifact | default(bie_hub)) | default('generic-bie') }}"
 groupId: "{{ bie_hub_group_id | default('au.org.ala') }}"
 classifier: ''
 packaging: "war"

--- a/ansible/roles/biocache-hub/vars/main.yml
+++ b/ansible/roles/biocache-hub/vars/main.yml
@@ -8,7 +8,7 @@ biocache_service: biocache-service
 # assets
 
 version: "{{ biocache_hub_version | default('LATEST') }}"
-artifactId: "{{ biocache_hub | default('generic-hub') }}"
+artifactId: "{{ (biocache_hub_artifact | default(biocache_hub)) | default('generic-hub') }}"
 groupId: "{{ biocache_hub_group_id | default('au.org.ala') }}"
 classifier: "{{ biocache_hub_classifier | default('') }}"
 packaging: "{{ biocache_hub_packaging | default('war') }}"

--- a/ansible/roles/regions/vars/main.yml
+++ b/ansible/roles/regions/vars/main.yml
@@ -3,7 +3,7 @@ regions_config: "{{regions}}-config.properties"
 
 # assets
 version: "{{ regions_version | default('LATEST') }}"
-artifactId: "{{ regions | default('regions')}}"
+artifactId: "{{ (regions_artifact | default(regions)) | default('regions')}}"
 classifier: ''
 packaging: "war"
 groupId: "{{ regions_group_id | default('au.org.ala') }}"


### PR DESCRIPTION
This PR just add some new optional artifact variables backwards compatible with old inventories.

These is used to deploy LA hubs but using the plain ala hub wars. For instance: 
```
biocache_hub = my-new-hub
biocache_hub_artifact = ala-hub
(...)
biocache_hub = my-other-hub
biocache_hub_artifact = ala-hub
```

will deploy `ala-hub.war` from nexus and setup the configuration of the hubs in `/data/my-new-hub` and `/data/my-other-hub`. So other LA portals can deploy several hubs easy (even in a shared server) without the need of building custom wars and using the typical `ala-install` playbooks (also without the need of creating playbooks for each hub).

This will used by a new functionality of the LA-Toolkit to deploy hubs:

![image](https://user-images.githubusercontent.com/180085/131959470-19feb5c4-9d14-4450-ab20-732ae3db2c25.png)

