### PR TITLE
Default userdetails values

### DIFF
--- a/ansible/roles/userdetails/templates/userdetails-config.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config.yml
@@ -12,8 +12,8 @@ security:
     # authCookieName: {{ auth_cookie_name | default('ALA-Auth') }}
   oidc:
     enabled: {{ userdetails_use_oidc | default('false') }}
-    client-id: {{ userdetails_oidc_client_id }}
-    secret: {{ userdetails_oidc_secret }}
+    client-id: {{ userdetails_oidc_client_id | default('') }}
+    secret: {{ userdetails_oidc_secret| default('') }}
     discovery-uri: {{ cas_server_name }}/{{ cas_context_path}}/oidc/.well-known
   jwt:
     enabled: {{ userdetails_jwt_enabled | default('false') }}


### PR DESCRIPTION
Set default empty values (as other roles) to prevent:

```
TASK [copy userdetails-config.yml] *************************************************************************************
fatal: [gbif-es-auth-2022]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'userdetails_oidc_client_id' is undefined"}
```