### PR TITLE
Remove iso-8859-1 encoding in yaml config as support utf-8

### DIFF
--- a/ansible/roles/bie-hub/tasks/main.yml
+++ b/ansible/roles/bie-hub/tasks/main.yml
@@ -17,7 +17,6 @@
     src: bie-hub-config.yml.j2
     dest: "{{ data_dir }}/{{ bie_hub }}/config/{{ bie_hub | default('generic-bie') }}-config.yml"
     force: yes
-    output_encoding: iso-8859-1
   tags:
     - webapps
     - properties


### PR DESCRIPTION
Using `iso-8859-1` in the `ala-bie-config.yml` configuration causes a startup exception in some cases:
```
2021-12-27 11:03:25.344 ERROR --- [.es-startStop-1] o.s.boot.SpringApplication               : Application startup failed

org.yaml.snakeyaml.error.YAMLException: java.nio.charset.MalformedInputException: Input length = 1
        a8t org.yaml.snakeyaml.reader.StreamReader.update(StreamReader.java:200)
        at org.yaml.snakeyaml.reader.StreamReader.peek(StreamReader.java:146)
```

This is solved using an `utf-8` configuration that is supported by `yaml` ([in contrast to properties](https://github.com/AtlasOfLivingAustralia/ala-install/pull/382)).