### PR TITLE
Correct logger auth filter

### DIFF
--- a/ansible/roles/logger-service/defaults/main.yml
+++ b/ansible/roles/logger-service/defaults/main.yml
@@ -1,5 +1,5 @@
-# Setup the CAS filter pattern to work with both /admin and /service/admin variants
-logger_uri_filter_pattern: "/admin.*,/service/admin.*"
+# Setup the CAS filter pattern to work with both /admin and /alaAdmin variants
+logger_uri_filter_pattern: "/admin/*,/alaAdmin/*"
 
 # Set this to a valid nginx logging line to enable logging of postdata
 # Also need to setup `nginx_other_log_formats` to define the format


### PR DESCRIPTION
Set `logger_uri_filter_pattern` def value.

I have a doubt: It's this specific of logger >= 4.0.0 after the recent grails and deps update?