### PR TITLE
Set default value for collectory auth_cookie_name

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -16,7 +16,8 @@ security.cas.loginUrl={{ auth_base_url }}/cas/login
 security.cas.logoutUrl={{ auth_base_url }}/cas/logout
 
 security.cas.contextPath={{ collectory_context_path }}
-security.cas.authCookieName={{ auth_cookie_name }}
+security.cas.authCookieName={{ auth_cookie_name | default('ALA-Auth') }}
+
 
 security.apikey.serviceUrl={{ apikey_service_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=')}}
 security.apikey.checkEnabled={{ api_key_check_enabled | default('false') }}


### PR DESCRIPTION
Similar to other service, just adding some default value as https://github.com/AtlasOfLivingAustralia/ala-install/commit/27d62060935538f77b887ec4e1242ec0402566de fails on new deployments if this var is not defined:

![image](https://user-images.githubusercontent.com/180085/143274132-f6bd55b0-4da7-4ab2-afb9-ae2c4b624aeb.png)
