### PR TITLE
Added optional checksum to war downloads with geoserver sample

### DIFF
--- a/ansible/roles/geoserver/defaults/main.yml
+++ b/ansible/roles/geoserver/defaults/main.yml
@@ -5,6 +5,7 @@
 #classifier: "war"
 
 geoserver_war_url: "https://repo.osgeo.org/repository/release/org/geoserver/web/gs-web-app/2.19.2/gs-web-app-2.19.2.war"
+geoserver_war_sha1sum: "sha1:db9ce038fb2bea7c67a7012bb338c1447260a2b0"
 
 # URLs to extensions as .zip
 # Must be compatible with the geoserver version

--- a/ansible/roles/tomcat_deploy/tasks/main.yml
+++ b/ansible/roles/tomcat_deploy/tasks/main.yml
@@ -47,7 +47,7 @@
   file: path="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" state=absent
 
 - name: download from maven repo {{ war_url }}
-  get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" force=true timeout=60
+  get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
   when: war_local_build is not defined
   notify:
     - restart tomcat


### PR DESCRIPTION
I added a option to optionally verify the checksum of a war download. 

This ensure the correct download of wars.

I added a example with the geoserver war. 

By default, in other wars should be work as before, without checking the checksum as the default value is ''.