### PR TITLE
Fix for too-many-redirects error in spatial-hub

### DIFF
--- a/ansible/roles/spatial-hub/templates/spatial-hub-config.yml
+++ b/ansible/roles/spatial-hub/templates/spatial-hub-config.yml
@@ -19,7 +19,10 @@ security:
     casServerUrlPrefix: "{{ auth_cas_url }}"
     loginUrl: "{{ auth_cas_url }}/login"
     logoutUrl: "{{ auth_cas_url }}/logout"
+{% if spatial_hub_context_path != '/' %}
+    # if contextPath: "/" we have a too many redirects with CAS
     contextPath: "{{ spatial_hub_context_path }}"
+{% endif %}
     bypass: {{ bypass_cas | default(true) }}
     disableCAS: {{ bypass_cas | default(true) }}
     gateway: {{ gateway_cas | default(false) }}


### PR DESCRIPTION
Fix for #570. After this, spatial-hub does not throws the too-many-redirects error:

![image](https://user-images.githubusercontent.com/180085/170068282-0bb5fe22-a2b8-44bc-a600-490ede1c9992.png)

cc @biodivAtlasAT.