### PR TITLE
Correct branding vhost configuration when using /path/ for the branding

### DIFF
--- a/ansible/roles/branding/tasks/main.yml
+++ b/ansible/roles/branding/tasks/main.yml
@@ -14,10 +14,10 @@
     name: nginx_vhost
   vars:
     appname: "branding"
-    hostname: "{{ branding_hostname }}"
+    hostname: "{{ branding_url }}"
     context_path: "/"
     nginx_paths:
-      - path: "/"
+      - path: "{{ branding_path }}"
         sort_label: "1"
         is_proxy: false
         alias: "/srv/{{ branding_url }}/www/"


### PR DESCRIPTION
Following [this slack conversation](https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1634651094073400?thread_ts=1634040000.048200&cd=CCTFGEU1G) . Thanks to Johannes Eberenz for the report.