### PR TITLE
Improve non-ala nameindex debug and added checksum

### DIFF
--- a/ansible/roles/nameindex/tasks/main.yml
+++ b/ansible/roles/nameindex/tasks/main.yml
@@ -86,7 +86,7 @@
     - "nameindex-stage"
 
 - name: Download lucene index (non-ALA) - please note, this step takes a long time. If it causes an issue, use '--skip-tags nameindex' to bypass it, to complete an installation
-  get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene/namematching.tgz force={{ force_nameindex_download | default(false) }} timeout=10000
+  get_url: url={{lucene_namematching_url}} dest={{data_dir}}/lucene/namematching.tgz force={{ force_nameindex_download | default(false) }} timeout=10000 checksum={{nameindex_checksum}}
   when: nameindex_variant != "ala"
   register: nameindex_nonala_downloaded
   tags:
@@ -95,7 +95,7 @@
 
 - name: DEBUG Index download status
   debug:
-    msg: "Download status is variant={{ nameindex_variant }}, ala={{ nameindex_ala_downloaded }}, nonala={{ nameindex_nonala_downloaded }} existing={{  existing_name_dir_status }}"
+    msg: "Download status is variant={{ nameindex_variant }}, ala={{ nameindex_ala_downloaded }}, nonala={{ nameindex_nonala_downloaded }} existing={{ existing_name_dir_status.stat.exists }}"
   tags:
     - "nameindex"
     - "nameindex-stage"
@@ -110,6 +110,13 @@
 - name: unpackage the lucene index if it was newly copied (ALA)
   unarchive: src={{ data_dir }}/lucene/namematching-{{ name_index_date }}.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
   when: nameindex_variant == "ala" and nameindex_ala_downloaded.changed
+  tags:
+    - "nameindex"
+    - "nameindex-stage"
+
+- name: unpackage the lucene index if it was newly copied (not ALA)
+  unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
+  when: nameindex_variant != "ala" and nameindex_nonala_downloaded.changed
   tags:
     - "nameindex"
     - "nameindex-stage"
@@ -129,16 +136,9 @@
     - "nameindex"
     - "nameindex-swap"
 
-- name: unpackage the lucene index if it was newly copied (not ALA)
-  unarchive: src={{ data_dir }}/lucene/namematching.tgz dest={{ data_dir }}/lucene/ copy=no group={{ nameindex_user | default(tomcat_user) }} owner="{{ nameindex_user | default(tomcat_user) }}"
-  when: nameindex_variant != "ala" and nameindex_nonala_downloaded.changed
-  tags:
-    - "nameindex"
-    - "nameindex-swap"
-
 - name: DEBUG Link non ALA namematching
   debug:
-    msg: "Trying to link {{ data_dir }}/lucene/namematching-{{ name_index_date }}/ to {{ data_dir }}/lucene/namematching"
+    msg: "Trying to link {{ data_dir }}/lucene/namematching-{{ name_index_date }}/ (exists: {{ tmp_name_dir_status.stat.exists }}) to {{ data_dir }}/lucene/namematching"
   when: nameindex_variant != "ala"
   tags:
     - "nameindex"


### PR DESCRIPTION
For non-ALA `nameindex`:

- Added more debug info
- Reorder of tasks
- added tags
- added checksum to `get_url`

I'll merge as not affects ALA.