### PR TITLE
Link non ALA nameindex too

### DIFF
--- a/ansible/roles/nameindex/tasks/main.yml
+++ b/ansible/roles/nameindex/tasks/main.yml
@@ -114,10 +114,9 @@
     - "nameindex"
     - "nameindex-stage"
 
-- name: check for directory to link (ALA)
+- name: check for directory to link
   stat:
     path: "{{ data_dir }}/lucene/namematching-{{ name_index_date }}/"
-  when: nameindex_variant == "ala"
   register: tmp_name_dir_status
   tags:
     - "nameindex"
@@ -130,17 +129,24 @@
     - "nameindex"
     - "nameindex-swap"
 
-## Else if not ALA, perform the following steps (apparently the date and file permissions do not matter for non-ALA users...)
-- name: ensure lucene namematching directory exists (not ALA)
-  file: path={{ data_dir }}/lucene/namematching state=directory
-  when: nameindex_variant != "ala"
+- name: unpackage the lucene index if it was newly copied (not ALA)
+  unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
+  when: nameindex_variant != "ala" and nameindex_nonala_downloaded.changed
   tags:
     - "nameindex"
     - "nameindex-swap"
 
-- name: unpackage the lucene index if it was newly copied (not ALA)
-  unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
-  when: nameindex_variant != "ala" and nameindex_nonala_downloaded.changed
+- name: DEBUG Link non ALA namematching
+  debug:
+    msg: "Trying to link {{ data_dir }}/lucene/namematching-{{ name_index_date }}/ to {{ data_dir }}/lucene/namematching"
+  when: nameindex_variant != "ala"
+  tags:
+    - "nameindex"
+    - "nameindex-stage"
+
+- name: link the current lucene index as namematching (Non ALA)
+  file: src={{ data_dir }}/lucene/namematching-{{ name_index_date }}/ dest={{ data_dir }}/lucene/namematching state=link force=yes
+  when: nameindex_variant != "ala" and tmp_name_dir_status.stat.exists == True
   tags:
     - "nameindex"
     - "nameindex-swap"


### PR DESCRIPTION
We link non ALA nameindexes similar as ALA does. This does not affect to ALA current use, so I'll commit.