### PR TITLE
Extra hdfs directories

### DIFF
--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -332,6 +332,8 @@
     - "/pipelines-all-datasets"
     - "/pipelines-species"
     - "/pipelines-jackknife"
+    - "/pipelines-clustering"
+    - "/pipelines-vocabularies"
     - "/migration"
   become: yes
   become_user: "{{ hadoop.user }}"
@@ -348,6 +350,8 @@
     - "/pipelines-all-datasets"
     - "/pipelines-species"
     - "/pipelines-jackknife"
+    - "/pipelines-clustering"
+    - "/pipelines-vocabularies"
     - "/migration"
   become: yes
   become_user: "{{ hadoop.user }}"

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -51,6 +51,7 @@
     - "{{ data_dir }}/pipelines-shp"
     - "{{ data_dir }}/dwca-tmp"
     - "{{ data_dir }}/dwca-export"
+    - "{{ data_dir }}/migration"
   tags:
     - la-pipelines-config
     - pipelines


### PR DESCRIPTION
Just some extra hdfs directories that should be created initially. To prevent this error, for instance during `clustering`:


> WARN : Putting block rdd_37_2 failed due to exception org.apache.beam.sdk.util.UserCodeException: org.apache.hadoop.security.AccessControlException: Permission denied: user=spark, access=WRITE, inode="/":hdfs:supergroup:drwxr-xr-xs

