### PR TITLE
Conditional artifact for collectory depending on the version

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -47,7 +47,7 @@ biocacheServicesUrl={{ biocache_service_url }}
 # https://github.com/AtlasOfLivingAustralia/collectory-plugin/commit/f47c181ee4c5c52f150670f84f4f55f5d20ade31
 # configure skin.layout instead
 ala.skin={{ skin | default('main') }}
-skin.layout={{ (collectory_skin_layout | default(skin_layout)) | default('ala') }}
+skin.layout={{ collectory_layout | default('ala') }}
 skin.fluidLayout={{ fluidLayout | default('')}}
 chartsBgColour={{ charts_bg_colour | default('#fffef7') }}
 

--- a/ansible/roles/collectory/vars/main.yml
+++ b/ansible/roles/collectory/vars/main.yml
@@ -3,7 +3,7 @@
 # collectory_version: "1.5.1"
 version: "{{ collectory_version | default('LATEST') }}"
 
-artifactId: "{{ collectory_app | default('generic-collectory') }}"
+artifactId: "{{ collectory_app is defined | ternary(collectory_app, collectory_version is version('3', '>=') | ternary('collectory', 'ala-collectory')) }}"
 
 groupId: "{{ collectory_group_id | default('au.org.ala') }}"
 # collectory does not need a value for classifier

--- a/ansible/roles/collectory/vars/main.yml
+++ b/ansible/roles/collectory/vars/main.yml
@@ -5,6 +5,8 @@ version: "{{ collectory_version | default('LATEST') }}"
 
 artifactId: "{{ collectory_app is defined | ternary(collectory_app, collectory_version is version('3', '>=') | ternary('collectory', 'ala-collectory')) }}"
 
+collectory_layout: "{{ collectory_skin_layout is defined | ternary(collectory_skin_layout, collectory_version is version('3', '>=') | ternary('ala-main', 'ala')) }}"
+
 groupId: "{{ collectory_group_id | default('au.org.ala') }}"
 # collectory does not need a value for classifier
 classifier: ''


### PR DESCRIPTION
Added some ternary operator in order to start using `collectory` >= `3.0.0` and match the artifact name when not defined.

In this case, we can select the correct artifact only selecting the `collectory` version.

PS: I just added also the `skin_layout` configuration depending on the version