### PR TITLE
Add some extra spark vars for ini inventories

### DIFF
--- a/ansible/roles/spark/templates/spark-defaults-conf.j2
+++ b/ansible/roles/spark/templates/spark-defaults-conf.j2
@@ -1,3 +1,6 @@
 {% for key, value in spark.defaults_extras.items() | sort %}
 {{ key }} {{ value }}
 {% endfor %}
+{% for key, value in spark_defaults_extras.items() | sort %}
+{{ key }} {{ value }}
+{% endfor %}

--- a/ansible/roles/spark/templates/spark-env-sh.j2
+++ b/ansible/roles/spark/templates/spark-env-sh.j2
@@ -16,3 +16,6 @@ export SPARK_DIST_CLASSPATH=$(/data/hadoop/bin/hadoop classpath)
 {% for key, value in spark.env_extras.items() | sort %}
 export {{ key }}="{{ value }}"
 {% endfor %}
+{% for key, value in spark_env_extras.items() | sort %}
+export {{ key }}="{{ value }}"
+{% endfor %}


### PR DESCRIPTION
We are using a unique `ini` inventory for all services even for pipelines, but ALA uses `yaml` inventories for their pipelines clusters. 

As the pipelines roles are referencing that variables in a `yaml.hierarchy.format` our `ini` inventories needs to use some [dictionary](https://github.com/living-atlases/generator-living-atlas/blob/d82c14e37926a6141f4d5482d82bc3ba48f82c99/generators/app/templates/quick-start-inventory.ini#L1158) as a workaround to access to our ini `spark_` and `hadoop_` equivalent variables.

This work for all the variables except for `spark.defaults_extras` and `spark.env_vars`. So I added some extra loop in the templates to use our equivalent `spark_defaults_extras` and `spark:env_vars`.