### PR TITLE
SDS extra configuration

### DIFF
--- a/ansible/roles/biocache-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache-properties/templates/biocache-config.properties
@@ -86,6 +86,10 @@ sds.enabled={{ sds_enabled | default('false') }}
 
 # SDS data file
 sds.url={{ biocache_sds_url | default('https://sds.ala.org.au') }}
+sds.species.data={{ biocache_sds_url | default('https://sds.ala.org.au') }}/sensitive-species-data.xml
+sds.category.data={{ biocache_sds_url | default('https://sds.ala.org.au') }}/sensitivity-categories.xml
+sds.zone.data={{ biocache_sds_url | default('https://sds.ala.org.au') }}/sensitivity-zones.xml
+sds.spatial.layers={{ sds_spatial_layers | default('cl932,cl927,cl23,cl937,cl941,cl938,cl939,cl936,cl940,cl963,cl962,cl961,cl960,cl964,cl965,cl22,cl10925') }}
 
 # The directory to write files to while ingesting data
 load.dir={{ data_dir }}/biocache-load/

--- a/ansible/roles/sds/tasks/main.yml
+++ b/ansible/roles/sds/tasks/main.yml
@@ -48,13 +48,13 @@
     - properties
 
 - name: Copy sensitivity categories XML
-  copy: src="sensitivity-categories.xml" dest="{{data_dir}}/sds/sensitivity-categories.xml"
+  copy: src="{{ sensitivity_categories_file | default ('sensitivity-categories.xml') }}" dest="{{data_dir}}/sds/sensitivity-categories.xml"
   tags:
     - sds
     - properties
 
 - name: Copy sensitivity zones XML
-  copy: src="sensitivity-zones.xml" dest="{{data_dir}}/sds/sensitivity-zones.xml"
+  copy: src="{{ sensitivity_zones_file | default ('sensitivity-zones.xml') }}" dest="{{data_dir}}/sds/sensitivity-zones.xml"
   tags:
     - sds
     - properties
@@ -77,4 +77,3 @@
     - restart tomcat
   tags:
     - sds
-    - properties

--- a/ansible/roles/sds/tasks/main.yml
+++ b/ansible/roles/sds/tasks/main.yml
@@ -77,3 +77,4 @@
     - restart tomcat
   tags:
     - sds
+    - properties


### PR DESCRIPTION
The `sds` configuration in `biocache-store` (sorry we are still there) still has some ALA default url values: 
https://github.com/AtlasOfLivingAustralia/sds/blob/b2b8157ecb8714e1a0175452a8ed1416572e3729/src/main/java/au/org/ala/sds/util/Configuration.java#L50

This PR configure these vars via ansible and also allow custom sds file configurations with inventories variables like:
```
sensitivity_zones_file = "{{ inventory_dir }}/files/custom-sensitivity-zones.xml"
```

It still has the ALA default values. 