### PR TITLE
data-quality-filter-service oidc and other variables

### DIFF
--- a/ansible/roles/data_quality_filter_service/templates/config/config.properties
+++ b/ansible/roles/data_quality_filter_service/templates/config/config.properties
@@ -68,13 +68,24 @@ dataSource.url={{ dq_db_url | default('jdbc:postgresql://localhost/data-quality'
 dataSource.dialect={{ dq_db_dialect | default('org.hibernate.dialect.PostgreSQLDialect') }}
 dataSource.driverClassName={{ dq_db_driver | default('org.postgresql.Driver') }}
 
-#oidc related
-security.oidc.clientId={{ clientId | default('') }}
-security.oidc.secret={{ secret | default('') }}
+# oidc related
+security.cas.enabled={{ security_cas_enabled | default(true) }}
+security.oidc.enabled={{ security_oidc_enabled | default(false) }}
+security.oidc.clientId={{ (dq_service_clientId | default(clientId)) | default('') }}
+security.oidc.secret={{ (dq_service_secret | default(secret)) | default('') }}
 security.oidc.discoveryUri={{ discoveryUri | default('') }}
+security.jwt.discoveryUri={{ discoveryUri | default('') }}
 
 # swagger configuration
-swagger.termsOfServices: "{{ swagger_info_terms_of_services | default('https://www.ala.org.au/who-we-are/terms-of-use/') }}"
-swagger.contact.name:  "{{ swagger_contact_name | default('ALA Support') }}"
-swagger.contact.url: "{{ swagger_contact_url | default('https://www.ala.org.au') }}"
-swagger.contact.email: "{{ swagger_contact_email | default('support@ala.org.au') }}"
+swagger.termsOfServices="{{ swagger_info_terms_of_services | default('https://www.ala.org.au/who-we-are/terms-of-use/') }}"
+swagger.contact.name="{{ swagger_contact_name | default('ALA Support') }}"
+swagger.contact.url="{{ swagger_contact_url | default('https://www.ala.org.au') }}"
+swagger.contact.email="{{ swagger_contact_email | default('support@ala.org.au') }}"
+
+# openapi
+openapi.components.security.oauth2.authorizationUrl={{ auth_base_url }}/cas/oidc/authorize
+openapi.components.security.oauth2.baseUrl={{ auth_base_url }}/cas/oidc
+openapi.components.security.oauth2.refreshUrl={{ auth_base_url }}/cas/oidc/refresh
+openapi.components.security.oauth2.tokenUrl={{ auth_base_url }}/cas/oidc/token
+openapi.terms={{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}
+openapi.contact.email={{ orgSupportEmail | default('support@ala.org.au') }}


### PR DESCRIPTION
- Added new oidc related variables to `dq-filter-service` role.
- Added extra named secret/clientId variables for LA portals with single inventories.
- Allow to enable/disable oidc for LA portals with not yet migrated auth systems
- Some extra API configuration variables