### PR TITLE
Allow to enable/disable oidc in image service

### DIFF
--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -18,6 +18,7 @@ security:
     loginUrl: {{ auth_cas_url }}/login
     logoutUrl: {{ auth_cas_url }}/logout
   oidc:
+    enabled: {{ security_oidc_enabled | default(false) }}
     clientId: {{ clientId | default('') }}
     secret: {{ secret | default('') }}
     discoveryUri: {{ discoveryUri | default('') }}


### PR DESCRIPTION
I added a flag just similar to:

https://github.com/AtlasOfLivingAustralia/ala-install/pull/640/files
https://github.com/AtlasOfLivingAustralia/ala-install/pull/639/files