### PR TITLE
Trying to mitigate CVE-2021-44228

### DIFF
--- a/ansible/roles/ansible-elasticsearch/templates/jvm.options.j2
+++ b/ansible/roles/ansible-elasticsearch/templates/jvm.options.j2
@@ -132,6 +132,9 @@
 # specify an alternative path for JVM fatal error logs
 -XX:ErrorFile={{ es_log_dir }}/hs_err_pid%p.log
 
+# CVE-2021-44228 mitigation
+-Dlog4j2.formatMsgNoLookups=true
+
 ## JDK 8 GC logging
 
 8:-XX:+PrintGCDetails

--- a/ansible/roles/common/tasks/setfacts.yml
+++ b/ansible/roles/common/tasks/setfacts.yml
@@ -134,7 +134,7 @@
 
 - name: set java defaults for openjdk11
   set_fact:
-    java_security_opts:
+    java_security_opts: -Dlog4j2.formatMsgNoLookups=true
     java_home: /usr/lib/jvm/java-11-openjdk-amd64
   when: use_openjdk11 is defined and use_openjdk11 | bool == True
   tags:
@@ -142,7 +142,7 @@
 
 - name: set java defaults for openjdk8
   set_fact:
-    java_security_opts: -Djava.security.properties=/etc/java-8-openjdk/security/enableLegacyTLS.security
+    java_security_opts: -Djava.security.properties=/etc/java-8-openjdk/security/enableLegacyTLS.security -Dlog4j2.formatMsgNoLookups=true
     java_home: /usr/lib/jvm/java-8-openjdk-amd64
   when: use_openjdk8 is defined and use_openjdk8 | bool == True
   tags:

--- a/ansible/roles/solr6/templates/solr.in.sh
+++ b/ansible/roles/solr6/templates/solr.in.sh
@@ -60,6 +60,9 @@ SOLR_HOST="{{ solr_host }}"
 # By default the start script uses UTC; override the timezone if needed
 #SOLR_TIMEZONE="UTC"
 
+# CVE-2021-44228 mitigation
+SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"
+
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)

--- a/ansible/roles/solr7/templates/solr.in.sh
+++ b/ansible/roles/solr7/templates/solr.in.sh
@@ -60,6 +60,9 @@ SOLR_HOST="{{ solr_host }}"
 # By default the start script uses UTC; override the timezone if needed
 #SOLR_TIMEZONE="UTC"
 
+# CVE-2021-44228 mitigation
+SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"
+
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)

--- a/ansible/roles/solrcloud/templates/solr.in.sh
+++ b/ansible/roles/solrcloud/templates/solr.in.sh
@@ -57,6 +57,9 @@ SOLR_HOST="{{ solr_host }}"
 # By default the start script uses UTC; override the timezone if needed
 #SOLR_TIMEZONE="UTC"
 
+# CVE-2021-44228 mitigation
+SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"
+
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)


### PR DESCRIPTION
Following: https://www.lunasec.io/docs/blog/log4j-zero-day/ 
although I'm not sure if the versions we are using of `log4j2` are vulnerable, I added the mitigation param for `tomcat,` `sorl,` `elasticsearch,` and `exec-jar` services `(cas,` `image-service,` `doi` ...).

Some screenshot after running this and restart services `(cas` services, `tomcat):`

![image](https://user-images.githubusercontent.com/180085/145680403-e5128624-89ee-42aa-82f9-4e57fac02c9f.png)

`image-service`, `solr` and `elasticsearch:`

![image](https://user-images.githubusercontent.com/180085/145680404-6917ac70-7e9c-4a08-b5fb-dffc552d18bb.png)
