### PR TITLE
Optional use of docker in pipelines vs direct deb packages

### DIFF
--- a/ansible/pipelines.yml
+++ b/ansible/pipelines.yml
@@ -1,7 +1,7 @@
 - hosts: hadoop, spark, pipelines, jenkins, pipelines_jenkins
   roles:
     - java
-    - i18n
+    - la-apt
 
 - hosts: hadoop
   roles:

--- a/ansible/roles/i18n/tasks/main.yml
+++ b/ansible/roles/i18n/tasks/main.yml
@@ -1,38 +1,11 @@
-- name: Add apt.gbif.es key
-  get_url:
-    # We use this key from the above repo temporally
-    url: 'https://keyserver.ubuntu.com/pks/lookup?op=hget&search=7524d3b383016eab0ee47bfe253a51f7'
-    dest: /etc/apt/trusted.gpg.d/apt-gbif-es-demo.asc
-    mode: 0644
+- name: Add apt.gbif.es key and repo
+  include_role: name=la-apt
   when:
     - ansible_os_family == "Debian"
     - i18n_package_enabled | bool == True
   tags:
     - packages
     - i18n
-
-- name: Install ala-i18n apt repository
-  apt_repository:
-    # We use this repo temporally
-    repo: deb [arch=amd64] https://apt.gbif.es/ bionic main
-    filename: apt_gbif_es
-    state: present
-  when:
-    - ansible_os_family == "Debian"
-    - i18n_package_enabled | bool == True
-  tags:
-    - packages
-    - i18n
-
-- name: Uninstall demo.gbif.es apt repository
-  apt_repository:
-    repo: deb [arch=amd64] https://demo.gbif.es/repo bionic main
-    filename: demo_gbif_es_repo
-    state: absent
-  tags:
-    - packages
-    - i18n
-  when: ansible_os_family == "Debian"
 
 - name: Install ala-i18n package
   apt:

--- a/ansible/roles/la-apt/tasks/main.yml
+++ b/ansible/roles/la-apt/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Add apt.gbif.es key
+  get_url:
+    # We use this key from the above repo temporally
+    url: 'https://keyserver.ubuntu.com/pks/lookup?op=hget&search=7524d3b383016eab0ee47bfe253a51f7'
+    dest: /etc/apt/trusted.gpg.d/apt-gbif-es-demo.asc
+    mode: 0644
+  when:
+    - ansible_os_family == "Debian"
+  tags:
+    - packages
+
+- name: Install gbif.es apt repository
+  apt_repository:
+    # We use this repo temporally
+    repo: deb [arch=amd64] https://apt.gbif.es/ bionic main
+    filename: apt_gbif_es
+    state: present
+  when:
+    - ansible_os_family == "Debian"
+  tags:
+    - packages

--- a/ansible/roles/pipelines/defaults/main.yml
+++ b/ansible/roles/pipelines/defaults/main.yml
@@ -4,3 +4,9 @@ yq_version: "*"
 
 # version can be for instance: "2.5.5-SNAPSHOT+0~20200811164905.80~1.gbp9acadb" or "*" for 'latest'
 pipelines_version: "*"
+
+use_docker_with_pipelines: True
+
+ala_namematching_service_version: "*"
+
+ala_sensitive_data_service_version: "*"

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -19,6 +19,7 @@
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
 
@@ -26,6 +27,7 @@
   apt_repository:
     repo: deb https://download.docker.com/linux/ubuntu bionic stable
     state: present
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
 
@@ -36,6 +38,7 @@
     - docker-ce-cli
     - docker-compose
     - containerd.io
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -57,6 +60,7 @@
   template: src={{ item }} dest=/etc/docker/daemon.json
   with_items:
     - daemon.json
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -65,6 +69,7 @@
   service:
     name: docker
     state: restarted
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -134,22 +139,6 @@
     - pipelines
     - docopts
 
-- name: Add an apt key by id from a keyserver
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: F697D8D2ADB9E24A
-  tags:
-    - la-pipelines
-    - pipelines
-
-- name: Add GBIF ES Repository
-  apt_repository:
-    repo: deb https://apt.gbif.es/ bionic main
-    state: present
-  tags:
-    - la-pipelines
-    - pipelines
-
 - name: Update apt and install pipelines
   apt: update_cache=yes name=la-pipelines={{ pipelines_version }}
   tags:
@@ -182,6 +171,7 @@
   with_items:
     - ala-name-service.sh
     - ala-sensitive-data-service.sh
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -191,6 +181,7 @@
   with_items:
     - ala-name-service.service
     - ala-sensitive-data-service.service
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -200,11 +191,13 @@
   with_items:
     - ala-name-service
     - ala-sensitive-data-service
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
 
 - name: Start service ala-sensitive-data-service, if not running
   service:
     name: ala-sensitive-data-service
     state: started
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
@@ -213,9 +206,101 @@
   service:
     name: ala-name-service
     state: started
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == True
   tags:
     - pipelines
     - docker
+
+- name: Setup namematching package
+  ansible.builtin.debconf:
+    name: ala-namematching-service
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: string
+  with_items:
+  - {
+    question: "ala-namematching-service/source",
+    value: "{{ ala_namemaching_service_source | default('https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz') }}"
+    }
+  - {
+    question: "ala-namematching-service/sha1",
+    value: "{{ ala_namemaching_service_source_sha1 | default('563814a7b5d886b746e10eb40c44f0d9bda62371') }}"
+    }
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
+    - la-pipelines
+    - apt
+
+- name: Setup sensitive-data-service package
+  ansible.builtin.debconf:
+    name: ala-sensitive-data-service
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: string
+  with_items:
+  - {
+    question: "ala-sensitive-data-service/sds-url",
+    value: "{{ sds_url | default('https://sds.ala.org.au') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/spatial-url",
+    value: "{{ spatial_url | default('https://spatial.ala.org.au') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/layers-url",
+    value: "{{ sds_layers_url | default('https://archives.ala.org.au/archives/layers/sds-layers.tgz') }}"
+    }
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
+    - la-pipelines
+    - apt
+
+- name: Install ala-namematching-service an ala-sensitive-data-service directly if not using docker
+  apt:
+    name:
+      - ala-namematching-service={{ ala_namematching_service_version }}
+      - ala-sensitive-data-service={{ ala_sensitive_data_service_version }}
+    state: present
+    autoclean: yes
+    update_cache: yes
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
+    - la-pipelines
+    - apt
+
+# See:
+# https://github.com/ansible/ansible/issues/29352
+# https://github.com/ansible/ansible/pull/39794
+# https://github.com/ansible/ansible/pull/74196
+- name: dpkg-reconfigure to get rid of configuration changes
+  shell: "dpkg-reconfigure -f noninteractive {{ item }}"
+  with_items:
+    - ala-namematching-service
+    - ala-sensitive-data-service
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
+    - la-pipelines
+    - apt
+
+- name: Start service ala-namematching-service installed via apt, if not running
+  service:
+    name: ala-namematching-service
+    state: started
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
+
+- name: Start service ala-sensitive-data-service installed via apt, if not running
+  service:
+    name: ala-sensitive-data-service
+    state: started
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - pipelines
 
 - name: Create HDFS base directories
   shell: "{{ hadoop_install_dir }}/bin/hdfs dfs -mkdir -p {{ item }}"


### PR DESCRIPTION
This PR:
- adds `use_docker_with_pipelines` to optionally use docker with `pipelines`.
- creates a `la-apt` role to configure apt.gbif.es repository and include it in `pipelines` and `i18n` roles.
- when using the deb packages, adds new variables to setup them (for instance to use the gbif nameindex backbone).

It should not affect current ALA deployments as `use_docker_with_pipelines` is `true` by default.