### PR TITLE
copying apiKey to bioache-service requets headers when jwt_enabled i…

### DIFF
--- a/ansible/roles/biocache3-service/tasks/main.yml
+++ b/ansible/roles/biocache3-service/tasks/main.yml
@@ -358,6 +358,7 @@
       - path: "{{biocache_service_context_path}}"
         sort_label: "9_ws"
         is_proxy: true
+        inject_api_key: "{{ jwt_auth_enabled }}"
         use_cache: false
         force_cache: false
         unlimited_conns: true

--- a/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
@@ -140,6 +140,13 @@ try_files {{ item.try_files }};
 {% else %}
         try_files {{ item.try_files }};
 {% endif %}
+{% if item.inject_api_key is defined and item.inject_api_key | bool == True %}
+        set $defaultKeyValue "";
+        if ($arg_apikey) {
+            set $defaultKeyValue $arg_apikey;
+        }
+        proxy_set_header apiKey $defaultKeyValue; 
+{% endif %}
 {% if item.location_includes is defined and item.location_includes|length > 0 %}
 {% for next_location_include in item.location_includes %}
         include {{ next_location_include }};


### PR DESCRIPTION
…s true for backwards compatibility with legacy usages of apiKey in url params