### PR TITLE
pipelines roles refactor

### DIFF
--- a/ansible/pipelines.yml
+++ b/ansible/pipelines.yml
@@ -1,27 +1,29 @@
-- hosts: all
-  roles:
-    - java
-
-- hosts: all
-  roles:
-    - i18n
-
 - hosts: hadoop
   roles:
+    - java
+    - i18n
     - hadoop
 
 - hosts: spark
   roles:
+    - java
+    - i18n
     - spark
 
 - hosts: jenkins
   roles:
+    - java
+    - i18n
     - jenkins-simple
 
 - hosts: pipelines
   roles:
+    - java
+    - i18n
     - pipelines
 
 - hosts: pipelines_jenkins
   roles:
+    - java
+    - i18n
     - pipelines_jenkins


### PR DESCRIPTION
I reordered a bit this playbook to prevent that the `java` and `i18n` roles are executed over other non-pipelines hosts (and hosts that do not need `java`). Useful when using a general inventory including all the servers of a LA portal. 