### PR TITLE
LA apt repos configurable

### DIFF
--- a/ansible/roles/la-apt/defaults/main.yml
+++ b/ansible/roles/la-apt/defaults/main.yml
@@ -1,0 +1,1 @@
+la_apt_repo: 'unstable'

--- a/ansible/roles/la-apt/tasks/main.yml
+++ b/ansible/roles/la-apt/tasks/main.yml
@@ -8,14 +8,15 @@
     - ansible_os_family == "Debian"
   tags:
     - packages
+    - apt
 
 - name: Install gbif.es apt repository
-  apt_repository:
+  copy:
     # We use this repo temporally
-    repo: deb [arch=amd64] https://apt.gbif.es/ bionic main
-    filename: apt_gbif_es
-    state: present
+    content: "deb [arch=amd64] https://apt.gbif.es/ {{ la_apt_repo }}  main\n"
+    dest: "/etc/apt/sources.list.d/apt_gbif_es.list"
   when:
     - ansible_os_family == "Debian"
   tags:
     - packages
+    - apt


### PR DESCRIPTION
This allow to configure stable/unstable repo in apt.gbif.es so we can choose between tagged stable versions of packages and snapshot packages.

So you can select:
``` 
la_apt_repo = 'stable'
``` 

``` 
la_apt_repo = 'unstable'
``` 

Current content of stable:

![image](https://user-images.githubusercontent.com/180085/146411219-09cdc047-645d-4343-8b28-7f292a903e4c.png)

`ala-senstive-data-service` is not there til we have a tagged version with the debian package.

We use a template now because if not several lines are added to the sources without replacing the previous one:
https://github.com/ansible/ansible/issues/58386#issuecomment-505888418
