### PR TITLE
Correct gbifWebsite url (without ending slash)

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -143,7 +143,8 @@ useGbifDoi={{ gbif_use_doi | default('false') }}
 gbifRegistrationDryRun={{ gbif_registration_dry_run | default('true') }}
 gbifLicenceMappingUrl={{ gbif_licence_mapping_url | default('file:///data/ala-collectory/config/default-gbif-licence-mapping.json') }}
 gbifOrphansPublisherID={{ gbif_orphans_publisher_id | default('') }}
-gbifWebsite={{ gbif_website | default('https://www.gbif.org/') }}
+# Use https://www.gbif-uat.org during testing/development
+gbifWebsite={{ gbif_website | default('https://www.gbif.org') }}
 
 # URL paths for archives
 resource.publicArchive.url.template = {{ public_archive_url | default('https://biocache.ala.org.au/archives/gbif/@UID@/@UID@.zip') }}


### PR DESCRIPTION
This was generating incorrect Gbif url links in collectory:
https://www.gbif.org//publisher/797b2594-278e-421d-88c1-0925d122d611 (404)

Instead of:
https://www.gbif.org/publisher/797b2594-278e-421d-88c1-0925d122d611