### PR TITLE
Added isPipelineCompatible variable to collectory role

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -51,7 +51,7 @@ api_key={{ api_key | default('XxXXXXXXXXXXXXXXXXXXXXXXX') }}
 # Biocache integration
 biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
-isPipelinesCompatible={{ is_pipelines_compatible | default('True') }}
+isPipelinesCompatible={{ is_pipelines_compatible | default('true') }}
 
 # Skinning
 # ala.skin is deprecated after:

--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -51,6 +51,7 @@ api_key={{ api_key | default('XxXXXXXXXXXXXXXXXXXXXXXXX') }}
 # Biocache integration
 biocacheUiURL={{ biocache_hub_url }}
 biocacheServicesUrl={{ biocache_service_url }}
+isPipelinesCompatible={{ is_pipelines_compatible | default('True') }}
 
 # Skinning
 # ala.skin is deprecated after:


### PR DESCRIPTION
New `is_pipelines_compatible` variable for https://github.com/AtlasOfLivingAustralia/collectory/pull/98.
