### PR TITLE
Correct simplification of pipelines playbook

### DIFF
--- a/ansible/pipelines.yml
+++ b/ansible/pipelines.yml
@@ -1,29 +1,24 @@
-- hosts: hadoop
+- hosts: hadoop, spark, pipelines, jenkins, pipelines_jenkins
   roles:
     - java
     - i18n
+
+- hosts: hadoop
+  roles:
     - hadoop
 
 - hosts: spark
   roles:
-    - java
-    - i18n
     - spark
 
 - hosts: jenkins
   roles:
-    - java
-    - i18n
     - jenkins-simple
 
 - hosts: pipelines
   roles:
-    - java
-    - i18n
     - pipelines
 
 - hosts: pipelines_jenkins
   roles:
-    - java
-    - i18n
     - pipelines_jenkins


### PR DESCRIPTION
My last changes in the pipelines playbook #503 exec `i18n` and `java` roles more than once. This simplifies again but using host groups instead of `all`.