### PR TITLE
Externalize some userdetails variables for non-ALA portals

### DIFF
--- a/ansible/roles/userdetails/templates/userdetails-config.yml
+++ b/ansible/roles/userdetails/templates/userdetails-config.yml
@@ -98,9 +98,9 @@ bcrypt:
 
 registration:
   showAlaMessage: {{ show_ala_message | default('false') }}
-  resetPasswordArticle: {{ reset_password_article | default('') }}
-  alertArticle: {{ alert_article | default('') }}
-  activationArticle: {{ activation_article | default('') }}
+  resetPasswordArticle: {{ reset_password_article | default('https://support.ala.org.au/support/solutions/articles/6000194958-my-username-password-isn-t-working-or-i-can-t-remember-my-username-password') }}
+  alertArticle: {{ alert_article | default('https://support.ala.org.au/support/solutions/articles/6000195858-how-do-i-manage-email-alerts-from-the-ala') }}
+  activationArticle: {{ activation_article | default('https://support.ala.org.au/support/solutions/articles/6000195196-i-created-an-account-but-did-not-receive-the-account-activation-email') }}
 
 recaptcha:
   baseUrl: {{ recaptcha_base_url | default('https://www.google.com/recaptcha/api/') }}
@@ -199,4 +199,15 @@ spring:
       nodes: {{ spring_session_redis_host }}:{{ spring_session_redis_port | default('6379') }}
 {% endif %}
 {% endif %}
+
+# Allow to disable some tools for non-ALA Portals
+myProfile:
+  useDigiVol: {{ use_digivol | default('true') }}
+  useSandbox: {{ use_sandbox | default('true') }}
+  useBiocollect: {{ use_biocollect | default('true') }}
+
 privacyPolicy: {{ privacy_policy_url | default('https://www.ala.org.au/about/terms-of-use/privacy-policy/') }}
+termsOfUse: {{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}
+
+openapi:
+  terms: {{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}


### PR DESCRIPTION
This PR externalize some variables to allow proper configuration of support and legal articles.

It also includes these variables (a PR not yet merged but quite safe):
https://github.com/AtlasOfLivingAustralia/userdetails/pull/135