### PR TITLE
Added comments to collectory gbif properties

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -110,6 +110,12 @@ gbifApiUrl={{ gbif_api_url | default('https://api.gbif.org/v1/') }}
 # GBIF Registration enables the Collectory to create and update organisations and datasets
 # This mode of operation is only expected to be used by National Nodes running the ALA as a publishing gateway to GBIF.
 # (i.e. where the ALA installation is not sourcing information from GBIF.org itself)
+# 
+# The gbifEndorsingNodeKey and gbifInstallationKey should be requested to GBIF via helpdesk and only needed for publishing to GBIF.
+#
+# The gbifApiUser and gbifApiPassword can be any user registered in gbif.org and are used for loading data from GBIF.
+# Note: Don't use your user email as gbifApiUser but your user id (like johndoe instead of johndoe@example.com)
+#
 gbifRegistrationEnabled={{ gbif_registration_enabled | default('false') }}
 gbifEndorsingNodeKey={{ gbif_endorsing_node_key | default('') }}
 gbifInstallationKey={{ gbif_installation_key | default('') }}


### PR DESCRIPTION
Recently Tanzania team was unable to download datasets from GBIF because they used an email instead of an user id. Clarifying this in the template comments.