### PR TITLE
Add custom namedata variables and tasks to use with GBIF Taxonomy and similars

### DIFF
--- a/ansible/roles/namedata/tasks/main.yml
+++ b/ansible/roles/namedata/tasks/main.yml
@@ -31,3 +31,28 @@
   tags:
     - config
     - namedata
+
+- name: ensure target directories exist [data subdirectories etc.]
+  when: namedata_variant == "custom"
+  file: path={{ data_dir }}/bie/import/{{item.name}}-{{item.datestamp}} state=directory owner={{tomcat_user}} group={{tomcat_user}}
+  with_items: "{{custom_name_sources}}"
+  tags:
+    - config
+    - namedata
+
+# https://stackoverflow.com/questions/68163812/ansible-get-url-download-file-only-if-changed
+- name: get custom source name data
+  when: namedata_variant == "custom"
+  get_url: url={{custom_namedata_repo}}/{{item.name}}-{{item.datestamp}}.zip dest={{data_dir}}/bie/import/{{item.name}}-{{item.datestamp}}.zip checksum={{item.checksum}}
+  with_items: "{{custom_name_sources}}"
+  tags:
+    - config
+    - namedata
+
+- name: unpackage custom source name data
+  when: namedata_variant == "custom"
+  unarchive: src={{data_dir}}/bie/import/{{item.name}}-{{item.datestamp}}.zip dest={{data_dir}}/bie/import/{{item.name}}-{{item.datestamp}} owner={{tomcat_user}} group={{tomcat_user}} copy=no
+  with_items: "{{custom_name_sources}}"
+  tags:
+    - config
+    - namedata


### PR DESCRIPTION
I added some extra variables and tasks in `namedata` so we can use alternative namedatas in bie-index instead of the ALA combined default one. This was something we do manually until now. The `get_url` task also prevent to download the source if it was downloaded previously. Sample of usage:
 
```
namedata_to_use = custom
custom_namedata_repo = https://datos.gbif.es/namedata
custom_name_sources = "[ { 'name': 'gbif-backbone', 'checksum': 'sha256:6b753ff062337321df62377410bb728f90ae9e3e4e10f872639d1d6234b52ea5', 'datestamp': '2021-09-14' } ]"
``` 