### PR TITLE
Prevent to use pymongo 4 for now. Fix for #525

### DIFF
--- a/ansible/roles/mongodb-org/tasks/main.yml
+++ b/ansible/roles/mongodb-org/tasks/main.yml
@@ -92,7 +92,7 @@
 
 - name: Install pip python-pymongo package
   pip:
-    name: pymongo
+    name: pymongo==3.12.2
   tags: mongodb-org
 
 - name: Enable service mongod


### PR DESCRIPTION
This fix #525.

![image](https://user-images.githubusercontent.com/180085/144421620-421be3df-3eea-4615-adfc-280f0c1fb4c0.png)
