### PR TITLE
Some partial work for prevent the chown recursive issues described #505

### DIFF
--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -44,7 +44,6 @@
   file: path={{ item }} state=directory owner={{ spark_user }} group={{ spark_user }} recurse=true
   with_items:
     - "{{ data_dir }}/la-pipelines/config"
-    - "{{ data_dir }}/docker"
     - "{{ data_dir }}/spark-tmp"
     - "{{ data_dir }}/pipelines-shp"
     - "{{ data_dir }}/dwca-tmp"


### PR DESCRIPTION
While we choose another solution as described in #505, I remove the chown over `/data/docker`.