### PR TITLE
Revert "postgresql versions moved to common facts"

### DIFF
--- a/ansible/data_quality_filter_service.yml
+++ b/ansible/data_quality_filter_service.yml
@@ -3,7 +3,7 @@
     - common
     - java
     - {role: db-backup, db: postgres, db_name: "{{ dq_db_name }}", db_user: "{{ dq_db_user }}", db_password: "{{ dq_db_password }}" }
-    - postgresql
+    - {role: postgresql, pg_version: "{{ data_quality_pg_version | default('13') }}"}
     - {role: pg_instance, extensions: [], db_name: "{{ dq_db_name }}", db_user: "{{ dq_db_user }}", db_password: "{{ dq_db_password }}" }
     - tomcat
     - webserver

--- a/ansible/doi-service-standalone.yml
+++ b/ansible/doi-service-standalone.yml
@@ -4,7 +4,7 @@
     - java
     - postfix
     - {role: db-backup, db: postgres, db_name: "{{ doi_db_name }}", db_user: "{{ doi_db_user }}", db_password: "{{ doi_db_password }}" }
-    - postgresql
+    - {role: postgresql, pg_version: "9.6"}
     - {role: pg_instance, extensions: ["citext", "pgcrypto"], db_name: "{{ doi_db_name }}", db_user: "{{ doi_db_user }}", db_password: "{{ doi_db_password }}" }
     - {role: ansible-elasticsearch, es_templates: false,  es_instance_name: 'doi-elasticsearch', es_data_dirs: ['/data/elasticsearch'], tags: ['elasticsearch']}
     - webserver

--- a/ansible/image-service.yml
+++ b/ansible/image-service.yml
@@ -1,12 +1,10 @@
 - hosts: image-service
-  vars:
-    use_postgis: true
   roles:
     # - java
     - common
     - { role: ansible-elasticsearch, es_templates: false,  es_instance_name: 'images', tags: ['elasticsearch']}
     - { role: db-backup, db: postgres, db_name: "images", db_user: "{{ image_service_db_username }}", db_password: "{{ image_service_db_password }}" }
-    - postgresql
+    - { role: postgresql, pg_version: "{{ image_service_postgresql_version | default('10') }}", postgis_version: "{{ image_service_postgis_version | default('2.4') }}" }
     - { role: pg_instance, extensions: ["citext", "pgcrypto"], db_name: "{{ image_service_db_name }}", db_user: "{{ image_service_db_username }}", db_password: "{{ image_service_db_password }}", db_role_attr_flags: "NOSUPERUSER" }
     - webserver
     - i18n

--- a/ansible/phylolink.yml
+++ b/ansible/phylolink.yml
@@ -1,6 +1,4 @@
 - hosts: phylolink
-  vars:
-    use_postgis: true
   roles:
     - phylolink-dependencies
     - common

--- a/ansible/roles/common/tasks/setfacts.yml
+++ b/ansible/roles/common/tasks/setfacts.yml
@@ -87,9 +87,6 @@
     python_software_properties: "python3-software-properties"
     tomcat_dir: "/var/lib/{{ tomcat }}"
     tomcat_webapps: "/var/lib/{{ tomcat }}/webapps/"
-    pg_version: '9.6'
-    postgis_version: '2.4'
-    postgis_scripts_version: '2.4'
 # openjdk-8 will be removed at some point from Ubuntu-18.04, so we will need to switch to Zulu-8 or similar at that point
 # openjdk-lts on Ubuntu-18.04 is JDK-11, so will not be directly useful by our applications at this point due to lack of testing
 #    use_openjdk8: true
@@ -127,9 +124,6 @@
     python_software_properties: "python3-software-properties"
     tomcat_dir: "/var/lib/{{ tomcat }}"
     tomcat_webapps: "/var/lib/{{ tomcat }}/webapps/"
-    pg_version: '10'
-    postgis_version: '2.5'
-    postgis_scripts_version: '2.5'
 # openjdk-8 will be removed at some point from Ubuntu-18.04, so we will need to switch to Zulu-8 or similar at that point
 #    use_openjdk8: true
 #    use_zulu8: False
@@ -167,9 +161,6 @@
     tomcat_dir: "/var/lib/{{ tomcat }}"
     tomcat_webapps: "/var/lib/{{ tomcat }}/webapps/"
     psycopg2_package: "python3-psycopg2"
-    pg_version: '14'
-    postgis_version: '3'
-    postgis_scripts_version: '3.2'
   when: ansible_os_family == "Debian" and ansible_distribution_version == "22.04"
   tags:
     - setfacts

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,1 +1,0 @@
-install_postgis: "{{ use_postgis | default(False) }}"

--- a/ansible/roles/postgresql/tasks/debian.yml
+++ b/ansible/roles/postgresql/tasks/debian.yml
@@ -14,7 +14,7 @@
 - name: Set postgis package names
   set_fact:
     postgresql_packages: "{{postgresql_packages}} + [ 'postgresql-{{pg_version}}-postgis-{{postgis_version}}', 'postgresql-{{pg_version}}-postgis-{{postgis_version}}-scripts', 'gdal-bin' ]"
-  when: postgis_version is defined and install_postgis | bool == True
+  when: postgis_version is defined
   tags: postgresql
 
 - name: Install Postgres
@@ -55,7 +55,7 @@
 # Not pulling in recommended packages as that would pull in postgres-10
 - name: Install separate postgis package to get shp2pgsql binary
   apt: pkg="postgis" state="present" update_cache="yes" install_recommends="no"
-  when: postgis_version is defined and install_postgis | bool == True
+  when: postgis_version is defined
   tags:
     - postgresql
   register: postgresql_installed
@@ -65,7 +65,7 @@
 # PostGIS 2.2+ only needs CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology; etc on the target DB
 - debug:
     msg: "PostGIS-enabled databases also need a corresponding pg_instance role with postgis in the extensions list"
-  when: postgis_version is defined and install_postgis | bool == True
+  when: postgis_version is defined
 
 - name: start postgresql and configure to startup automatically
   service:

--- a/ansible/roles/postgresql/tasks/postgis.yml
+++ b/ansible/roles/postgresql/tasks/postgis.yml
@@ -1,15 +1,8 @@
-- name: "Show postgis version"
-  debug:
-    msg: "postgis version: {{ postgis_version }} and installing postgis: {{ install_postgis }}"
-  tags:
-    - postgresql
-    - postgis
-
 - name: install setfacl support
   become: yes
   apt:
     pkg: acl
-  when: postgis_version and install_postgis | bool == True
+  when: postgis_version
   tags:
     - postgresql
     - postgis
@@ -31,7 +24,7 @@
   postgresql_db:
     db: postgis_template
     state: present
-  when: postgis_version and install_postgis | bool == True
+  when: postgis_version
   become: yes
   become_user: postgres
   tags:
@@ -40,7 +33,7 @@
 
 - name: make postgis_template a template
   action: command psql -d postgis_template -c "UPDATE pg_database SET datistemplate=true WHERE datname='postgis_template';"
-  when: postgis_version and install_postgis | bool == True
+  when: postgis_version
   become: yes
   become_user: postgres
   tags:
@@ -49,13 +42,13 @@
 
 - name: run the postgis SQL scripts
   action: command psql -d postgis_template -f {{ item }}
-  when: postgis_version and install_postgis | bool == True
+  when: postgis_version
   become: yes
   become_user: postgres
   with_items:
-    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_scripts_version}}/postgis.sql"
-    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_scripts_version}}/spatial_ref_sys.sql"
-    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_scripts_version}}/postgis_comments.sql"
+    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_version}}/postgis.sql"
+    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_version}}/spatial_ref_sys.sql"
+    - "/usr/share/postgresql/{{pg_version}}/contrib/postgis-{{postgis_version}}/postgis_comments.sql"
   tags:
     - postgresql
     - postgis

--- a/ansible/spatial.yml
+++ b/ansible/spatial.yml
@@ -1,13 +1,11 @@
 - name: spatial
   hosts: spatial
-  vars:
-    use_postgis: true
   roles:
     - common
     - java
     - tomcat
     - webserver
-    - postgresql
+    - {role: postgresql, pg_service: 'postgresql-9.6', pg_version: '9.6', postgis_version: '2.4'}
     - {role: pg_instance, extensions: ['postgis', 'postgis_topology', 'uuid-ossp'], db_name: "{{geonetwork_database}}", db_user: "{{geonetwork_db_username}}", db_password: "{{geonetwork_db_password }}" }
     - {role: pg_instance, extensions: ['postgis', 'postgis_topology', 'uuid-ossp'], db_name: "{{layers_db_name}}", db_user: "{{layers_db_username}}", db_password: "{{layers_db_password}}" }
     - layers-db


### PR DESCRIPTION
Reverts AtlasOfLivingAustralia/ala-install#600

This change forced installation of different postgres versions than were already installed and is not backwards compatible, needs to be reworked so postgres version isn't defined via set facts which has higher priority than basically everything else. 