### PR TITLE
Conditional packaging war/jar in doi

### DIFF
--- a/ansible/roles/doi-service/vars/main.yml
+++ b/ansible/roles/doi-service/vars/main.yml
@@ -3,5 +3,5 @@ version: "{{ doi_service_version | default('LATEST') }}"
 artifactId: "doi-service"
 classifier: 'exec'
 groupId: "au.org.ala"
-packaging: "war"
+packaging: "{{ (doi_service_version is version('2', '>=')) | ternary('war', 'jar') }}"
 doi_service_jar_url: "{{maven_repo_ws_url}}"


### PR DESCRIPTION
PR to avoid errors like this one trying to install `doi-service` < `2.0`:

> TASK [exec-jar : Download doi-service JAR] *************************************
Thursday 15 September 2022  13:17:20 +0200 (0:00:00.742)       0:04:04.207 **** 
fatal: [ala-install-test-3]: FAILED! => {"changed": false, "msg": "Failed to download artifact au.org.ala:doi-service:war:exec:1.1.5 because of HTTP Error 404: Not Foundfor URL https://nexus.ala.org.au/content/groups/public/au/org/ala/doi-service/1.1.5/doi-service-1.1.5-exec.war"}
