### PR TITLE
Allow configure some extra variables in collectory for non-ALA portals

### DIFF
--- a/ansible/roles/collectory/templates/config/collectory-config.properties
+++ b/ansible/roles/collectory/templates/config/collectory-config.properties
@@ -93,6 +93,7 @@ skin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}
 skin.orgNameLong={{ orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort={{ orgNameShort | default('Atlas') }}
 skin.favicon={{ skin_favicon | default('https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png') }}
+skin.orgSupportEmail={{ orgSupportEmail | default('support@ala.org.au') }}
 orgNameLong={{ orgNameLong | default('Atlas of Living Australia') }}
 
 # Header and footer
@@ -157,11 +158,19 @@ citation.rights.template = {{ citation_rights_template | default('') }}
 citation.link.template = {{ citation_link_template | default('For more information: @link@') }}
 suitableFor = {{ collection_suitable_for | default('[{"spListNational":"Species list national"}, {"spListState": "Species list state"}, {"spListGreaterThan1000": "Species list >1000km radius"}, {"spList100to1000": "Species list 100-1000km radius"}, {"spList10to100":"Species list 10k to 100km radius"}, {"spListLessThan10":"Species list <10km radius"}, {"speciesDistribution":"Defining a species distribution"}, {"quantifyAbundance":"Quantifying abundance at a point in time"}, {"quantifyChange": "Quantifying change over time"}, {"other":"Other"}]')}}
 
-
-#oidc related
+# oidc related
 security.cas.enabled={{ collectory_cas_enabled | default(true) }}
 security.oidc.enabled={{ collectory_oidc_enabled | default(false) }}
 security.oidc.clientId={{ clientId | default('') }}
 security.oidc.secret={{ secret | default('') }}
 security.oidc.discoveryUri={{ discoveryUri | default('') }}
+security.oidc.discovery-uri={{ discoveryUri | default('') }}
 security.jwt.discoveryUri={{ discoveryUri | default('') }}
+
+# openapi
+openapi.components.security.oauth2.authorizationUrl={{ auth_base_url }}/cas/oidc/authorize
+openapi.components.security.oauth2.baseUrl={{ auth_base_url }}/cas/oidc
+openapi.components.security.oauth2.refreshUrl={{ auth_base_url }}/cas/oidc/refresh
+openapi.components.security.oauth2.tokenUrl={{ auth_base_url }}/cas/oidc/token
+openapi.terms={{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}
+openapi.contact.email={{ orgSupportEmail | default('support@ala.org.au') }}


### PR DESCRIPTION
With this PR we can configure some variables for other portals to avoid the default `ala.org.au` domain:

![image](https://user-images.githubusercontent.com/180085/193046763-d5dbccf3-829c-4d5d-a33d-9e115fbd108c.png)
