### PR TITLE
Fix for ssh key upload error in pipelines jenkins role

### DIFF
--- a/ansible/roles/pipelines_jenkins/tasks/main.yml
+++ b/ansible/roles/pipelines_jenkins/tasks/main.yml
@@ -67,7 +67,7 @@
     state: directory
     owner: "jenkins"
     group: "jenkins"
-    mode: 0600
+    mode: 0700
   become: yes
   become_user: "jenkins"
   when: is_master
@@ -89,13 +89,13 @@
     - pipelines_jenkins
     - pipelines_jenkins_slaves
 
-- name: Upload SSH Key for slave
-  copy:
-    src: "{{ ssh_key_filename }}"
-    dest: "/home/jenkins/.ssh/id_rsa"
+- name: Upload SSH Public Key for Jenkins user - mkdir
+  file:
+    path: /home/jenkins/.ssh/
+    state: directory
     owner: "jenkins"
     group: "jenkins"
-    mode: 0600
+    mode: 0700
   become: yes
   become_user: "jenkins"
   when: is_slave
@@ -103,10 +103,10 @@
     - pipelines_jenkins
     - pipelines_jenkins_slaves
 
-- name: Upload SSH Public Key for Jenkins user - mkdir
-  file:
-    path: /home/jenkins/.ssh/
-    state: directory
+- name: Upload SSH Key for slave
+  copy:
+    src: "{{ ssh_key_filename }}"
+    dest: "/home/jenkins/.ssh/id_rsa"
     owner: "jenkins"
     group: "jenkins"
     mode: 0600


### PR DESCRIPTION
There was a small issue with the directory permissions of '.ssh' that make some task fails:
![2021-06-31-18-00-31-screenshot](https://user-images.githubusercontent.com/180085/139634865-030b7871-dc3b-48d9-978f-fe7e329dd171.png)
Also I reorder to mkdir `.ssh` before to add the key in slaves.
