### PR TITLE
Re-added yq and docopt with some conditional variable

### DIFF
--- a/ansible/roles/pipelines/defaults/main.yml
+++ b/ansible/roles/pipelines/defaults/main.yml
@@ -1,0 +1,3 @@
+# yq_version: 4.13.0
+# or asterisk for 'latest':
+yq_version: "*"

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -103,7 +103,7 @@
     - yq
 
 - name: Update apt and install pipelines
-  apt: update_cache=yes name=yq
+  apt: update_cache=yes name=yq={{ yq_version }}
   when: use_yq_via_ppa is defined and use_yq_via_ppa | bool == True
   tags:
     - pipelines


### PR DESCRIPTION
I re-added `yq` and `docopts` to the pipelines role with a conditional variable to choose between snap or ubuntu ppa version.

In September I contacted with the ppa maintainer in order to update the yq binary to 4.13.0.

![image](https://user-images.githubusercontent.com/180085/138149371-bd99dbdc-f1e8-488b-b80b-da56e3560b7f.png)
 
I also added the `yq_version` to use to some specific version in the ppa instead of the last one that may affect our workflow with new issues:
https://launchpad.net/~rmescandon/+archive/ubuntu/yq
default to latest. Nowadays the ppa only has available a yq version per ubuntu release.

Maybe an option to control more this `yq` releases is to package ourselves `yq` and to store several versions for stability.