### PR TITLE
Use of debian packages in namematching and sensitive service instead of war

### DIFF
--- a/ansible/namematching-service.yml
+++ b/ansible/namematching-service.yml
@@ -2,7 +2,6 @@
 - hosts: namematching-service
   roles:
     - common
-    - java
     - webserver
-    - nameindex
+    - la-apt
     - namematching-service

--- a/ansible/roles/namematching-service/defaults/main.yml
+++ b/ansible/roles/namematching-service/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 
 # The port that namematching-service will run on
-namematching_service_port: 8080
-namematching_admin_port: 8081
-namematching_user: namematching-service
+namematching_service_port: 9179
+namematching_admin_port: 9180
+namematching_user: namematching
 namematching_service_context_path:
+# * = latest
+ala_namematching_service_version: "*"

--- a/ansible/roles/namematching-service/handlers/main.yml
+++ b/ansible/roles/namematching-service/handlers/main.yml
@@ -1,2 +1,2 @@
-- name: restart namematching-service
-  service: name=namematching-service state=restarted enabled=yes
+- name: restart ala-namematching-service
+  service: name=ala-namematching-service state=restarted enabled=yes

--- a/ansible/roles/namematching-service/tasks/apt.yml
+++ b/ansible/roles/namematching-service/tasks/apt.yml
@@ -1,0 +1,47 @@
+- name: Setup namematching package
+  ansible.builtin.debconf:
+    name: ala-namematching-service
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: string
+  with_items:
+  - {
+    question: "ala-namematching-service/source",
+    value: "{{ ala_namemaching_service_source | default('https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz') }}"
+    }
+  - {
+    question: "ala-namematching-service/sha1",
+    value: "{{ ala_namemaching_service_source_sha1 | default('563814a7b5d886b746e10eb40c44f0d9bda62371') }}"
+    }
+  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
+  tags:
+    - apt
+
+- name: Install ala-namematching-service
+  apt:
+    name:
+      - ala-namematching-service={{ ala_namematching_service_version }}
+    state: present
+    autoclean: yes
+    update_cache: yes
+    force: yes
+  tags:
+    - apt
+
+# See:
+# https://github.com/ansible/ansible/issues/29352
+# https://github.com/ansible/ansible/pull/39794
+# https://github.com/ansible/ansible/pull/74196
+- name: dpkg-reconfigure to get rid of configuration changes
+  shell: "dpkg-reconfigure -f noninteractive {{ item }}"
+  with_items:
+    - ala-namematching-service
+  tags:
+    - apt
+
+- name: Start service ala-namematching-service installed via apt, if not running
+  service:
+    name: ala-namematching-service
+    state: started
+  tags:
+    - apt

--- a/ansible/roles/namematching-service/tasks/main.yml
+++ b/ansible/roles/namematching-service/tasks/main.yml
@@ -5,29 +5,16 @@
     - properties
     - nginx_vhost
 
-#
-# JAR file deployment
-#
-# Also creates config directories
-- name: add jar and service
-  include_role:
-    name: exec-jar-generic
-  vars:
-    service_name: "namematching-service"
-    jar_url: '{{ namematching_service_jar_url }}'
-    service_owner: "{{ namematching_user }}"
-    args:
-      - server
-      - "{{data_dir}}/namematching-service/config/namematching-service-config.yml"
+- include: ./apt.yml
   tags:
-    - deploy
-    - service
     - namematching-service
+    - deploy
+    - apt
 
-- name: Create configuration
+- name: Customize configuration already added by apt package
   template:
     src: namematching-service-config.yml
-    dest: "{{data_dir}}/namematching-service/config/namematching-service-config.yml"
+    dest: "{{data_dir}}/ala-namematching-service/config/config.yml"
     owner: "{{ namematching_user }}"
     group: "{{ namematching_user }}"
   notify:
@@ -36,10 +23,10 @@
     - properties
     - namematching-service
 
-- name: Create species group files
+- name: Customize species group files
   copy:
     src: "{{item}}"
-    dest: "{{data_dir}}/namematching-service/config/{{item}}"
+    dest: "{{data_dir}}/ala-namematching-service/config/{{item}}"
     owner: "{{ namematching_user }}"
     group: "{{ namematching_user }}"
   with_items:
@@ -51,13 +38,18 @@
     - properties
     - namematching-service
 
-- name: Restart namematching service
+- name: Restart ala-namematching service
   service:
-    name: namematching-service
+    name: ala-namematching-service
     state: restarted
     enabled: yes
-  tags:
-    - namematching-service
+
+- name: Disable previous namematching service (not packaged war)
+  service:
+    name: namematching-service
+    state: stopped
+    enabled: no
+  ignore_errors: yes
 
 - name: add nginx vhost
   include_role:

--- a/ansible/roles/namematching-service/tasks/main.yml
+++ b/ansible/roles/namematching-service/tasks/main.yml
@@ -18,10 +18,20 @@
     owner: "{{ namematching_user }}"
     group: "{{ namematching_user }}"
   notify:
-    - restart namematching-service
+    - restart ala-namematching-service
   tags:
     - properties
     - namematching-service
+
+- name: "Create ala-namematching-service directories"
+  file:
+    path: "{{item}}"
+    state: directory
+    owner: "{{ namematching_user }}"
+    group: "{{ namematching_user }}"
+    mode: 0755
+  with_items:
+    - "/var/log/atlas/namematching-service"
 
 - name: Customize species group files
   copy:
@@ -33,16 +43,10 @@
     - "groups.json"
     - "subgroups.json"
   notify:
-    - restart namematching-service
+    - restart ala-namematching-service
   tags:
     - properties
     - namematching-service
-
-- name: Restart ala-namematching service
-  service:
-    name: ala-namematching-service
-    state: restarted
-    enabled: yes
 
 - name: Disable previous namematching service (not packaged war)
   service:

--- a/ansible/roles/namematching-service/templates/namematching-service-config.yml
+++ b/ansible/roles/namematching-service/templates/namematching-service-config.yml
@@ -27,9 +27,9 @@ server:
     - type: http
       port: {{ namematching_admin_port }}
 search:
-  index: {{ data_dir }}/lucene/namematching
-  groups: file:{{data_dir}}/namematching-service/config/groups.json
-  subgroups: file:{{data_dir}}/namematching-service/config/subgroups.json
+  index: {{ data_dir }}/lucene/namematching-nm
+  groups: file:{{data_dir}}/ala-namematching-service/config/groups.json
+  subgroups: file:{{data_dir}}/ala-namematching-service/config/subgroups.json
   cache:
     entryCapacity: 1000
     enableJmx: true

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -220,21 +220,7 @@
     - pipelines-services
     - docker
 
-- name: Setup namematching package
-  ansible.builtin.debconf:
-    name: ala-namematching-service
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: string
-  with_items:
-  - {
-    question: "ala-namematching-service/source",
-    value: "{{ ala_namemaching_service_source | default('https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz') }}"
-    }
-  - {
-    question: "ala-namematching-service/sha1",
-    value: "{{ ala_namemaching_service_source_sha1 | default('563814a7b5d886b746e10eb40c44f0d9bda62371') }}"
-    }
+- include: ../../namematching-service/tasks/apt.yml
   when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
   tags:
     - pipelines
@@ -242,89 +228,13 @@
     - la-pipelines
     - apt
 
-- name: Setup sensitive-data-service package
-  ansible.builtin.debconf:
-    name: ala-sensitive-data-service
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: string
-  with_items:
-  - {
-    question: "ala-sensitive-data-service/sds-url",
-    value: "{{ sds_url | default('https://sds.ala.org.au') }}"
-    }
-  - {
-    question: "ala-sensitive-data-service/spatial-url",
-    value: "{{ spatial_url | default('https://spatial.ala.org.au') }}"
-    }
-  - {
-    question: "ala-sensitive-data-service/layers-url",
-    value: "{{ sds_layers_url | default('https://archives.ala.org.au/archives/layers/sds-layers.tgz') }}"
-    }
-  - {
-    question: "ala-sensitive-data-service/source",
-    value: "{{ ala_sensitive_data_service_namematching_source | default('https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz') }}"
-    }
-  - {
-    question: "ala-sensitive-data-service/sha1",
-    value: "{{ ala_sensitive_data_service_namematching_sha1 | default('f9e42325db8d41ca0c8afeb6aeadf670978a13ac') }}"
-    }
+- include: ../../sensitive-data-service/tasks/apt.yml
   when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
   tags:
     - pipelines
     - pipelines-services
     - la-pipelines
     - apt
-
-- name: Install ala-namematching-service an ala-sensitive-data-service directly if not using docker
-  apt:
-    name:
-      - ala-namematching-service={{ ala_namematching_service_version }}
-      - ala-sensitive-data-service={{ ala_sensitive_data_service_version }}
-    state: present
-    autoclean: yes
-    update_cache: yes
-    force: yes
-  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
-  tags:
-    - pipelines
-    - pipelines-services
-    - la-pipelines
-    - apt
-
-# See:
-# https://github.com/ansible/ansible/issues/29352
-# https://github.com/ansible/ansible/pull/39794
-# https://github.com/ansible/ansible/pull/74196
-- name: dpkg-reconfigure to get rid of configuration changes
-  shell: "dpkg-reconfigure -f noninteractive {{ item }}"
-  with_items:
-    - ala-namematching-service
-    - ala-sensitive-data-service
-  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
-  tags:
-    - pipelines
-    - pipelines-services
-    - la-pipelines
-    - apt
-
-- name: Start service ala-namematching-service installed via apt, if not running
-  service:
-    name: ala-namematching-service
-    state: started
-  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
-  tags:
-    - pipelines
-    - pipelines-services
-
-- name: Start service ala-sensitive-data-service installed via apt, if not running
-  service:
-    name: ala-sensitive-data-service
-    state: started
-  when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
-  tags:
-    - pipelines
-    - pipelines-services
 
 - name: Create HDFS base directories
   shell: "{{ hadoop_install_dir }}/bin/hdfs dfs -mkdir -p {{ item }}"

--- a/ansible/roles/sensitive-data-service/defaults/main.yml
+++ b/ansible/roles/sensitive-data-service/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
 
 # The port that sensitive_data-service will run on
-sensitive_data_service_port: 8080
-sensitive_data_admin_port: 8081
-sensitive_data_user: sensitive-data-service
+sensitive_data_service_port: 9189
+sensitive_data_admin_port: 9190
+sensitive_data_user: sds-data
 sensitive_data_service_context_path:
 sds_url: "https://sds.ala.org.au"
 layers_url: "https://archives.ala.org.au/archives/layers/sds-layers.tgz"
 layers_service_url: "https://spatial.ala.org.au/layers-service"
+# * = latest
+ala_sensitive_data_service_version: "*"

--- a/ansible/roles/sensitive-data-service/handlers/main.yml
+++ b/ansible/roles/sensitive-data-service/handlers/main.yml
@@ -1,2 +1,2 @@
-- name: restart sensitive-data-service
-  service: name=sensitive-data-service state=restarted enabled=yes
+- name: restart ala-sensitive-data-service
+  service: name=ala-sensitive-data-service state=restarted enabled=yes

--- a/ansible/roles/sensitive-data-service/tasks/apt.yml
+++ b/ansible/roles/sensitive-data-service/tasks/apt.yml
@@ -1,0 +1,58 @@
+- name: Setup sensitive-data-service package
+  ansible.builtin.debconf:
+    name: ala-sensitive-data-service
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: string
+  with_items:
+  - {
+    question: "ala-sensitive-data-service/sds-url",
+    value: "{{ sds_url | default('https://sds.ala.org.au') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/spatial-url",
+    value: "{{ spatial_url | default('https://spatial.ala.org.au') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/layers-url",
+    value: "{{ sds_layers_url | default('https://archives.ala.org.au/archives/layers/sds-layers.tgz') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/source",
+    value: "{{ ala_sensitive_data_service_namematching_source | default('https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz') }}"
+    }
+  - {
+    question: "ala-sensitive-data-service/sha1",
+    value: "{{ ala_sensitive_data_service_namematching_sha1 | default('f9e42325db8d41ca0c8afeb6aeadf670978a13ac') }}"
+    }
+  tags:
+    - apt
+
+- name: Install the ala-sensitive-data-service package
+  apt:
+    name:
+      - ala-sensitive-data-service={{ ala_sensitive_data_service_version }}
+    state: present
+    autoclean: yes
+    update_cache: yes
+    force: yes
+  tags:
+    - apt
+
+# See:
+# https://github.com/ansible/ansible/issues/29352
+# https://github.com/ansible/ansible/pull/39794
+# https://github.com/ansible/ansible/pull/74196
+- name: dpkg-reconfigure to get rid of configuration changes
+  shell: "dpkg-reconfigure -f noninteractive {{ item }}"
+  with_items:
+    - ala-sensitive-data-service
+  tags:
+    - apt
+
+- name: Start service ala-sensitive-data-service installed via apt, if not running
+  service:
+    name: ala-sensitive-data-service
+    state: started
+  tags:
+    - apt

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -5,6 +5,19 @@
     - properties
     - nginx_vhost
 
+# Recent versions use the namemaching index so we have to configure too
+- include_vars: ../namematching-service/defaults/main.yml
+  tags:
+    - sensitive-data-service
+    - deploy
+    - apt
+
+- include: ../namematching-service/tasks/apt.yml
+  tags:
+    - sensitive-data-service
+    - deploy
+    - apt
+
 - include: ./apt.yml
   tags:
     - sensitive-data-service

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -5,125 +5,38 @@
     - properties
     - nginx_vhost
 
-- name: Create directories
-  file:
-    path: "{{data_dir}}/{{ item }}"
-    state: directory
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  with_items:
-    - sds/config
-    - sensitive-data-service/config
-    - biocache/layers
-#
-# JAR file deployment
-#
-# Also creates config directories
-- name: add jar and service
-  include_role:
-    name: exec-jar-generic
-  vars:
-    service_name: "sensitive-data-service"
-    jar_url: '{{ sensitive_data_service_jar_url }}'
-    service_owner: "{{ sensitive_data_user }}"
-    args:
-      - server
-      - "{{data_dir}}/sensitive-data-service/config/sensitive-data-service-config.yml"
+- include: ./apt.yml
   tags:
-    - deploy
-    - service
     - sensitive-data-service
+    - deploy
+    - apt
 
-- name: Create configuration
+- name: Customize configuration already added by apt package
   template:
     src: sensitive-data-service-config.yml
-    dest: "{{data_dir}}/sensitive-data-service/config/sensitive-data-service-config.yml"
+    dest: "{{data_dir}}/ala-sensitive-data-service/config/config.yml"
     owner: "{{ sensitive_data_user }}"
     group: "{{ sensitive_data_user }}"
   notify:
-    - restart sensitive-data-service
+    - restart ala-sensitive-data-service
   tags:
     - properties
     - sensitive-data-service
 
-- name: Create SDS configuration
-  template:
-    src: sds-config.properties
-    dest: "{{data_dir}}/sds/sds-config.properties"
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  notify:
-    - restart sensitive-data-service
-  tags:
-    - properties
-    - sensitive-data-service
-
-- name: Create SDS configuration
-  template:
-    src: sds-config.properties
-    dest: "{{data_dir}}/sds/config/sds-config.properties"
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  notify:
-    - restart sensitive-data-service
-  tags:
-    - properties
-    - sensitive-data-service
-
-- name: Get SDS configuration from server
-  get_url:
-    url: "{{sds_url}}/{{item}}"
-    dest: "{{data_dir}}/sds/{{item}}"
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  with_items:
-    - "sensitive-species-data.xml"
-    - "sensitivity-zones.xml"
-    - "sensitivity-categories.xml"
-  notify:
-    - restart sensitive-data-service
-  tags:
-    - properties
-    - sensitive-data-service
-
-- name: Get SDS layers from server
-  get_url:
-    url: "{{sds_url}}/ws/layers"
-    dest: "{{data_dir}}/sds/layers.json"
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  notify:
-    - restart sensitive-data-service
-  tags:
-    - properties
-    - sensitive-data-service
-
-- name: Get spatial layers from archive
-  get_url:
-    url: "{{ layers_url }}"
-    dest: "{{data_dir}}/biocache/layers/layers.tgz"
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  tags:
-     - sensitive-data-service
-
-- name: Uncompress layers
-  unarchive:
-    src: "{{ data_dir }}/biocache/layers/layers.tgz"
-    dest: "{{ data_dir }}/biocache/layers"
-    copy: no
-    owner: "{{ sensitive_data_user }}"
-    group: "{{ sensitive_data_user }}"
-  tags:
-    - sensitive-data-service
-
-- name: Restart sensitive_data service
+- name: Restart ala-sensitive-data service
   service:
-    name: sensitive-data-service
+    name: ala-sensitive-data-service
     state: restarted
     enabled: yes
   tags:
     - sensitive-data-service
+
+- name: Disable previous sensitive_data service (not packaged war)
+  service:
+    name: sensitive-data-service
+    state: stopped
+    enabled: no
+  ignore_errors: yes
 
 - name: add nginx vhost
   include_role:

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -23,14 +23,6 @@
     - properties
     - sensitive-data-service
 
-- name: Restart ala-sensitive-data service
-  service:
-    name: ala-sensitive-data-service
-    state: restarted
-    enabled: yes
-  tags:
-    - sensitive-data-service
-
 - name: Disable previous sensitive_data service (not packaged war)
   service:
     name: sensitive-data-service

--- a/ansible/roles/sensitive-data-service/templates/sensitive-data-service-config.yml
+++ b/ansible/roles/sensitive-data-service/templates/sensitive-data-service-config.yml
@@ -27,11 +27,11 @@ server:
     - type: http
       port: {{ sensitive_data_admin_port }}
 conservation:
-  index: /data/lucene/namematching-{{ nameindex_datestamp }}
-  speciesUrl: {{ sds_url }}/sensitive-species-data.xml
-  zonesUrl: {{ sds_url }}/sensitivity-zones.xml
-  categoriesUrl: {{ sds_url }}/sensitivity-categories.xml
-  layersUrl: {{ sds_url }}/ws/layers
+  index: /data/lucene/namematching-nm
+  speciesUrl: file://{{ data_dir }}/sds/sensitive-species-data.xml
+  zonesUrl: {{ data_dir }}/sds/sensitivity-zones.xml
+  categoriesUrl: {{ data_dir }}/sds/sensitivity-categories.xml
+  layersUrl: {{ data_dir }}/sds/layers.json
   layersServiceUrl: {{ layers_service_url }}
   cache:
     entryCapacity: 10000

--- a/ansible/sensitive-data-service.yml
+++ b/ansible/sensitive-data-service.yml
@@ -2,7 +2,6 @@
 - hosts: sensitive-data-service
   roles:
     - common
-    - java
     - webserver
-    - nameindex
+    - la-apt
     - sensitive-data-service


### PR DESCRIPTION
I proposed the debian package system as a way to avoid code duplication between people using ala-install based installations and these portals using docker.

But for instance `ala-sensitive-data-service` has now three ways to install the service:

1. the [docker image](https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service/blob/master/ala-sensitive-data-server/docker/Dockerfile) (using the deb package)
1. the [docker-test](https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service/blob/master/ala-sensitive-data-server/docker/Dockerfile-test) image (using a war instead of the debian package)
1. the `sensitive-data-service` role that installs the war via ansible instead of the debian package and that has tasks that the debian package already does (so we have duplicate code too).

The same occurs with the `namematching-service`.

The problem with duplicating code is that at the end, we have different bugs and issues that we have to fix/test in the different install code.

For instance, nowadays the debian package does not works properly for us (the LA community) because we are waiting for the PR https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service/pull/21 also because of https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service/issues/18 So people that are installing pipelines for the first time are having these issues too.

As a sample, the `la-pipelines` debian package is the only way to install via the `pipelines` role, so we only have to maintain these pieces of code.

So this PR:

- it uses the debian package for both namematching and sensitive-data service instead of a war (point 3)
- it uses the ports configured in the debian package (instead of `8080` ...) so avoids port conflicts
- disables previous services if present.
- allow to overwrite configurations installed by the packages (probably useful for customizations).
- as recent versions of `ala-sensitive-data` service depends now on the `namematching` service (and uses lucene 8) we configure it also in the `sensitive-data-service` role.

Configured with the PR:

![image](https://user-images.githubusercontent.com/180085/178259297-5d92e58c-db35-4d3c-9d64-10590388768e.png)

![image](https://user-images.githubusercontent.com/180085/178259313-68896e2e-7f8c-46d8-834a-0469a37d8d6b.png)
