### PR TITLE
Fix apt jenkins repo and deprecated apt install

### DIFF
--- a/ansible/roles/jenkins-simple/tasks/main.yml
+++ b/ansible/roles/jenkins-simple/tasks/main.yml
@@ -1,24 +1,19 @@
 - include: ../../common/tasks/setfacts.yml
 
-- apt_key: url="https://pkg.jenkins-ci.org/{{ jenkins_channel }}/jenkins-ci.org.key" state=present
-  when: ansible_os_family == "Debian"
-  tags: jenkins
-
 - apt_key: url="https://pkg.jenkins.io//{{ jenkins_channel }}/jenkins.io.key" state=present id=FCEF32E745F2C3D5
   when: ansible_os_family == "Debian"
   tags: jenkins
 
-- apt_repository: repo="deb https ://pkg.jenkins-ci.org/{{ jenkins_channel }} binary/" state=present update-cache=yes
+- apt_repository: repo="deb https://pkg.jenkins.io/{{ jenkins_channel }} binary/" state=present update-cache=yes
   when: ansible_os_family == "Debian"
   tags: jenkins
 
-- name: install packages
-  apt: name=jenkins state=present
-  when: ansible_os_family == "Debian"
-  tags: jenkins
-
-- name: install packages 2
-  apt: name=git state=present
+- name: install packages and deps
+  apt:
+    name: ['jenkins', 'git']
+    state: present
+    autoclean: yes
+    update_cache: yes
   when: ansible_os_family == "Debian"
   tags: jenkins
 


### PR DESCRIPTION
Fix for wrong apt repository for jenkins. Using:
https://pkg.jenkins.io/debian/

The error was:

![2021-11-25-11-10-38-screenshot](https://user-images.githubusercontent.com/180085/138675244-cdb236ea-d188-4e11-8eba-d30f69dc8931.png)

I also removed a warning about a deprecated apt use.


