### PR TITLE
biocache oidc related variables

### DIFF
--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -235,6 +235,10 @@ doi.mintDoi={{ doi_mint_doi | default('false') }}
 endpoints.enabled=false
 
 # oidc related
-security.oidc.clientId={{ clientId | default('') }}
-security.oidc.secret={{ secret | default('') }}
+security.cas.enabled={{ security_cas_enabled | default(false) }}
+security.oidc.enabled={{ security_oidc_enabled | default(true) }}
+security.oidc.clientId={{ (ala_hub_clientId | default(clientId)) | default('') }}
+security.oidc.secret={{ (ala_hub_secret | default(secret)) | default('') }}
 security.oidc.discoveryUri={{ discoveryUri | default('') }}
+
+info.app.description={{ info_app_description | default('Atlas of Living Australia') }}

--- a/ansible/roles/biocache3-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache3-properties/templates/biocache-config.properties
@@ -462,7 +462,7 @@ sensitiveAccessRoles20={{ sensitive_access_roles | default('{}') }}
 
 security.jwt.enabled={{ jwt_auth_enabled | default('false') }}
 security.jwt.discovery-uri={{ oidc_discovery_url }}
-security.jwt.clientId={{ oidc_client_id }}
+security.jwt.clientId={{ (biocache_client_id | default(oidc_client_id)) | default('') }}
 
 security.apikey.enabled={{ apikey_check_enabled | default('false') }}
 security.apiKey.auth.serviceUrl = {{ apikey_auth_url }}


### PR DESCRIPTION
- Added new oidc related variables to `ala-hub` and `biocache-service` roles.
- Added extra named secret/clientId variables for LA portals with single inventories.