### PR TITLE
OIDC extra variables for bie. More configurable urls

### DIFF
--- a/ansible/roles/bie-hub/defaults/main.yml
+++ b/ansible/roles/bie-hub/defaults/main.yml
@@ -40,6 +40,7 @@ namematching_service_url: https://namematching-ws.ala.org.au
 profile_service_url: https://profiles-ws.ala.org.au/
 regions_url: https://regions.ala.org.au
 scholar_url: https://scholar.google.com
+google_url: https://www.google.com.au
 sightings_url: https://sightings.ala.org.au/
 skin_favicon: https://www.ala.org.au/app/uploads/2019/01/cropped-favicon-32x32.png
 skin_fluid_layout:

--- a/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
@@ -176,3 +176,5 @@ dataquality:
   baseUrl: {{ data_quality_profiles_url | default('https://dataquality.ala.org.au/data-profiles') }}
 
 speciesParent : {{ specieslist_iconic_species_url | default('https://lists.ala.org.au/iconic-species') }}
+
+supportEmail: {{ support_email | default('support@ala.org.au') }}

--- a/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
@@ -17,9 +17,11 @@ security:
     contextPath: {{ bie_hub_context_path }}
     bypass: {{ bypass_cas  }}
     applyUriFiltersToTicketValidation: false
+    enabled: {{ security_cas_enabled | default(false) }}
   oidc:
-    clientId: {{ clientId | default('') }}
-    secret: {{ secret | default('') }}
+    enabled: {{ security_oidc_enabled | default(true) }}
+    clientId: {{ (bie_hub_clientId | default(clientId)) | default('') }}
+    secret: {{ (bie_hub_secret | default(secret)) | default('') }}
     discoveryUri: {{ discoveryUri | default('') }}
   jwt:
     discoveryUri: {{ discoveryUri | default('') }}
@@ -53,6 +55,7 @@ ala:
   image:
     service:
       url: {{ image_service_url }}
+imageServiceBaseUrl: {{ image_service_url }}
 allowedImageEditingRoles: {{ allowed_image_editing_roles }}
 
 # Skin and layout
@@ -84,6 +87,7 @@ spatial:
   baseURL: {{ spatial_base_url | default(spatial_url) }}
 collectory:
   baseURL: {{ collectory_url }}
+  threatenedSpeciesCodesUrl: {{ collectory_url }}/public/showDataResource
 speciesList:
   baseURL: {{ species_list_url }}
   preferredSpeciesListDruid: {{ specieslist_preferredDruid }}
@@ -168,3 +172,7 @@ eol:
 namematching:
   serviceURL: {{ namematching_service_url }}
 
+dataquality:
+  baseUrl: {{ data_quality_profiles_url | default('https://dataquality.ala.org.au/data-profiles') }}
+
+speciesParent : {{ specieslist_iconic_species_url | default('https://lists.ala.org.au/iconic-species') }}

--- a/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
@@ -120,6 +120,8 @@ literature:
     url: {{ genbank_url  }}
   scholar:
     url: {{ scholar_url }}
+  google:
+    url: {{ google_url }}
   trove:
     url: {{ trove_url }}
     api: {{ trove_service_url  }}

--- a/ansible/roles/bie-index/templates/bie-index-config.yml
+++ b/ansible/roles/bie-index/templates/bie-index-config.yml
@@ -15,9 +15,11 @@ security:
     logoutUrl:   {{ auth_cas_url }}/logout
     contextPath:   {{ bie_index_context_path }}
     bypass:   {{ bypass_cas | default(true) }}
+    enabled: {{ security_cas_enabled | default(false) }}
   oidc:
-    clientId: {{ clientId | default('') }}
-    secret: {{ secret | default('') }}
+    enabled: {{ security_oidc_enabled | default(true) }}
+    clientId: {{ (bie_index_clientId | default(clientId)) | default('') }}
+    secret: {{ (bie_index_secret | default(secret)) | default('') }}
     discoveryUri: {{ discoveryUri | default('') }}
   jwt:
     discoveryUri: {{ discoveryUri | default('') }}
@@ -123,3 +125,11 @@ ala:
 bie:
   baseURL: {{ bie_base_url | default('https://bie.ala.org.au') }}
   searchPath: {{ bie_search_path | default('/search') }}
+openapi:
+  components:
+    security:
+      oauth2:
+        baseUrl: {{ auth_cas_url }}/oidc
+        authorizationUrl: {{ auth_cas_url }}/oidc/authorize
+        refreshUrl: {{ auth_cas_url }}/oidc/refresh
+        tokenUrl: {{ auth_cas_url }}/oidc/token


### PR DESCRIPTION
This PR externalize some extra url variables and then they can be configured by other LA portals (see ala.org.au variables):

![image](https://user-images.githubusercontent.com/180085/207697348-f5866d15-d7fd-4745-b793-654e356d5495.png)
![image](https://user-images.githubusercontent.com/180085/207697351-5a0ac371-a224-46e6-b697-1a85ddf80023.png)

Also allow to fine tune OIDC and related variables.
