### PR TITLE
Added alert_url and userdetails to collectory config for backward compatibility

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -108,7 +108,10 @@ loggerURL={{ (logger_webservice_url | default(logger_url)) }}
 
 # External services
 alertsUrl={{ (alerts_url | default(alert_url)) | default('') }}
+# For backward compatibility with ala-collectory:
+alertUrl={{ (alerts_url | default(alert_url)) | default('') }}
 speciesListToolUrl={{ species_list_tool_url | default('https://lists.ala.org.au/speciesListItem/list/') }}
+userDetails.url = {{ auth_base_url }}/userdetails/
 
 # GBIF base URL for webservices
 gbifApiUrl={{ gbif_api_url | default('https://api.gbif-uat.org/v1/') }}


### PR DESCRIPTION
In our production collectory using still `ala-collectory` suddenly we have `ala.org.au` urls:
![image](https://user-images.githubusercontent.com/180085/153200871-45f762b5-4642-48cb-9892-8943deb05205.png)

This PR adds the previous `alert_url` used still by portals using `ala-collectory` as we need  https://github.com/AtlasOfLivingAustralia/collectory/issues/65 to migrate to `collectory`.

We setup also `userdetails` from the default value.