### PR TITLE
Allow to show vernacular names optionally in biocache

### DIFF
--- a/ansible/roles/biocache3-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache3-properties/templates/biocache-config.properties
@@ -468,3 +468,5 @@ security.apikey.enabled={{ apikey_check_enabled | default('false') }}
 security.apiKey.auth.serviceUrl = {{ apikey_auth_url }}
 security.apikey.check.serviceUrl={{ apikey_check_url }}
 security.apikey.userdetails.serviceUrl={{ apikey_userdetails_url }}
+
+vernacularName.show={{ vernacularName_show | default('true') }}


### PR DESCRIPTION
This PR just adds the new variable introduced by https://github.com/AtlasOfLivingAustralia/biocache-hubs/pull/562 so it can be configurable.