### PR TITLE
Add biocache_service_url to biocache config in image-service-config.yml

### DIFF
--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -65,8 +65,6 @@ biocache:
   baseURL: "{{ biocache_url | default('https://biocache.ala.org.au')}}"
   service:
     baseURL: "{{ biocache_service_url | default('https://biocache.ala.org.au/ws')}}"
-    searchPath: /occurrences/search
-  imagesFieldName: all_image_url
   
 # header block
 headerAndFooter:


### PR DESCRIPTION
In an la-toolkit install of the latest image-service (1.1.5.1), using a subdomain for biocache-service (biocache-ws.living-atlas.org) causes errors in image-service.

With this PR, biocache.service.baseURL can be configured with install variable 'biocache_service_url', or left as the default as indicated here: (https://github.com/AtlasOfLivingAustralia/image-service/blob/b1481e3b18e63147f7979f3a9cfcee080e96a3e8/grails-app/conf/application.yml#L336).

Tested the install and the deployment in live system. @vjrj reviewed PR in fork.