### PR TITLE
CAS backwards compatibility with pre OIDC versions

### DIFF
--- a/ansible/roles/apikey/tasks/main.yml
+++ b/ansible/roles/apikey/tasks/main.yml
@@ -50,6 +50,20 @@
     group: apikey
   notify:
     - restart apikey
+  when: apikey_version is version('1.7.0', '>=')
+  tags:
+    - properties
+    - apikey
+
+- name: copy apikey-config.yml
+  template:
+    src: apikey-config-pre-1.7.0.yml
+    dest: "{{data_dir}}/apikey/config/apikey-config.yml"
+    owner: apikey
+    group: apikey
+  notify:
+    - restart apikey
+  when: apikey_version is version('1.7.0', '<')
   tags:
     - properties
     - apikey
@@ -72,8 +86,8 @@
   vars:
     service_name: "apikey"
     jar_url: '{{ apikey_jar_url }}'
-    use_openjdk11: True
-    use_openjdk8: False
+    use_openjdk11: "{{ apikey_version is version('1.7.0', '>=') }}"
+    use_openjdk8: "{{ apikey_version is version('1.7.0', '<') }}"
     java_headless: true
     java_jre: true
     log_config_filename: logback.xml

--- a/ansible/roles/apikey/templates/apikey-config-pre-1.7.0.yml
+++ b/ansible/roles/apikey/templates/apikey-config-pre-1.7.0.yml
@@ -1,0 +1,110 @@
+# CAS Config
+security:
+  cas:
+    casServerName: {{ cas_server_name }}
+    casServerUrlPrefix: ${security.cas.casServerName}/{{ cas_context_path | default('cas') }}
+    loginUrl: ${security.cas.casServerUrlPrefix}/login
+    logoutUrl: ${security.cas.casServerUrlPrefix}/logout
+    appServerName: {{ apikey_server_name }}
+    authCookieName: {{ auth_cookie_name | default('ALA-Auth') }}
+  user:
+    name: {{ apikey_endpoint_user | default('admin') }}
+    password: {{ apikey_endpoint_password | default('secret') }}
+    role:
+      - ACTUATOR
+  basic:
+    enabled: true
+    authorizeMode: role
+    realm: ALA CAS
+    path:
+      - /status/**
+endpoints:
+  enabled: {{ endpoints_enabled | default('true') }}
+management:
+  security:
+    enabled: true
+    roles: ACTUATOR
+
+serverURL: {{ apikey_server_name }}
+serverName: {{ apikey_server_name }}
+grails:
+  serverURL: {{ apikey_server_name }}/{{ apikey_context_path | default('apikey') }}
+server:
+  port: {{ apikey_port | default('9002') }}
+  contextPath: /{{ apikey_context_path | default('apikey') }}
+
+# Data source configuration
+dataSource:
+  dbCreate: "none"
+  url: jdbc:mysql://{{ apikey_db_hostname | default('localhost') }}:{{ apikey_db_port | default('3306') }}/{{ apikey_db_name | default('apikey') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8&useSSL={{mysql_connection_ssl | default(false)}}
+  username: {{ apikey_db_username }}
+  password: {{ apikey_db_password }}
+flyway:
+  baselineOnMigrate: {{ apikey_db_migration_baseline | default('true') }}
+
+ala:
+  baseURL: {{ ala_baseurl | default('https://www.ala.org.au') }}
+
+supportEmail: {{ support_email | default('support@ala.org.au') }}
+homeUrl: {{ ala_baseurl | default('https://www.ala.org.au') }}
+mainTitle: {{ orgNameLong | default('Atlas of Living Australia') }}
+emailSenderTitle: {{ orgNameLong | default('Atlas of Living Australia') }}
+emailSender: {{ support_email | default('support@ala.org.au') }}
+
+sightings.url: {{ sightings_base_url }}/mine
+spatial.url: {{ spatial_base_url }}?tool=log
+volunteer.url: {{ volunteer_base_url }}/user/myStats
+lists.url: {{ lists_base_url }}/speciesList/list
+biocache.search.url: {{ biocache_base_url }}/occurrences/search
+alerts.url: {{ alerts_base_url }}
+
+# this property is read/used by ala-auth-plugin (included by apikey)
+userDetails:
+  url: {{ userdetails_base_url }}/{{ userdetails_context_path | default('userdetails') }}/
+
+# Header and footer
+headerAndFooter:
+  baseURL: {{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3')}}
+  version: {{ header_and_footer_version | default('1')}}
+ala.baseURL: {{ ala_base_url | default('https://www.ala.org.au')}}
+bie.baseURL: {{ bie_base_url | default('https://bie.ala.org.au')}}
+bie.searchPath: {{ bie_search_path | default('/search') }}
+
+# Skin options
+skin.layout: {{ (apikey_skin_layout | default(skin_layout)) | default('ala-main') }}
+skin.fluidLayout: {{ skin_fluid_layout | default('false') }}
+skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
+skin.orgNameShort: {{ orgNameShort | default('ALA') }}
+skin.favicon: {{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+
+spring:
+{% if bootadmin_enabled | bool %}
+  boot:
+    admin:
+      url: {{ bootadmin_url | default('https://bootadmin.ala.org.au') }}
+      username: {{ bootadmin_username }}
+      password: {{ bootadmin_password }}
+      client:
+        enabled: true
+        service-url: {{ bootadmin_client_base_url | default('${serverURL}/') }}{{ apikey_context_path | default('apikey') }}
+        management-url: {{ bootadmin_client_base_url | default('${serverURL}/') }}{{ apikey_context_path | default('apikey') }}/status
+        name: {{ apikey_bootadmin_client_name | default('API Key') }}
+        metadata:
+          user:
+            name: ${security.user.name}
+            password: ${security.user.password}
+{% endif %}
+  session:
+    store-type: {{ spring_session_store_type | default('none') }}
+    {% if spring_session_store_type == 'redis' %}disable-redis-config-action: {{ is_secured_redis | default('false') | bool }}
+    redis:
+      namespace: {{ apikey_redis_namespace | default('apikey') }}
+  redis:
+    host: {{ spring_session_redis_host }}
+    password: {{ spring_session_redis_password }}
+    port: {{ spring_session_redis_port | default('6379') }}
+{% if spring_session_redis_clustered | bool %}
+    cluster:
+      nodes: {{ spring_session_redis_host }}:{{ spring_session_redis_port | default('6379') }}
+{% endif %}
+{% endif %}

--- a/ansible/roles/apikey/vars/main.yml
+++ b/ansible/roles/apikey/vars/main.yml
@@ -2,6 +2,6 @@
 version: "{{ apikey_version | default('LATEST') }}"
 artifactId: "apikey" 
 classifier: 'exec'
-packaging: "war"
+packaging: "{{ (apikey_version is version('1.7.0', '>=')) | ternary('war', 'jar') }}"
 groupId: "au.org.ala"
 apikey_jar_url: "{{maven_repo_ws_url}}"

--- a/ansible/roles/cas-management/tasks/main.yml
+++ b/ansible/roles/cas-management/tasks/main.yml
@@ -51,6 +51,20 @@
     dest: "{{data_dir}}/cas-management/config/application.yml"
     owner: cas
     group: cas
+  when: cas_management_version is version('6', '>=')
+  notify:
+    - restart cas-management
+  tags:
+    - properties
+    - cas-management
+
+- name: copy application.yml
+  template:
+    src: application.properties
+    dest: "{{data_dir}}/cas-management/config/application.properties"
+    owner: cas
+    group: cas
+  when: cas_management_version is version('6', '<')
   notify:
     - restart cas-management
   tags:
@@ -78,8 +92,8 @@
     service_name: "cas-management"
     service_owner: 'cas'
     service_group: 'cas'
-    use_openjdk11: True
-    use_openjdk8: False
+    use_openjdk11: "{{ cas_management_version is version('6', '>=') }}"
+    use_openjdk8: "{{ cas_management_version is version('6', '<') }}"
     java_headless: True
     java_jre: True
     jar_url: '{{ cas_management_jar_url }}'

--- a/ansible/roles/cas-management/templates/application.properties
+++ b/ansible/roles/cas-management/templates/application.properties
@@ -7,11 +7,11 @@ mgmt.serverName={{ cas_management_server_name }}
 mgmt.adminRoles[0]=ROLE_ADMIN
 mgmt.authzAttributes[0]=role
 mgmt.userPropertiesFile=file:/data/cas-management/config/users.properties
-mgmt.version-control.enabled={{ cas_management_enable_version_control | default('false') }}
-mgmt.version-control.services-repo={{ cas_management_services_repo | default('/data/cas-management/services-repo') }}
-mgmt.delegated.user-repos-dir={{ cas_management_user_repos_dir | default('/data/cas-management/user-repos') }}
+mgmt.enableVersionControl={{ cas_management_enable_version_control | default('false') }}
+mgmt.servicesRepo={{ cas_management_services_repo | default('/data/cas-management/services-repo') }}
+mgmt.userReposDir={{ cas_management_user_repos_dir | default('/data/cas-management/user-repos') }}
 
-server.servlet.context-path=/{{ cas_management_context_path | default('cas-management') }}
+server.context-path=/{{ cas_management_context_path | default('cas-management') }}
 server.port={{ cas_management_server_port | default(8070) }}
 server.ssl.enabled=false
 
@@ -25,20 +25,25 @@ cas.authn.attributeRepository.jdbc[0].url=jdbc:mysql://{{ cas_db_hostname | defa
 cas.authn.attributeRepository.jdbc[0].user={{cas_db_username | default('cas') }}
 cas.authn.attributeRepository.jdbc[0].password={{cas_db_password | default('password') }}
 
-#cas.serviceRegistry.mongo.sslEnabled={{ cas_services_ssl_enabled | default('false') }}
+cas.serviceRegistry.mongo.sslEnabled={{ cas_services_ssl_enabled | default('false') }}
 cas.serviceRegistry.mongo.clientUri={{ cas_services_uri | default('') }}
-cas.serviceRegistry.mongo.databaseName={{ cas_services_db | default('services') }}
-#cas.serviceRegistry.mongo.host={{ cas_services_host | default('localhost') }}
-#cas.serviceRegistry.mongo.port={{ cas_services_port | default('27017') }}
-#cas.serviceRegistry.mongo.replicaSet={{ cas_services_replica_set | default('') }}
-#cas.serviceRegistry.mongo.collection={{ cas_services_collection | default('services') }}
-#cas.serviceRegistry.mongo.authenticationDatabaseName={{ cas_services_auth_db | default('') }}
-#cas.serviceRegistry.mongo.userId={{ cas_services_username | default('cas') }}
-#cas.serviceRegistry.mongo.password={{ cas_services_password | default('password') }}
+cas.serviceRegistry.mongo.host={{ cas_services_host | default('localhost') }}
+cas.serviceRegistry.mongo.port={{ cas_services_port | default('27017') }}
+cas.serviceRegistry.mongo.replicaSet={{ cas_services_replica_set | default('') }}
+cas.serviceRegistry.mongo.collection={{ cas_services_collection | default('services') }}
+cas.serviceRegistry.mongo.databaseName={{ cas_services_db | default('cas-service-registry') }}
+cas.serviceRegistry.mongo.authenticationDatabaseName={{ cas_services_auth_db | default('') }}
+cas.serviceRegistry.mongo.userId={{ cas_services_username | default('cas') }}
+cas.serviceRegistry.mongo.password={{ cas_services_password | default('password') }}
 
-spring.session.enabled={{ spring_session_enabled | default('false') }}
 spring.session.store-type={{ spring_session_store_type | default('none') }}
-{% if spring_session_store_type == 'mongodb' %}
-spring.session.mongodb.collectionName={{ spring_session_mongo_collection | default('cas-mgmt-sessions') }}
-spring.data.mongodb.uri={{ spring_session_mongo_uri }}
+{% if spring_session_store_type == 'redis' %}
+spring.session.disable-redis-config-action={{ is_secured_redis | default('false') | bool }}
+spring.session.redis.namespace={{ cas_management_redis_namespace | default('mgmt') }}
+spring.redis.host={{ spring_session_redis_host }}
+spring.redis.password={{ spring_session_redis_password }}
+spring.redis.port={{ spring_session_redis_port | default('6379') }}
+{% if spring_session_redis_clustered | bool %}
+spring.redis.cluster.nodes= {{ spring_session_redis_host }}:{{ spring_session_redis_port | default('6379') }}
+{% endif %}
 {% endif %}

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -48,6 +48,20 @@
     dest: "{{data_dir}}/cas/config/application.yml"
     owner: cas
     group: cas
+  when: cas_version is version('6', '>=')
+  notify:
+    - restart cas
+  tags:
+    - properties
+    - cas
+
+- name: copy application.yml
+  template:
+    src: application-pre-6.yml
+    dest: "{{data_dir}}/cas/config/application.yml"
+    owner: cas
+    group: cas
+  when: cas_version is version('6', '<')
   notify:
     - restart cas
   tags:
@@ -104,8 +118,8 @@
       value: /data/cas/config/pwe.properties
     log_config_filename: 'log4j2.xml'
     service_name: "cas"
-    use_openjdk11: True
-    use_openjdk8: False
+    use_openjdk11: "{{ cas_version is version('6', '>=') }}"
+    use_openjdk8: "{{ cas_version is version('6', '<') }}"
     java_headless: true
     java_jre: true
     jar_url: '{{ cas_jar_url }}'

--- a/ansible/roles/cas5/templates/application-pre-6.yml
+++ b/ansible/roles/cas5/templates/application-pre-6.yml
@@ -1,0 +1,251 @@
+info:
+  description: ALA CAS Configuration
+server:
+  port: {{ cas_server_port | default('9000') }}
+  session:
+    timeout: {{ cas_session_timeout | default('86400') }}  # seconds, 24 hours
+  ssl:
+    enabled: false
+    key-store: 
+jndi:
+  hikari:
+    jdbccas:
+      driverClass: com.mysql.jdbc.Driver
+      url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&logger=Slf4JLogger&gatherPerfMetrics=true&logSlowQueries=true&characterEncoding=UTF-8&nullCatalogMeansCurrent=true&nullNamePatternMatchesAll=true&noAccessToProcedureBodies=true&useSSL={{mysql_connection_ssl | default(false)}}
+      user: {{ cas_db_username | default('cas') }}
+      password: {{ cas_db_password | default('password') }}
+      dataSourceProperties:
+        cachePrepStmts: true
+        prepStmtCacheSize: 250
+        prepStmtCacheSqlLimit: 2048
+flyway:
+  baselineOnMigrate: {{ cas_db_migration_baseline | default('true') }}
+  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8&nullCatalogMeansCurrent=true&nullNamePatternMatchesAll=true&noAccessToProcedureBodies=true&useSSL={{mysql_connection_ssl | default(false)}}
+  user: {{ cas_flyway_username | default('root') }}
+  password: {{ cas_flyway_password | default('password') }}
+
+logging:
+  config: "{{ log4j2_config_location | default('file:/data/cas/config/log4j2.xml') }}"
+
+cas:
+  server:
+    name: {{ cas_server_name }}
+    prefix: ${cas.server.name}/{{ cas_context_path | default('cas') }}
+  host:
+    name: {{ cas_host_name }}
+  adminPagesSecurity:
+    ip: {{ cas_admin_pages_ip | default('.*') }}
+    actuatorEndpointsEnabled: true
+  http-web-request:
+    cors:
+      enabled: {{ cas_cors_enabled | default('true')}}
+      allow-origins:
+{% for allowed_origin in cas_cors_allowed_origins | default(["'*'"]) %}
+      - {{allowed_origin}}
+{% endfor %}
+  jdbc:
+    showSql: false
+  audit:
+    mongo:
+      sslEnabled: {{ cas_audit_ssl_enabled | default('false') }}
+      clientUri: {{ cas_audit_uri | default('') }}
+      host: {{ cas_audit_host | default('localhost') }}
+      port: {{ cas_audit_port | default('27017') }}
+      replicaSet: {{ cas_audit_replica_set | default('') }}
+      databaseName: {{ cas_audit_db | default('cas-audit-repository') }}
+      authenticationDatabaseName: {{ cas_audit_auth_db | default('') }}
+      userId: {{ cas_audit_username | default('cas') }}
+      password: {{ cas_audit_password | default('password') }}
+      timeout: {{ cas_audit_timeout | default('PT5S') }}
+  authn:
+    throttle:
+      failure:
+        range-seconds: {{ cas_throttle_range | default('30') }}
+        threshold: {{ cas_throttle_threshold | default('3') }}
+    pac4j:
+      typedIdUsed: true
+      cookie:
+        crypto:
+          signing:
+            key: {{ pac4j_cookie_signing_key }}
+          encryption:
+            key: {{ pac4j_cookie_encryption_key }}
+{% if pac4j_facebook_consumer_key is defined %}
+      facebook:
+        # fields:
+        id: {{ pac4j_facebook_consumer_key }}
+        secret: {{ pac4j_facebook_consumer_secret }}
+        scope: public_profile,email
+{% endif %}
+{% if pac4j_twitter_consumer_key is defined %}
+      twitter:
+        id: {{ pac4j_twitter_consumer_key }}
+        secret: {{ pac4j_twitter_consumer_secret }}
+{% endif %}
+{% if pac4j_google_consumer_key is defined %}
+      google:
+        scope: EMAIL_AND_PROFILE
+        id: {{ pac4j_google_consumer_key }}
+        secret: {{ pac4j_google_consumer_secret }}
+{% endif %}
+{% if pac4j_github_consumer_key is defined %}
+      github:
+        id: {{ pac4j_github_consumer_key }}
+        secret: {{ pac4j_github_consumer_secret }}
+{% endif %}
+{% if pac4j_linkedin_consumer_key is defined %}
+      linkedin:
+        id: {{ pac4j_linkedin_consumer_key }}
+        secret: {{ pac4j_linkedin_consumer_secret }}
+{% endif %}
+{% if pac4j_windows_consumer_key is defined %}
+      windows:
+        id: {{ pac4j_windows_consumer_key }}
+        secret: {{ pac4j_windows_consumer_secret }}
+{% endif %}
+{% if pac4j_yahoo_consumer_key is defined %}
+      yahoo:
+        id: {{ pac4j_yahoo_consumer_key }}
+        secret: {{ pac4j_yahoo_consumer_secret }}
+{% endif %}
+{% if pac4j_aaf_consumer_key is defined %}
+      oidc:
+      - client-name: aaf
+        discovery-uri: {{ pac4j_aaf_discovery_uri | default('https://central.test.aaf.edu.au/.well-known/openid-configuration') }}
+        id: {{ pac4j_aaf_consumer_key }}
+        secret: {{ pac4j_aaf_consumer_secret }}
+        scope: openid profile email
+{% endif %}
+    oidc:
+      issuer: ${cas.server.name}/cas/oidc
+      jwksFile: file:/data/cas/keystore.jwks
+  monitor:
+    endpoints:
+      enabled: true
+    jdbc:
+      validationQuery: /* ping */ SELECT 1
+      dataSourceName: java:comp/env/jdbccas
+  serviceRegistry:
+    initFromJson: {{ serviceRegistryInitFromJson | default('true') }}
+    mongo:
+      sslEnabled: {{ cas_services_ssl_enabled | default('false') }}
+      clientUri: {{ cas_services_uri | default('') }}
+      host: {{ cas_services_host | default('localhost') }}
+      port: {{ cas_services_port | default('27017') }}
+      replicaSet: {{ cas_services_replica_set | default('') }}
+      collection: {{ cas_services_collection | default('services') }}
+      databaseName: {{ cas_services_db | default('cas-service-registry') }}
+      authenticationDatabaseName: {{ cas_services_auth_db | default('') }}
+      userId: {{ cas_services_username | default('cas') }}
+      password: {{ cas_services_password | default('password') }}
+      timeout: {{ cas_services_timeout | default('PT5S') }}
+  ticket:
+    registry:
+      cleaner:
+        schedule:
+          enabled: {{ cas_ticket_registry_cleaner_enabled | default('true') }}
+      mongo:
+        sslEnabled: {{ cas_tickets_ssl_enabled | default('false') }}
+        clientUri: {{ cas_tickets_uri | default('') }}
+        host: {{ cas_tickets_host | default('localhost') }}
+        port: {{ cas_tickets_port | default('27017') }}
+        replicaSet: {{ cas_tickets_replica_set | default('') }}
+        databaseName: {{ cas_tickets_db | default('cas-ticket-registry') }}
+        authenticationDatabaseName: {{ cas_tickets_auth_db | default('') }}
+        userId: {{ cas_tickets_username | default('cas') }}
+        password: {{ cas_tickets_password | default('password') }}
+        timeout: {{ cas_tickets_timeout | default('PT15S') }}
+    st:
+      timeToKillInSeconds: {{ cas_service_ticket_timeout | default('10') }}
+  tgc:
+    crypto:
+      enabled: false
+  webflow:
+    crypto:
+      signing:
+        key: {{ cas_webflow_signing_key }}
+      encryption:
+        key: {{ cas_webflow_encryption_key }}
+
+ala:
+  userDetailsBaseUrl: {{ userdetails_base_url }}/{{ userdetails_context_path | default('userdetails') }}/
+  cookie:
+    domain: {{ auth_cookie_domain | default('ala.org.au') }}
+    secure: {{ auth_cookie_secure | default('false') }}
+    httpOnly: {{ auth_cookie_httpOnly | default('true') }}
+    maxAge: {{ auth_cookie_maxAge | default('-1') }}
+    name: {{ auth_cookie_name | default('ALA-Auth') }}
+    path: {{ auth_cookie_path | default('/') }}
+  userCreator:
+    userCreatePassword: {{ user_create_password }}
+    enableUserSurvey: {{ show_ala_survey | default('false') }}
+    jdbc:
+      dataSourceName: java:comp/env/jdbccas
+      enableUpdateLastLoginTime: {{ cas_update_last_login | default('true') }}
+      enableRequestExtraAttributes: {{ cas_request_extra_attrs | default('true') }}
+      enableUpdateLegacyPasswords: {{ cas_update_legacy_passwords | default('true') }}
+  skin:
+    baseUrl: {{ ala_base_url | default('https://www.ala.org.au')}}
+    termsUrl: {{ terms_url | default('${ala.skin.baseUrl}/terms-of-use/') }}
+    uiVersion: {{ ala_cas_ui_version | default('2') }}
+    headerFooterUrl: {{ header_and_footer_baseurl | default('${ala.skin.baseUrl}/commonui-bs3')}}/
+    favIconBaseUrl: {{ skin_favicon_baseurl | default('${ala.skin.baseUrl}/wp-content/themes/ala-wordpress-theme/img/favicon/') }}
+    bieBaseUrl: {{ bie_base_url | default('https://bie.ala.org.au')}}
+    bieSearchPath: {{ bie_search_path | default('/search') }}
+    userDetailsUrl: {{ userdetails_base_url }}/{{ userdetails_context_path | default('userdetails') }}/
+    orgShortName: {{ orgNameShort | default('ALA') }}
+    orgLongName: {{ orgNameLong | default('Atlas of Living Australia') }}
+    orgNameKey: {{ orgNameKey | default('ala') }}
+
+# Enable these for Spring Boot actuator (required for Spring Boot Admin client)
+
+endpoints:
+  enabled: {{ endpoints_enabled }}
+security:
+  user:
+    name: {{ cas_endpoint_user | default('admin') }}
+    password: {{ cas_endpoint_password | default('secret') }}
+    role:
+      - ACTUATOR
+  basic:
+    enabled: true
+    authorizeMode: role
+    realm: ALA CAS
+    path:
+      - /status/**
+management:
+  security:
+    enabled: true
+    roles: ACTUATOR
+
+spring:
+{% if bootadmin_enabled | bool %}
+  boot:
+    admin:
+      url: {{ bootadmin_url | default('https://bootadmin.ala.org.au') }}
+      username: {{ bootadmin_username }}
+      password: {{ bootadmin_password }}
+      client:
+        enabled: true
+        service-url: "{{ bootadmin_client_base_url | default('${cas.server.name}/') }}{{ cas_context_path | default('cas') }}"
+        management-url: "{{ bootadmin_client_base_url | default('${cas.server.name}/') }}{{ cas_context_path | default('cas') }}/status"
+        name: {{ cas_bootadmin_client_name | default('ALA CAS') }}
+        metadata:
+          user:
+            name: ${security.user.name}
+            password: ${security.user.password}
+{% endif %}
+  session:
+    store-type: {{ spring_session_store_type | default('none') }}
+    {% if spring_session_store_type == 'redis' %}disable-redis-config-action: {{ is_secured_redis | default('false') | bool }}
+    redis:
+      namespace: {{ cas_redis_namespace | default('cas') }}
+  redis:
+    host: {{ spring_session_redis_host }}
+    password: {{ spring_session_redis_password }}
+    port: {{ spring_session_redis_port | default('6379') }}
+{% if spring_session_redis_clustered | bool %}
+    cluster:
+      nodes: {{ spring_session_redis_host }}:{{ spring_session_redis_port | default('6379') }}
+{% endif %}
+{% endif %}

--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -81,8 +81,8 @@
   vars:
     service_name: 'image-service'
     jar_url: '{{ image_service_jar_url }}'
-    use_openjdk11: True
-    use_openjdk8: False
+    use_openjdk11: "{{ image_service_version is version('1.1.7.1', '>') }}"
+    use_openjdk8: "{{ image_service_version is version('1.1.7.1', '<=') }}"
     java_headless: True
   tags:
     - deploy

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -1,5 +1,12 @@
 - include: ../../common/tasks/setfacts.yml 
 
+
+- name: "Show java version"
+  debug:
+    msg: "Using java versions: java8={{ use_openjdk8 }} java11={{ use_openjdk11 }}'"
+  tags:
+    - java
+
 - include: openjdk-java-8.yml
   when: use_openjdk8 is defined and use_openjdk8 | bool == True
 

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -50,6 +50,20 @@
     group: userdetails
   notify:
     - restart userdetails
+  when: user_details_version is version('3', '>=')
+  tags:
+    - properties
+    - userdetails
+
+- name: copy userdetails-config.yml
+  template:
+    src: userdetails-config-pre-3.yml
+    dest: "{{data_dir}}/userdetails/config/userdetails-config.yml"
+    owner: userdetails
+    group: userdetails
+  notify:
+    - restart userdetails
+  when: user_details_version is version('3', '<')
   tags:
     - properties
     - userdetails
@@ -72,8 +86,8 @@
   vars:
     service_name: "userdetails"
     jar_url: '{{ userdetails_jar_url }}'
-    use_openjdk11: True
-    use_openjdk8: False
+    use_openjdk11: "{{ user_details_version is version('3', '>=') }}"
+    use_openjdk8: "{{ user_details_version is version('3', '<') }}"
     java_headless: true
     java_jre: true
     log_config_filename: logback.xml

--- a/ansible/roles/userdetails/templates/userdetails-config-pre-3.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config-pre-3.yml
@@ -1,0 +1,174 @@
+# CAS Config
+security:
+  cas:
+    casServerName: {{ cas_server_name }}
+    casServerUrlPrefix: ${security.cas.casServerName}/{{ cas_context_path | default('cas') }}
+    loginUrl: ${security.cas.casServerUrlPrefix}/login
+    logoutUrl: ${security.cas.casServerUrlPrefix}/logout
+    appServerName: {{ userdetails_server_name }}
+    authCookieName: {{ auth_cookie_name | default('ALA-Auth') }}
+  user:
+    name: {{ userdetails_endpoint_user | default('admin') }}
+    password: {{ userdetails_endpoint_password | default('secret') }}
+    role:
+      - ACTUATOR
+  basic:
+    enabled: true
+    authorizeMode: role
+    realm: ALA CAS
+    path:
+      - /status/**
+endpoints:
+  enabled: {{ endpoints_enabled | default('true') }}
+  health:
+    sensitive: false
+management:
+  security:
+    enabled: true
+    roles: ACTUATOR
+{% if spring_session_store_type == 'redis' %}
+  health:
+    redis:
+      enabled: true
+{% endif %}
+
+serverURL: {{ userdetails_server_name }}
+serverName: {{ userdetails_server_name }}
+grails:
+  serverURL: {{ userdetails_server_name }}/{{ userdetails_context_path | default('userdetails') }}
+server:
+  port: {{ userdetails_port | default('9001') }}
+  contextPath: /{{ userdetails_context_path  | default('userdetails') }}
+redirectAfterFirstLogin: ${grails.serverURL}/myprofile
+
+# Data source configuration
+dataSource:
+  dbCreate: "none"
+  url: jdbc:mysql://{{ cas_db_hostname | default('localhost') }}:{{ cas_db_port | default('3306') }}/{{ cas_db_name | default('emmet') }}?serverTimezone={{ server_tz | default('Australia/Sydney') }}&zeroDateTimeBehavior=convertToNull&characterEncoding=UTF-8&useSSL={{mysql_connection_ssl | default(false)}}
+  username: {{ userdetails_db_username | default(cas_db_username) | default('cas') }}
+  password: {{ userdetails_db_password | default(cas_db_password) | default('password') }}
+
+oauth:
+  providers:
+{% if oauth_providers_flickr_enabled | default('true') | bool %}
+    flickr:
+      enabled: true
+      key: {{ oauth_providers_flickr_key }}
+      secret: {{ oauth_providers_flickr_secret }}
+      callback: ${grails.serverURL}/profile/flickrCallback
+{% endif %}
+{% if oauth_providers_inaturalist_enabled | default('false') | bool %}
+    inaturalist:
+      enabled: true
+      key: {{ oauth_providers_inaturalist_key | default('DISABLED') }}
+      secret: {{ oauth_providers_inaturalist_secret | default('DISABLED') }}
+      callback: ${grails.serverURL}/profile/inaturalistCallback
+inaturalist:
+  name: {{ inaturalist_name | default('iNaturalist Australia') }}
+  baseUrl: {{ inaturalist_base_url | default('https://inaturalist.ala.org.au/') }}
+{% endif %}
+password:
+  encoder: {{ user_store_db_encoder | default('bcrypt') }} # or legacy
+bcrypt:
+  strength: {{ user_store_db_bcrypt_strength | default('10') }}
+#encoding:
+#  algorithm: {{ user_store_db_encoding_algorithm }}
+#  salt: {{ user_store_db_encoding_salt }}
+
+registration:
+  showAlaMessage: {{ show_ala_message | default('false') }}
+  resetPasswordArticle: {{ reset_password_article | default('') }}
+  alertArticle: {{ alert_article | default('') }}
+  activationArticle: {{ activation_article | default('') }}
+
+recaptcha:
+  baseUrl: {{ recaptcha_base_url | default('https://www.google.com/recaptcha/api/') }}
+  siteKey: {{ userdetails_recaptcha_site_key | default('') }}
+  secretKey: {{ userdetails_recaptcha_secret_key | default('') }}
+
+ala:
+  baseURL: {{ ala_base_url | default('https://www.ala.org.au') }}
+
+supportEmail: {{ support_email | default('support@ala.org.au') }}
+homeUrl: {{ ala_base_url | default('https://www.ala.org.au') }}
+homeLogoUrl: {{ ala_logo_url | default('https://www.ala.org.au/app/uploads/2020/06/ALA_Logo_Inline_RGB-300x63.png') }}
+mainTitle: {{ orgNameLong | default('Atlas of Living Australia') }}
+emailSenderTitle: {{ orgNameLong | default('Atlas of Living Australia') }}
+emailSender: {{ support_email | default('support@ala.org.au') }}
+
+sightings.url: {{ sightings_base_url }}
+spatial.url: {{ spatial_base_url }}?tool=log
+volunteer.url: {{ volunteer_base_url }}/user/myStats
+lists.url: {{ lists_base_url }}/speciesList/list
+biocache.search.baseUrl: {{ biocache_base_url }}/occurrences/search
+biocache.search.url: {{ biocache_base_url }}/occurrences/search/?q=*%3A*&fq=assertion_user_id%3A
+biocache.myDownloads.url: {{ biocache_base_url }}/download/myDownloads/
+myData.url: {{ sandbox_base_url }}/tempDataResource/myData
+alerts.url: {{ alerts_base_url }}
+
+# this property is read/used by ala-auth-plugin (included by userdetails)
+userDetails:
+  url: {{ userdetails_base_url }}/{{ userdetails_context_path | default('userdetails') }}/
+
+# Header and footer
+headerAndFooter:
+  baseURL: {{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3')}}
+  version: {{ header_and_footer_version | default('1')}}
+ala.baseURL: {{ ala_base_url | default('https://www.ala.org.au')}}
+bie.baseURL: {{ bie_base_url | default('https://bie.ala.org.au')}}
+bie.searchPath: {{ bie_search_path | default('/search') }}
+
+# Skin options
+skin.layout: {{ (userdetails_skin_layout | default(skin_layout)) | default('ala-main') }}
+skin.fluidLayout: {{ skin_fluid_layout | default('false') }}
+skin.orgNameLong: {{ orgNameLong | default('Atlas of Living Australia') }}
+skin.orgNameShort: {{ orgNameShort | default('ALA') }}
+skin.favicon: {{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon-16x16.png') }}
+skin.homeUrl: {{ skin_home_url | default('http://www.ala.org.au') }}
+
+attributes:
+    affiliations:
+      enabled: {{ show_ala_survey | default('false') }}
+
+# API key for external apps
+webservice.apiKey: {{ api_key }}
+
+# show api link
+apiKey.showLink: {{ api_key_show_link | default('false') }}
+apiKey.showSecret: {{ api_key_show_secret | default('false') }}
+
+# Default primary fields for Export to CSV functionality
+admin.export.csv.primary.fields: {{ admin_export_csv_primary_fields | default('id,userName,firstName,lastName,email,activated,locked,created')}}
+
+spring:
+{% if bootadmin_enabled | bool %}
+  boot:
+    admin:
+      url: {{ bootadmin_url | default('https://bootadmin.ala.org.au') }}
+      username: {{ bootadmin_username }}
+      password: {{ bootadmin_password }}
+      client:
+        enabled: true
+        service-url: {{ bootadmin_client_base_url | default('${serverURL}/') }}{{ userdetails_context_path | default('userdetails') }}
+        management-url: {{ bootadmin_client_base_url | default('${serverURL}/') }}{{ userdetails_context_path | default('userdetails') }}/status
+        name: {{ userdetails_bootadmin_client_name | default('User Details') }}
+        metadata:
+          user:
+            name: ${security.user.name}
+            password: ${security.user.password}
+{% endif %}
+  session:
+    store-type: {{ spring_session_store_type | default('none') }}
+    {% if spring_session_store_type == 'redis' %}disable-redis-config-action: {{ is_secured_redis | default('false') | bool }}
+    redis:
+      namespace: {{ userdetails_redis_namespace | default('userdetails') }}
+  redis:
+    host: {{ spring_session_redis_host }}
+    password: {{ spring_session_redis_password }}
+    port: {{ spring_session_redis_port | default('6379') }}
+{% if spring_session_redis_clustered | bool %}
+    cluster:
+      nodes: {{ spring_session_redis_host }}:{{ spring_session_redis_port | default('6379') }}
+{% endif %}
+{% endif %}
+privacyPolicy:{{ privacy_policy_url | default('https://www.ala.org.au/about/terms-of-use/privacy-policy/') }}

--- a/ansible/roles/userdetails/vars/main.yml
+++ b/ansible/roles/userdetails/vars/main.yml
@@ -2,7 +2,7 @@
 version: "{{ user_details_version | default('LATEST') }}"
 artifactId: "userdetails"
 classifier: 'exec'
-packaging: "war"
+packaging: "{{ (user_details_version is version('3', '>=')) | ternary('war', 'jar') }}"
 groupId: "au.org.ala"
 userdetails_jar_url: "{{maven_repo_ws_url}}"
 


### PR DESCRIPTION
This PR allows to still install previous versions of CAS with ala-install. For that:

1. we require the install of java 11 (or 8) depending on each component version
1. we use previous ala-install (2.1.9) configurations of each cas components for that versions and new configurations for recent versions
1. we use jar of wars also depending of the version 

I'm not sure of this PR. I started to do point 1) and continued with the rest. Feel free to reject it.
 