### PR TITLE
Pipelines extra shapes and state config

### DIFF
--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -379,6 +379,16 @@
     - pipelines
     - pipelines-layers
 
+- name: Download extra tar with layers
+  get_url:
+    url: "{{ pipelines_shapefiles_extra_url }}"
+    checksum: "{{ pipelines_shapefiles_extra_checksum }}"
+    dest: "{{ data_dir }}/pipelines-shp/extra-layers.tgz"
+  tags:
+    - pipelines
+    - pipelines-layers
+  when: pipelines_shapefiles_extra_url is defined
+
 - name: Unpack SHP files
   unarchive:
     src: "{{ item }}"
@@ -389,6 +399,8 @@
   with_items:
     - "{{ data_dir }}/pipelines-shp/pipelines-shapefiles.zip"
     - "{{ data_dir }}/pipelines-shp/sds-layers.tgz"
+    - "{{ data_dir }}/pipelines-shp/extra-layers.tgz"
   tags:
     - pipelines
     - pipelines-layers
+  when: item is defined

--- a/ansible/roles/pipelines/templates/la-pipelines-local.yaml
+++ b/ansible/roles/pipelines/templates/la-pipelines-local.yaml
@@ -39,6 +39,8 @@ geocodeConfig:
       CC: {{geocode_region | default('AU')}}
       HM: {{geocode_region | default('AU')}}
       NF: {{geocode_region | default('AU')}}
+  stateProvince:
+    path: /data/pipelines-shp/{{ geocode_state_province_layer | default('cw_state_poly') }}
 
 gbifConfig:
   vocabularyConfig:


### PR DESCRIPTION
This PR allows to configure the states provinces layer and also to add some extra layers (so we can reuse the political and ezz shapes from Australia). Sample conf:
 
```
geocode_state_province_layer = provincias
pipelines_shapefiles_extra_url = https://datos.gbif.es/others/layers/extra-layers.tgz
pipelines_shapefiles_extra_checksum = sha1:88b864096936416890cd4d01ec647d32b26b76ad
```

![image](https://user-images.githubusercontent.com/180085/173807630-4d06603d-e06a-4224-b14c-bd8d740c13f2.png)



