### PR TITLE
Externalize cas logo image

### DIFF
--- a/ansible/roles/cas5/templates/application.yml
+++ b/ansible/roles/cas5/templates/application.yml
@@ -235,6 +235,7 @@ ala:
     orgShortName: {{ orgNameShort | default('ALA') }}
     orgLongName: {{ orgNameLong | default('Atlas of Living Australia') }}
     orgNameKey: {{ orgNameKey | default('ala') }}
+    loginLogo: {{ loginLogo | default('https://auth.ala.org.au/cas/images/supporting-graphic-element-flat-medium.png') }}
 
 # Enable these for Spring Boot actuator (required for Spring Boot Admin client)
 


### PR DESCRIPTION
Externalize the logo variable ot the PR https://github.com/AtlasOfLivingAustralia/ala-cas-5/pull/30

With this others can easily set this logo:

![image](https://user-images.githubusercontent.com/180085/190669065-e7e71c4e-8314-450c-bb9f-5c769898b363.png)
