### PR TITLE
Adjustments to generate /data locally

### DIFF
--- a/ansible/roles/biocache-hub/handlers/main.yml
+++ b/ansible/roles/biocache-hub/handlers/main.yml
@@ -1,5 +1,7 @@
 - name: restart tomcat
   service: name={{tomcat}} state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false
 
 - name: restart httpd
   service: name={{apache}} state=restarted enabled="yes"
@@ -9,3 +11,5 @@
 
 - name: restart {{ biocache_hub }}
   service: name={{biocache_hub}} state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/biocache3-service/handlers/main.yml
+++ b/ansible/roles/biocache3-service/handlers/main.yml
@@ -1,5 +1,7 @@
 - name: restart tomcat
   service: name={{tomcat}} state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false
 
 - name: restart httpd
   service: name={{apache}} state=restarted enabled="yes"

--- a/ansible/roles/biocollect/handlers/main.yml
+++ b/ansible/roles/biocollect/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart biocollect
   service: name=biocollect state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/biocollect/tasks/main.yml
+++ b/ansible/roles/biocollect/tasks/main.yml
@@ -60,8 +60,8 @@
   template:
     src: logback.xml
     dest: "{{data_dir}}/biocollect/config/logback.xml"
-    owner: biocollect
-    group: biocollect
+    owner: "{{biocollect_user}}"
+    group: "{{biocollect_user}}"
   notify:
     - restart biocollect
   tags:

--- a/ansible/roles/collectory/handlers/main.yml
+++ b/ansible/roles/collectory/handlers/main.yml
@@ -3,6 +3,8 @@
 
 - name: restart tomcat
   service: name={{tomcat}} state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false
 
 - name: restart httpd
   service: name={{apache}} state=restarted enabled="yes"

--- a/ansible/roles/data_quality_filter_service/handlers/main.yml
+++ b/ansible/roles/data_quality_filter_service/handlers/main.yml
@@ -1,5 +1,7 @@
 - name: restart tomcat
   service: name={{tomcat}} state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false
 
 - name: restart httpd
   service: name={{apache}} state=restarted enabled="yes"

--- a/ansible/roles/jenkins-simple/tasks/main.yml
+++ b/ansible/roles/jenkins-simple/tasks/main.yml
@@ -1,12 +1,16 @@
 - include: ../../common/tasks/setfacts.yml
 
-- apt_key: url="https://pkg.jenkins.io//{{ jenkins_channel }}/jenkins.io.key" state=present id=FCEF32E745F2C3D5
+- apt_key: url="https://pkg.jenkins.io//{{ jenkins_channel }}/jenkins.io-2023.key" state=present id=5BA31D57EF5975CA
   when: ansible_os_family == "Debian"
-  tags: jenkins
+  tags:
+    - jenkins
+    - jenkins-apt
 
 - apt_repository: repo="deb https://pkg.jenkins.io/{{ jenkins_channel }} binary/" state=present update-cache=yes
   when: ansible_os_family == "Debian"
-  tags: jenkins
+  tags:
+    - jenkins
+    - jenkins-apt
 
 - name: install packages and deps
   apt:
@@ -17,7 +21,9 @@
   when: ansible_os_family == "Debian"
   # this can fail if the port 8080 is in use (for instance by spark) and we want to use a different one
   ignore_errors: yes
-  tags: jenkins
+  tags:
+    - jenkins
+    - jenkins-apt
 
 - name: create JENKINS_HOME
   file: name=/data/jenkins state=directory owner=jenkins group=jenkins

--- a/ansible/roles/merit-grails4/handlers/main.yml
+++ b/ansible/roles/merit-grails4/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart fieldcapture
   service: name=fieldcapture state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/mongodb-org/handlers/main.yml
+++ b/ansible/roles/mongodb-org/handlers/main.yml
@@ -2,3 +2,5 @@
   service:
     name: mongod
     state: restarted
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/mongodb-org/tasks/main.yml
+++ b/ansible/roles/mongodb-org/tasks/main.yml
@@ -90,7 +90,9 @@
 - name: Restart mongod
   service: name=mongod state=restarted daemon-reload=true enabled="yes"
   when: ansible_os_family == "Debian"
-  tags: mongodb-org
+  tags: 
+    mongodb-org
+    mongodb-org-restart
 
 - name: Uninstall official python-pymongo package
   apt:
@@ -108,7 +110,10 @@
   service:
     name: mongod
     enabled: yes
-  tags: mongodb-org
+  tags: 
+    mongodb-org
+    mongodb-org-restart
+
 
 
 # https://github.com/ansible/ansible/issues/33832
@@ -152,5 +157,7 @@
         authorization: enabled
   notify:
     - restart mongod
-  tags: mongodb-org
+  tags: 
+    mongodb-org
+    mongodb-org-restart
   when: "{{ ecodata_replica_set_disable_mongo_security | default(true) }}"

--- a/ansible/roles/namematching-service/handlers/main.yml
+++ b/ansible/roles/namematching-service/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart ala-namematching-service
   service: name=ala-namematching-service state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/namematching-service/tasks/apt.yml
+++ b/ansible/roles/namematching-service/tasks/apt.yml
@@ -45,3 +45,5 @@
     state: started
   tags:
     - apt
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/namematching-service/tasks/main.yml
+++ b/ansible/roles/namematching-service/tasks/main.yml
@@ -32,6 +32,9 @@
     mode: 0755
   with_items:
     - "/var/log/atlas/namematching-service"
+  tags:
+    - properties
+    - namematching-service
 
 - name: Customize species group files
   copy:

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -4,6 +4,7 @@
     - docker
     - la-pipelines
     - hadoop_vocab
+    - properties
     - la-pipelines-config
 
 - name: Install aptitude using apt
@@ -55,6 +56,7 @@
     - "{{ data_dir }}/dwca-export"
     - "{{ data_dir }}/migration"
   tags:
+    - properties
     - la-pipelines-config
     - pipelines
     - docker
@@ -156,6 +158,7 @@
   with_items:
     - la-pipelines-local.yaml
   tags:
+    - properties
     - la-pipelines-config
     - pipelines
     - la-pipelines
@@ -260,7 +263,7 @@
     - hadoop_dir
 
 - name: Set ownership of HDFS base directories
-  shell: "{{ hadoop_install_dir }}/bin/hdfs dfs -chown spark:spark {{ item }}"
+  shell: "{{ hadoop_install_dir }}/bin/hdfs dfs -chown {{ spark_user }}:{{ spark_user }} {{ item }}"
   with_items:
     - "/dwca-exports"
     - "/dwca-imports"

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Install required system packages
   apt: name={{ item }} state=latest update_cache=yes
-  loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools']
+  loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools', 'unzip']
   tags:
     - pipelines
 

--- a/ansible/roles/profile-hub/tasks/main.yml
+++ b/ansible/roles/profile-hub/tasks/main.yml
@@ -90,8 +90,8 @@
   template:
     src: logback.xml
     dest: "{{data_dir}}/profile-hub/config/logback.xml"
-    owner: profile-hub
-    group: profile-hub
+    owner: "{{profile_hub_user}}"
+    group: "{{profile_hub_user}}"
   notify:
     - restart profile-hub
   tags:

--- a/ansible/roles/profile-service/handlers/main.yml
+++ b/ansible/roles/profile-service/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart profile-service
   service: name=profile-service state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/profile-service/tasks/main.yml
+++ b/ansible/roles/profile-service/tasks/main.yml
@@ -49,6 +49,7 @@
       - { db: "{{ profiles_database }}", role: "readWrite" }
   tags:
     - mongodb-org
+    - mongodb-users
   when: grails_version is version("3", ">=")
 
 - name: set profile_service_user as default value
@@ -107,8 +108,8 @@
   template:
     src: logback.xml
     dest: "{{data_dir}}/profile-service/config/logback.xml"
-    owner: profile-service
-    group: profile-service
+    owner: "{{ profile_service_user }}"
+    group: "{{ profile_service_user }}"
   notify:
     - restart profile-service
   tags:

--- a/ansible/roles/sensitive-data-service/handlers/main.yml
+++ b/ansible/roles/sensitive-data-service/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart ala-sensitive-data-service
   service: name=ala-sensitive-data-service state=restarted enabled=yes
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/sensitive-data-service/tasks/apt.yml
+++ b/ansible/roles/sensitive-data-service/tasks/apt.yml
@@ -56,3 +56,5 @@
     state: started
   tags:
     - apt
+  when:
+  - skip_handlers | default("false") | bool == false


### PR DESCRIPTION
Small adjustments to generate `/data` locally via https://github.com/living-atlases/la-data-generator.

It's add some new tags, some conditional service restart (to skip services to restart when we are looking only for configurations), and some minor fix (missing deps, new gpg key for jenkins).