### PR TITLE
Fix for #641 and added debug

### DIFF
--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -142,6 +142,12 @@
   tags:
     - tomcat
 
+- name: "Show tomcat and distro"
+  debug:
+    msg: "Using distro {{ansible_distribution_version}} and {{tomcat}}"
+  tags:
+    - tomcat
+
 - name: configure tomcat (Debian)
   blockinfile:
     path={{tomcat_conf}}
@@ -151,6 +157,19 @@
   notify: 
     - restart tomcat
   when: ansible_os_family == "Debian"
+  tags:
+    - tomcat
+    - tomcat-security
+
+- name: configure tomcat (Debian) in 18.04
+  blockinfile:
+    path={{tomcat_conf}}
+    marker="# {mark} Configure Tomcat Memory (Ansible managed)"
+    block='JAVA_OPTS="-Djava.awt.headless=true -XX:+UseG1GC {{tomcat_java_opts}} {{java_security_opts}}"'
+    backup=yes
+  notify:
+    - restart tomcat
+  when: ansible_os_family == "Debian" and ansible_distribution_version == "18.04" and tomcat == "tomcat9"
   tags:
     - tomcat
     - tomcat-security


### PR DESCRIPTION
This is a fix of #641, adding the default options of debian instead of the variable `$JAVA_OPTS` only for ubuntu `18.04` when using `tomcat9`.