### PR TITLE
Added branding cors variable to setup cors in l-a branding only

### DIFF
--- a/ansible/roles/branding/tasks/main.yml
+++ b/ansible/roles/branding/tasks/main.yml
@@ -16,6 +16,7 @@
     appname: "branding"
     hostname: "{{ branding_url }}"
     context_path: "/"
+    nginx_cors_origin_regexp: "{{ branding_nginx_cors_origin_regexp if branding_nginx_cors_origin_regexp is defined }}"
     nginx_paths:
       - path: "/"
         sort_label: "1"


### PR DESCRIPTION
This setup CORS for the branding of LA portals without the need of doing it manually.

I'll merge it as is something not used by ALA and I tested.