### PR TITLE
Pipelines ingest job correct order

### DIFF
--- a/ansible/roles/pipelines_jenkins/templates/jenkins/jobs/Ingest-dataset/config.xml.j2
+++ b/ansible/roles/pipelines_jenkins/templates/jenkins/jobs/Ingest-dataset/config.xml.j2
@@ -87,10 +87,10 @@ stage('Dwc-verbatim') {
     }
 }
 
-stage('UUID') {
+stage('Interpretation') {
     node(){
-        if (params.dwcaToVerbatim || params.uuid){
-            build job: 'UUID-dataset', parameters: [
+        if (params.interpretation){
+            build job: 'Interpret-dataset', parameters: [
                  string(name: 'datasetId', value: datasetId),
                  string(name: 'displayName', value: datasetId),
                  string(name: 'mode', value: mode)
@@ -99,10 +99,10 @@ stage('UUID') {
     }
 }
 
-stage('Interpretation') {
+stage('UUID') {
     node(){
-        if (params.interpretation){
-            build job: 'Interpret-dataset', parameters: [
+        if (params.dwcaToVerbatim || params.uuid){
+            build job: 'UUID-dataset', parameters: [
                  string(name: 'datasetId', value: datasetId),
                  string(name: 'displayName', value: datasetId),
                  string(name: 'mode', value: mode)


### PR DESCRIPTION
With an initial ingest in a just installed cluster, the `uuid` step should be done after `interpretation`, if not:

![image](https://user-images.githubusercontent.com/180085/172170861-1ff2897f-3e2c-4f2c-b2af-dcbd7ad4842d.png)
