### PR TITLE
userdetails url configurable. Re-enable logging

### DIFF
--- a/ansible/roles/spatial-service/templates/spatial-service-config.yml
+++ b/ansible/roles/spatial-service/templates/spatial-service-config.yml
@@ -180,3 +180,14 @@ grails.controllers.upload.maxRequestSize: {{ max_request_size | default(52428800
 # Needed for map exports
 google:
   apikey: "{{ google_api_key | default('') }}"
+
+logging:
+  level:
+    root: INFO
+
+userdetails:
+    baseUrl: "{{ user_details_base_url | default('https://auth.ala.org.au/userdetails') }}"
+
+# ala-auth-plugin conf
+userDetails:
+    url: {{ auth_base_url }}/userdetails/


### PR DESCRIPTION
In this PR:

- I reenable logging (see https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1660658827331449)
- I allow to customize the `userdetails` urls