### PR TITLE
Correct owner for /data/dwca-export directory

### DIFF
--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -50,6 +50,7 @@
     - "{{ data_dir }}/spark-tmp"
     - "{{ data_dir }}/pipelines-shp"
     - "{{ data_dir }}/dwca-tmp"
+    - "{{ data_dir }}/dwca-export"
   tags:
     - la-pipelines-config
     - pipelines

--- a/ansible/roles/pipelines_jenkins/tasks/main.yml
+++ b/ansible/roles/pipelines_jenkins/tasks/main.yml
@@ -37,14 +37,6 @@
   tags:
     - pipelines_jenkins
 
-- name: Create /data/dwca-export for Copy-dwca-to-hdfs job
-  file:
-    path: /data/dwca-export/
-    state: directory
-  when: is_master
-  tags:
-    - pipelines_jenkins
-
 - name: Jenkins jobs definitions
   template:
     src: "{{ item }}"


### PR DESCRIPTION
Fix for #578 .  I moved the create directory task to a better place in the pipelines role.

After running this:

![image](https://user-images.githubusercontent.com/180085/171331341-d9dfd63a-cd96-453b-80ea-03338edfb9e9.png)
