### PR TITLE
data-quality postgresql version selectable

### DIFF
--- a/ansible/data_quality_filter_service.yml
+++ b/ansible/data_quality_filter_service.yml
@@ -3,7 +3,7 @@
     - common
     - java
     - {role: db-backup, db: postgres, db_name: "{{ dq_db_name }}", db_user: "{{ dq_db_user }}", db_password: "{{ dq_db_password }}" }
-    - {role: postgresql, pg_version: "13"}
+    - {role: postgresql, pg_version: "{{ data_quality_pg_version | default('13') }}"}
     - {role: pg_instance, extensions: [], db_name: "{{ dq_db_name }}", db_user: "{{ dq_db_user }}", db_password: "{{ dq_db_password }}" }
     - tomcat
     - webserver


### PR DESCRIPTION
I added an extra variable to allow to select a different `postgresql` version than the default one (13).  I tested it using pg 10 and it seems that works.

This allows us to use this service in other VMs with other services that are using pg 10 right now like the image-service.

Do you see any problem in using pg < 13 with the `data_quality_filter_service`?
