### PR TITLE
local /data config generation for docker use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vagrant/centos/.vagrant/machines/default/virtualbox/id
 *.retry
 
 ansible/roles/alerts/tasks/main.yml
+utils/docopts

--- a/ansible/ecodata.yml
+++ b/ansible/ecodata.yml
@@ -6,7 +6,7 @@
     es_heap_dump_path: "/data/"
     es_api_host: "{{ elasticsearch_host | default('localhost') }}"
     es_config:
-      network.host: "{{ elasticsearch_host | default('localhost') }}"
+      network.host: "{{ (ecodata_elasticsearch_host | default(elasticsearch_host)) | default('localhost') }}"
       discovery.type: "single-node"
   roles:
     - common

--- a/ansible/events.yml
+++ b/ansible/events.yml
@@ -10,13 +10,13 @@
   vars:
     es_version: "7.17.7"
     es_heap_dump_path: "/data/"
-    es_api_host: "{{ elasticsearch_host | default('localhost') }}"
+    es_api_host: "{{ (events_elasticsearch_host | default(elasticsearch_host) | default('localhost') }}"
     es_heap_size: "8g"
     es_config:
       cluster.name: "{{ elasticsearch_cluster_name | default('extended-data') }}"
       node.name: "{{ elasticsearch_host | default('localhost') }}"
-      network.host: "{{ elasticsearch_network_host }}"
-      discovery.seed_hosts: "{{ elasticsearch_seed_hosts }}"
+      network.host: "{{ (events_elasticsearch_network_host | default(elasticsearch_network_host) }}"
+      discovery.seed_hosts: "{{ (events_elasticsearch_seed_host | default(elasticsearch_seed_host) }}"
       bootstrap.memory_lock: false
       cluster.initial_master_nodes: "{{ elasticsearch_cluster_initial_master_nodes }}"
       indices.memory.index_buffer_size: "{{ elasticsearch_index_buffer_size | default('40%') }}"

--- a/ansible/roles/apikey/tasks/main.yml
+++ b/ansible/roles/apikey/tasks/main.yml
@@ -21,8 +21,8 @@
   file:
     path: "{{item}}"
     state: directory
-    owner: apikey
-    group: apikey
+    owner: "{{ apikey_user | default('apikey') }}"
+    group: "{{ apikey_user | default('apikey') }}"
   with_items:
     - "{{data_dir}}/apikey"
     - "{{data_dir}}/apikey/config"
@@ -35,8 +35,8 @@
 - name: set data ownership
   file:
     path: "{{data_dir}}/apikey"
-    owner: apikey
-    group: apikey
+    owner: "{{ apikey_user | default('apikey') }}"
+    group: "{{ apikey_user | default('apikey') }}"
     recurse: true
   tags:
     - properties
@@ -46,8 +46,8 @@
   template:
     src: apikey-config.yml
     dest: "{{data_dir}}/apikey/config/apikey-config.yml"
-    owner: apikey
-    group: apikey
+    owner: "{{ apikey_user | default('apikey') }}"
+    group: "{{ apikey_user | default('apikey') }}"
   notify:
     - restart apikey
   when: apikey_version is version('1.7.0', '>=')
@@ -59,8 +59,8 @@
   template:
     src: apikey-config-pre-1.7.0.yml
     dest: "{{data_dir}}/apikey/config/apikey-config.yml"
-    owner: apikey
-    group: apikey
+    owner: "{{ apikey_user | default('apikey') }}"
+    group: "{{ apikey_user | default('apikey') }}"
   notify:
     - restart apikey
   when: apikey_version is version('1.7.0', '<')
@@ -72,8 +72,8 @@
   template:
     src: logback.xml
     dest: "{{data_dir}}/apikey/config/logback.xml"
-    owner: apikey
-    group: apikey
+    owner: "{{ apikey_user | default('apikey') }}"
+    group: "{{ apikey_user | default('apikey') }}"
   tags:
     - properties
     - apikey

--- a/ansible/roles/cas-management/tasks/main.yml
+++ b/ansible/roles/cas-management/tasks/main.yml
@@ -11,8 +11,8 @@
   file:
     path: "{{item}}"
     state: directory
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   with_items:
     - "{{data_dir}}/cas-management"
     - "{{data_dir}}/cas-management/config"
@@ -25,8 +25,8 @@
 - name: set data ownership
   file:
     path: "{{data_dir}}/cas-management"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
     recurse: true
   tags:
     - properties
@@ -37,8 +37,8 @@
 #   template:
 #     src: application.properties
 #     dest: "{{data_dir}}/cas-management/config/application.properties"
-#     owner: cas
-#     group: cas
+#     owner: "{{ cas_user | default('cas') }}"
+#     group: "{{ cas_user | default('cas') }}"
 #   notify:
 #     - restart cas-management
 #   tags:
@@ -49,8 +49,8 @@
   template:
     src: application.yml
     dest: "{{data_dir}}/cas-management/config/application.yml"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   when: cas_management_version is version('6', '>=')
   notify:
     - restart cas-management
@@ -62,8 +62,8 @@
   template:
     src: application.properties
     dest: "{{data_dir}}/cas-management/config/application.properties"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   when: cas_management_version is version('6', '<')
   notify:
     - restart cas-management
@@ -75,8 +75,8 @@
   template:
     src: log4j2-management.xml
     dest: "{{data_dir}}/cas-management/config/log4j2.xml"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   tags:
     - properties
     - cas-management
@@ -90,8 +90,8 @@
       value: /data/cas-management/config/
     log_config_filename: 'log4j2.xml'
     service_name: "cas-management"
-    service_owner: 'cas'
-    service_group: 'cas'
+    service_owner: "{{ cas_user | default('cas') }}"
+    service_group: "{{ cas_user | default('cas') }}"
     use_openjdk11: "{{ cas_management_version is version('6', '>=') }}"
     use_openjdk8: "{{ cas_management_version is version('6', '<') }}"
     java_headless: True

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -21,8 +21,8 @@
   file:
     path: "{{item}}"
     state: directory
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   with_items:
     - "{{data_dir}}/cas"
     - "{{data_dir}}/cas/config"
@@ -35,8 +35,8 @@
 - name: set data ownership
   file:
     path: "{{data_dir}}/cas"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
     recurse: true
   tags:
     - properties
@@ -46,8 +46,8 @@
   template:
     src: application.yml
     dest: "{{data_dir}}/cas/config/application.yml"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   when: cas_version is version('6', '>=')
   notify:
     - restart cas
@@ -59,8 +59,8 @@
   template:
     src: application-pre-6.yml
     dest: "{{data_dir}}/cas/config/application.yml"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   when: cas_version is version('6', '<')
   notify:
     - restart cas
@@ -72,8 +72,8 @@
   template:
     src: log4j2.xml
     dest: "{{data_dir}}/cas/config/log4j2.xml"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   tags:
     - properties
     - cas
@@ -82,8 +82,8 @@
   template:
     src: pwe.properties
     dest: "{{data_dir}}/cas/config/pwe.properties"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
   notify:
     - restart cas
   tags:
@@ -95,8 +95,8 @@
   copy:
     src:  "{{ inventory_dir }}/{{ cas_jwks_file | default('keystore.jwks') }}"
     dest: "{{data_dir}}/cas/keystore.jwks"
-    owner: cas
-    group: cas
+    owner: "{{ cas_user | default('cas') }}"
+    group: "{{ cas_user | default('cas') }}"
     mode: u=rw,g=,o=
   notify:
     - restart cas
@@ -150,7 +150,7 @@
     - db
 
 - name: ensure target sql directory exist
-  file: path={{item}} state=directory owner=cas group=cas
+  file: path={{item}} state=directory owner="{{ cas_user | default('cas') }}" group="{{ cas_user | default('cas') }}"
   with_items:
     - "{{data_dir}}/cas/setup"
   when: cas_first_admin_email is defined and cas_first_admin_bcrypt_password is defined and cas_first_admin_temp_auth_key is defined

--- a/ansible/roles/doi-service/tasks/main.yml
+++ b/ansible/roles/doi-service/tasks/main.yml
@@ -28,8 +28,8 @@
   file:
     path: "{{item}}"
     state: directory
-    owner: doi-service
-    group: doi-service
+    owner: "{{ doi_user | default('doi-service') }}"
+    group: "{{ doi_user | default('doi-service') }}"
   with_items:
     - "{{data_dir}}/doi-service"
     - "{{data_dir}}/doi-service/config"
@@ -41,8 +41,8 @@
 - name: set data ownership
   file:
     path: "{{data_dir}}/doi-service"
-    owner: doi-service
-    group: doi-service
+    owner: "{{ doi_user | default('doi-service') }}"
+    group: "{{ doi_user | default('doi-service') }}"
     recurse: true
   tags:
     - properties
@@ -52,8 +52,8 @@
   template:
     src: doi-service-config.yml
     dest: "{{data_dir}}/doi-service/config/doi-service-config.yml"
-    owner: doi-service
-    group: doi-service
+    owner: "{{ doi_user | default('doi-service') }}"
+    group: "{{ doi_user | default('doi-service') }}"
   notify:
     - restart doi-service
   tags:
@@ -64,8 +64,8 @@
   template:
     src: logback.groovy
     dest: "{{data_dir}}/doi-service/config/logback.groovy"
-    owner: doi-service
-    group: doi-service
+    owner: "{{ doi_user | default('doi-service') }}"
+    group: "{{ doi_user | default('doi-service') }}"
   notify:
     - restart doi-service
   tags:

--- a/ansible/roles/ecodata/handlers/main.yml
+++ b/ansible/roles/ecodata/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart ecodata
   service: name=ecodata state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/ecodata/tasks/main.yml
+++ b/ansible/roles/ecodata/tasks/main.yml
@@ -20,6 +20,7 @@
   with_items:
     - "{{data_dir}}/mongodb"
   tags:
+    - mongodb-org
     - properties
     - ecodata
 

--- a/ansible/roles/events/handlers/main.yml
+++ b/ansible/roles/events/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart graphql_service
   service: name={{ env }}-graphql state=restarted enabled="yes"
+  when:
+  - skip_handlers | default("false") | bool == false

--- a/ansible/roles/events/tasks/main.yaml
+++ b/ansible/roles/events/tasks/main.yaml
@@ -61,6 +61,7 @@
     - events
     - update-images
     - docker-config
+    - properties
 
 - name: Copy docker YAML files to {{ data_dir }}
   template: src={{ item }} dest={{ data_dir }}/{{ env }}/{{ item }}
@@ -76,6 +77,7 @@
     - events
     - update-images
     - docker-config
+    - properties
 
 - name: Copy service scripts to /usr/bin
   template: src={{ item }} dest=/usr/bin/{{ env }}-{{ item }} mode=777

--- a/ansible/roles/geoserver/tasks/ecodata-geoserver.yml
+++ b/ansible/roles/geoserver/tasks/ecodata-geoserver.yml
@@ -80,6 +80,13 @@
   tags:
     - geoserver
 
+# Used for /data local generation
+- name: set ownership of geoserver data
+  shell: "chown -R {{ geoserver_user }}:{{ geoserver_user }} {{data_dir}}/geoserver*"
+  when: geoserver_user is defined
+  tags:
+    - geoserver
+
 #
 # Override the default memory settings for Tomcat to increase heap space and change the garbage collector
 #

--- a/ansible/roles/geoserver/tasks/geoserver.yml
+++ b/ansible/roles/geoserver/tasks/geoserver.yml
@@ -254,6 +254,14 @@
     - geoserver
     - properties
 
+# Used for /data local generation
+- name: set ownership of geoserver data
+  shell: "chown -R {{ geoserver_user }}:{{ geoserver_user }} {{data_dir}}/geoserver*"
+  when: geoserver_user is defined
+  tags:
+    - geoserver
+    - properties
+
 - name: Running geoserver.sh
   command: "{{data_dir}}/geoserver.sh"
   args:

--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -48,7 +48,7 @@
     - image-service
 
 - name: ensure target directories exist [data subdirectories etc.]
-  file: path={{item}} state=directory owner=image-service group=image-service
+  file: path={{item}} state=directory owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}"
   with_items:
     - "{{data_dir}}/image-service/setup"
     - "{{data_dir}}/image-service/config"
@@ -90,7 +90,7 @@
     - image-service
 
 - name: ensure target directories exist [data subdirectories etc.]
-  file: path={{item}} state=directory owner=image-service group=image-service
+  file: path={{item}} state=directory owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}"
   with_items:
     - "{{data_dir}}/image-service/setup"
     - "{{data_dir}}/image-service/config"
@@ -106,7 +106,7 @@
     - properties
 
 - name: set data ownership for {{data_dir}}/image-service
-  file: path={{data_dir}}/image-service owner="image-service" group="image-service"
+  file: path={{data_dir}}/image-service owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}"
   notify:
      - restart image-service
   tags:
@@ -115,7 +115,7 @@
     - image-service
 
 - name: set data ownership postgres for {{data_dir}}/image-service/exports
-  file: path={{data_dir}}/image-service/exports owner="image-service" group="image-service" recurse=true
+  file: path={{data_dir}}/image-service/exports owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}" recurse=true
   notify:
      - restart image-service
   tags:
@@ -124,7 +124,7 @@
     - image-service
 
 - name: set data ownership for /opt/atlas/image-service
-  file: path=/opt/atlas/image-service owner="image-service" group="image-service" recurse=true
+  file: path=/opt/atlas/image-service owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}" recurse=true
   notify:
      - restart image-service
   tags:
@@ -133,7 +133,7 @@
     - image-service
 
 - name: set data ownership for /var/log/atlas/image-service
-  file: path=/var/log/atlas/image-service owner="image-service" group="image-service" recurse=true
+  file: path=/var/log/atlas/image-service owner="{{ image_user | default('image-service') }}" group="{{ image_user | default('image-service') }}" recurse=true
   notify:
      - restart image-service
   tags:

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -43,7 +43,7 @@ flyway:
   baselineOnMigrate: {{ image_service_baseline_on_migrate | default('true') }}
 
 dataSource:
-  url: "jdbc:postgresql://localhost/{{ image_service_db_name }}?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8"
+  url: "jdbc:postgresql://{{ image_service_db_host | default('localhost') }}/{{ image_service_db_name }}?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8"
   driverClassName: org.postgresql.Driver
   username: {{ image_service_db_username }}
   password: {{ image_service_db_password }}

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -18,6 +18,7 @@
   loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools', 'unzip']
   tags:
     - pipelines
+    - apt
 
 - name: Add Docker GPG apt Key
   apt_key:
@@ -93,6 +94,7 @@
     - la-pipelines
     - pipelines
     - yq
+    - apt
 
 - name: Add YQ Repository
   apt_repository:
@@ -102,6 +104,7 @@
     - la-pipelines
     - pipelines
     - yq
+    - apt
 
 - name: Add an apt key by id from a keyserver
   apt_key:
@@ -112,6 +115,7 @@
     - la-pipelines
     - pipelines
     - yq
+    - apt
 
 - name: Update apt and install pipelines
   apt: update_cache=yes name=yq={{ yq_version }}
@@ -120,6 +124,7 @@
     - pipelines
     - la-pipelines
     - yq
+    - apt
 
 # docopts is needed by the la-pipelines script
 
@@ -138,6 +143,7 @@
     - la-pipelines
     - pipelines
     - docopts
+    - apt
 
 - name: Make docopts executable
   shell: chmod +x /usr/local/bin/docopts

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -11,6 +11,7 @@
   apt: name=aptitude state=latest update_cache=yes force_apt_get=yes
   tags:
     - pipelines
+    - apt
 
 - name: Install required system packages
   apt: name={{ item }} state=latest update_cache=yes

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -21,8 +21,8 @@
   file:
     path: "{{item}}"
     state: directory
-    owner: userdetails
-    group: userdetails
+    owner: "{{ userdetails_user | default('userdetails') }}"
+    group: "{{ userdetails_user | default('userdetails') }}"
   with_items:
     - "{{data_dir}}/userdetails"
     - "{{data_dir}}/userdetails/config"
@@ -35,8 +35,8 @@
 - name: set data ownership
   file:
     path: "{{data_dir}}/userdetails"
-    owner: userdetails
-    group: userdetails
+    owner: "{{ userdetails_user | default('userdetails') }}"
+    group: "{{ userdetails_user | default('userdetails') }}"
     recurse: true
   tags:
     - properties
@@ -46,8 +46,8 @@
   template:
     src: userdetails-config.yml
     dest: "{{data_dir}}/userdetails/config/userdetails-config.yml"
-    owner: userdetails
-    group: userdetails
+    owner: "{{ userdetails_user | default('userdetails') }}"
+    group: "{{ userdetails_user | default('userdetails') }}"
   notify:
     - restart userdetails
   when: user_details_version is version('3', '>=')
@@ -59,8 +59,8 @@
   template:
     src: userdetails-config-pre-3.yml
     dest: "{{data_dir}}/userdetails/config/userdetails-config.yml"
-    owner: userdetails
-    group: userdetails
+    owner: "{{ userdetails_user | default('userdetails') }}"
+    group: "{{ userdetails_user | default('userdetails') }}"
   notify:
     - restart userdetails
   when: user_details_version is version('3', '<')
@@ -72,8 +72,8 @@
   template:
     src: logback.xml
     dest: "{{data_dir}}/userdetails/config/logback.xml"
-    owner: userdetails
-    group: userdetails
+    owner: "{{ userdetails_user | default('userdetails') }}"
+    group: "{{ userdetails_user | default('userdetails') }}"
   tags:
     - properties
     - userdetails

--- a/utils/ala-data-generator
+++ b/utils/ala-data-generator
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run with:
-#   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate doi
+#   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate doi alerts
 # or for all services:
 #   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate
 
@@ -21,7 +21,7 @@ eval "$("$GEN_LOC/docopts" -V - -h - : "$@" <<EOF
 $CMD: ALA data generator
 
 Usage:
-  $CMD [options] --data=<dir> --inv=<dir> generate [<service>]
+  $CMD [options] --data=<dir> --inv=<dir> generate [<service>...]
   $CMD -h | --help
   $CMD -v | --version
 
@@ -63,6 +63,7 @@ list=(
   "./specieslists/specieslists-prod"
   "./ecodata/ecodata-prod"
   "./fieldguide/fieldguide-prod"
+  # This needs extra role work:
   "./pipelines/databox-pipelines.yml"
   "./namematching/namematching-prod"
   "./sensitive-data-service/sensitive-data-service-prod-2022"

--- a/utils/ala-data-generator
+++ b/utils/ala-data-generator
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Run with:
+#   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate doi
+# or for all services:
+#   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate
+
+# It will fail if some playbook fails 
+set -e
+
+CMD=$(basename "$0")
+GEN_LOC="$(dirname "$(realpath "$0")")"
+
+if [[ ! -e $GEN_LOC/docopts ]] ; then
+    curl -s -o "$GEN_LOC/docopts" -LJO https://github.com/docopt/docopts/releases/download/v0.6.3-rc2/docopts_linux_amd64
+    chmod +x "$GEN_LOC/docopts"
+fi
+
+eval "$("$GEN_LOC/docopts" -V - -h - : "$@" <<EOF
+
+$CMD: ALA data generator
+
+Usage:
+  $CMD [options] --data=<dir> --inv=<dir> generate [<service>]
+  $CMD -h | --help
+  $CMD -v | --version
+
+Options:
+  --verbose            Verbose output.
+  -h --help            Show this help.
+  -v --version         Show version.
+----
+$CMD $VER
+License Apache-2.0
+EOF
+)"
+
+list=(
+  "./alerts/alerts-prod"
+  "./auth/aws-auth-prod.yml"
+  "./bie/bie-hub-prod-2022"
+  "./bie/bie-ws-solr-prod-2022"
+  "./biocache/biocache-hub-2021"
+  "./biocache/biocache-service-2021"
+  "./biocache/cassandra-cluster-2021"
+  "./biocache/solrcloud-2021-1"
+  "./biocollect/biocollect-prod"
+  "./calendars/calendars-prod"
+  "./collections/collections-prod"
+  "./dashboard/dashboard-prod"
+  "./data_quality_filter_service/data_quality_filter_service_prod"
+  "./doi/doi-prod"
+  "./events/events-prod-2023"
+  "./fieldcapture/fieldcapture-prod"
+  "./image-service/image-service-prod"
+  "./logger/logger-prod"
+  "./pdf-service/pdf-service-prod"
+  "./profiles/profiles-prod"
+  "./regions/regions-prod"
+  "./sampling/sampling-prod"
+  "./sandbox/sandbox-prod"
+  "./spatial/spatial-prod"
+  "./specieslists/specieslists-prod"
+  "./ecodata/ecodata-prod"
+  "./fieldguide/fieldguide-prod"
+  "./pipelines/databox-pipelines.yml"
+  "./namematching/namematching-prod"
+  "./sensitive-data-service/sensitive-data-service-prod-2022"
+)
+  #"./pipelines/aws-spark-quoll-pipelines.yml"
+  #"./pipelines/nci3-spark-pipelines.yml"
+
+if [[ -n $service ]] ; then
+    services=("${service[@]}")
+fi
+
+for el in "${list[@]}"
+do
+  match=false
+  for arg in "${services[@]}"
+  do
+    if [[ $el == *"$arg"* ]]; then
+      match=true
+      break
+    fi
+  done
+
+  if [[ -z "${services[*]}" ]] || $match; then
+    # echo -n "$el "
+    "$GEN_LOC/la-data-generator" --inv=$inv --data=$data generate "$el"
+  fi
+done
+

--- a/utils/la-data-generator
+++ b/utils/la-data-generator
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# It will fail if some playbook fails 
+set -e
+
+CMD=$(basename "$0")
+GEN_LOC="$(dirname "$(realpath "$0")")"
+A_ALA_INSTALL="${GEN_LOC%/*}/ansible"
+#echo $GEN_LOC
+#echo $A_ALA_INSTALL
+
+
+if [[ ! -e $GEN_LOC/docopts ]] ; then
+    curl -s -o "$GEN_LOC/docopts" -LJO https://github.com/docopt/docopts/releases/download/v0.6.3-rc2/docopts_linux_amd64
+    chmod +x "$GEN_LOC/docopts"
+fi
+
+eval "$("$GEN_LOC/docopts" -V - -h - : "$@" <<EOF
+
+$CMD: LA data generator
+
+Usage:
+  $CMD [options] --data=<dir> --inv=<dir> generate [<service>]
+  $CMD -h | --help
+  $CMD -v | --version
+
+Options:
+  --verbose            Verbose output.
+  -d --dry-run         Print the commands without actually running them.
+  -h --help            Show this help.
+  -v --version         Show version.
+----
+$CMD $VER
+License Apache-2.0
+EOF
+)"
+
+# shellcheck disable=SC2154
+if ($dry_run); then _D="echo"; else _D=; fi
+if ($dry_run); then echo "Only printing the commands:"; fi
+
+# shellcheck disable=SC2154
+if $verbose; then
+      # shellcheck disable=SC2154
+      echo build: "$build"
+      # shellcheck disable=SC2154
+      echo run: "$run"
+      # shellcheck disable=SC2154
+      echo data: "$data"
+      # shellcheck disable=SC2154
+    echo inv: "$inv"
+fi
+
+use_an_inventory=false
+user=$USER
+
+# shellcheck disable=SC2154
+if [[ -d $inv && -f $inv/ansiblew ]]; then
+      # use_ansiblew=true
+      if $verbose; then echo "It seems a standard generated inventory"; fi
+elif [[ -f $inv/$service ]]; then
+      use_an_inventory=true
+elif [[ ! -d $inv || ! -f $inv/ansiblew ]]; then
+      >&2 echo "ERR: It seems that '$inv' is not a generated inventory as we expect or an ALA inventory directory + service inventory provided"
+      exit 1;
+fi
+
+TAGS=common,properties,mongodb-org,namematching-service,pipelines,pipelines-layers
+SKIP_TAGS=restart,image-stored-procedures,db,mongodb-org-restart,mongodb-users,sslcerts,pipelines-services,hadoop_dir,hadoop_vocab,apt_update,apt
+EXTRAS="user_store_db_hostname=auth-mysql ticket_registry_db_hostname=auth-mongo cas_audit_host=auth-mongo cas_spring_session_host=auth-mongo \
+    user_store_db_hostname=auth-mysql apikey_db_hostname=auth-mysql cas_db_hostname=auth-mysql cas_tickets_host=auth-mongo \
+    cas_tickets_host=auth-mongo cas_services_host=auth-mongo cas_services_host=auth-mongo collectory_db_host_address=collectory-mysql \
+    data_dir=/data/docker skip_handlers=true tomcat=$user tomcat_user=$user tomcat_apr=false biocollect_user=$user ecodata_user=$user \
+    merit_user=$user fieldguide_app=fieldguide use_docker_with_pipelines=false spark_user=$user profile_service_user=$user \ 
+    profile_hub_user=$user doi_user=$user cas_user=$user userdetails_user=$user apikey_user=$user image_user=$user"
+
+function gen() {
+    local what="$1"
+    echo "Generating config for '$what'"
+    if $verbose; then V="-vvvv" ; else V=""; fi
+    bash -c "cd $inv; ./ansiblew --alainstall=/ansible/ala-install -i "$GEN_LOC/local.ini" $what --tags=$TAGS --skip=$SKIP_TAGS -e '$EXTRAS' --nodryrun $V"
+
+    if [ $? -ne 0 ]; then
+      >&2 echo "The generation failed, are you inventories and/or your ala-install repo up-to-date?"
+    fi
+}
+
+function genCustom() {
+    # local dinv="$(dirname "$1")"
+    local cinv="$(basename "$1")"
+    local play="$2"
+    local dinv="$(dirname "$1")"
+    echo "Generating config for $dinv/$cinv and '$play' in '$inv'"
+
+    if $verbose; then V="-vvvv" ; else V=""; fi
+
+    cp "$GEN_LOC/local.ini" "$inv/$dinv"
+    bash -c "cd $inv/$dinv; ansible-playbook -u ubuntu --become -i $cinv -i local.ini $A_ALA_INSTALL/$play --tags $TAGS --skip-tags $SKIP_TAGS --extra-vars '$EXTRAS' --limit localhost $V"
+    rm "$inv/$dinv/local.ini"
+exit
+    # shellcheck disable=SC2181
+    if [ $? -ne 0 ]; then
+      >&2 echo "The generation failed, are you inventories and/or your ala-install repo up-to-date?"
+    fi
+}
+
+function run_checks() {
+    if [[ ! -d $data ]]; then
+        >&2 echo "Directory '$data' does not exists"
+        exit 1
+    fi
+
+    if [[ ! $data =~ ^/.* ]]; then
+        >&2 echo "Use an /absolute path for directory '$data' "
+        exit 1
+    fi
+
+    if [[ ! $inv =~ ^/.* ]]; then
+        >&2 echo "Use an /absolute path for directory '$inv' "
+        exit 1
+    fi
+
+    if [ -z "$(find "$inv" -mindepth 1 -print -quit)" ]; then
+        >&2 echo "WARN: It seems that '$inv' is empty"
+        exit 1
+    fi
+
+    if [[ ! -d $inv || ! -f $inv/ansiblew ]]; then
+        >&2 echo "WARN: It seems that '$inv' is not a generated inventory as we expect"
+        # exit 1
+    fi
+
+    # shellcheck disable=SC2154
+    if [[ -d $ala_install && ! -d $ala_install/ansible ]]; then
+        >&2 echo "It seems that '$ala_install' is not the ala-install repository as we expect"
+        exit 1
+    fi
+}
+
+run_checks
+
+if $use_an_inventory ; then
+      echo "Processing $inv$service"
+      set +e
+
+      output=$(bash -c "grep 'ansible-playbook -i' $inv$service 2>&1")
+
+      set -e
+
+      playbook_pattern="ala-install/ansible"
+
+      while IFS= read -r line; do
+        if [[ $line == *"ansible-playbook -i"* ]]; then
+          playbook=$(awk -F "$playbook_pattern" '{print $2}' <<< "$line" | awk '{gsub(/--.*$/, ""); print}')
+          playbook=${playbook// /}
+        fi
+      done <<< "$output"
+
+      if [[ -z "$playbook" ]]; then
+        >&2 echo "Playbook not detected in inventory comments"
+        exit 1
+      fi
+
+      genCustom "$service" "$playbook"
+
+else
+    if [[ -n $service ]] ; then
+       gen "$service"
+    else
+       gen all
+    fi
+fi

--- a/utils/la-data-generator
+++ b/utils/la-data-generator
@@ -5,6 +5,7 @@ set -e
 
 CMD=$(basename "$0")
 GEN_LOC="$(dirname "$(realpath "$0")")"
+ALA_INSTALL="${GEN_LOC%/*}"
 A_ALA_INSTALL="${GEN_LOC%/*}/ansible"
 #echo $GEN_LOC
 #echo $A_ALA_INSTALL
@@ -20,7 +21,7 @@ eval "$("$GEN_LOC/docopts" -V - -h - : "$@" <<EOF
 $CMD: LA data generator
 
 Usage:
-  $CMD [options] --data=<dir> --inv=<dir> generate [<service>]
+  $CMD [options] --data=<dir> --inv=<dir> generate [<service>...]
   $CMD -h | --help
   $CMD -v | --version
 
@@ -66,30 +67,43 @@ elif [[ ! -d $inv || ! -f $inv/ansiblew ]]; then
 fi
 
 TAGS=common,properties,mongodb-org,namematching-service,pipelines,pipelines-layers
-SKIP_TAGS=restart,image-stored-procedures,db,mongodb-org-restart,mongodb-users,sslcerts,pipelines-services,hadoop_dir,hadoop_vocab,apt_update,apt
-EXTRAS="user_store_db_hostname=auth-mysql ticket_registry_db_hostname=auth-mongo cas_audit_host=auth-mongo cas_spring_session_host=auth-mongo \
+SKIP_TAGS=restart,image-stored-procedures,db,mongodb-org-restart,mongodb-users,sslcerts,pipelines-services,hadoop_dir,hadoop_vocab,apt_update,apt,mongodb-org,docopts,yq
+ EXTRAS="user_store_db_hostname=auth-mysql ticket_registry_db_hostname=auth-mongo cas_audit_host=auth-mongo cas_spring_session_host=auth-mongo \
     user_store_db_hostname=auth-mysql apikey_db_hostname=auth-mysql cas_db_hostname=auth-mysql cas_tickets_host=auth-mongo \
     cas_tickets_host=auth-mongo cas_services_host=auth-mongo cas_services_host=auth-mongo collectory_db_host_address=collectory-mysql \
-    data_dir=/data/docker skip_handlers=true tomcat=$user tomcat_user=$user tomcat_apr=false biocollect_user=$user ecodata_user=$user \
-    merit_user=$user fieldguide_app=fieldguide use_docker_with_pipelines=false spark_user=$user profile_service_user=$user \ 
-    profile_hub_user=$user doi_user=$user cas_user=$user userdetails_user=$user apikey_user=$user image_user=$user"
+    dq_db_url=jdbc:postgresql://dq-postgresql/data-quality specieslist_db_hostname=lists-mysql logger_db_hostname=logger-mysql \
+    alerts_db_hostname=alerts-mysql phylolink_db_hostname=phylolink-mysql geonetwork_database=spatial-postgresql layers_db_host=spatial-postgresql \
+    doi_db_hostname=doi-postgresql image_service_db_host=images-postgresql \
+    mail_smtp_host=biocache-smtp mail_host=biocollect-smtp \
+    ecodata_elasticsearch_host=ecodata-es events_elasticsearch_host=events-es events_elasticsearch_network_host=events-es-network \
+    events_elasticsearch_seed_host=events-es-seed solr_url=FIXME_solr_url biocache_db_host=FIXME_cassandra_host \
+    data_dir=/data/docker skip_handlers=true tomcat_apr=false use_docker_with_pipelines=false install_elasticsearch=false ecodata_url=FIXME_ECODATA_URL \
+    tomcat=$user tomcat_user=$user biocollect_user=$user ecodata_user=$user merit_user=$user fieldguide_app=fieldguide spark_user=$user \
+    profile_service_user=$user profile_hub_user=$user doi_user=$user cas_user=$user userdetails_user=$user apikey_user=$user image_user=$user \
+    geoserver_user=$user"
 
 function gen() {
-    local what="$1"
+    local what
+    what="$1"
     echo "Generating config for '$what'"
     if $verbose; then V="-vvvv" ; else V=""; fi
-    bash -c "cd $inv; ./ansiblew --alainstall=/ansible/ala-install -i "$GEN_LOC/local.ini" $what --tags=$TAGS --skip=$SKIP_TAGS -e '$EXTRAS' --nodryrun $V"
-
+    cp "$GEN_LOC/local.ini" "$inv"
+    bash -c "cd $inv; ./ansiblew --alainstall=$ALA_INSTALL -i local.ini $what --tags=$TAGS --skip=$SKIP_TAGS -e '$EXTRAS' --nodryrun --limit localhost $V"
+    # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
       >&2 echo "The generation failed, are you inventories and/or your ala-install repo up-to-date?"
     fi
+    rm "$inv/local.ini"
 }
 
 function genCustom() {
     # local dinv="$(dirname "$1")"
-    local cinv="$(basename "$1")"
-    local play="$2"
-    local dinv="$(dirname "$1")"
+    local cinv
+    local play
+    local dinv
+    cinv="$(basename "$1")"
+    play="$2"
+    dinv="$(dirname "$1")"
     echo "Generating config for $dinv/$cinv and '$play' in '$inv'"
 
     if $verbose; then V="-vvvv" ; else V=""; fi
@@ -125,11 +139,6 @@ function run_checks() {
         exit 1
     fi
 
-    if [[ ! -d $inv || ! -f $inv/ansiblew ]]; then
-        >&2 echo "WARN: It seems that '$inv' is not a generated inventory as we expect"
-        # exit 1
-    fi
-
     # shellcheck disable=SC2154
     if [[ -d $ala_install && ! -d $ala_install/ansible ]]; then
         >&2 echo "It seems that '$ala_install' is not the ala-install repository as we expect"
@@ -138,6 +147,10 @@ function run_checks() {
 }
 
 run_checks
+
+if [[ -n $service ]] ; then
+    services=("${service[@]}")
+fi
 
 if $use_an_inventory ; then
       echo "Processing $inv$service"
@@ -165,8 +178,10 @@ if $use_an_inventory ; then
 
 else
     if [[ -n $service ]] ; then
-       gen "$service"
+        for s in "${services[@]}"; do
+            gen "$s"
+        done
     else
-       gen all
+        gen all
     fi
 fi

--- a/utils/local.ini
+++ b/utils/local.ini
@@ -1,3 +1,16 @@
+#
+# This extra inventory is needed for /data/ local generation, 
+# in order to don't modificate the ansible/playbooks groups.
+#
+# Also this local inventory should we placed in the same directory of your real
+# inventories, and if not, file accessing to files references in inventories, 
+# like:
+#   blacklist_file=blacklist-prod.json
+# fails. Because of this, we copy this file there and remove it on each run.
+#
+# Warn: be sure that your playbook group is included here to generate its 
+# config in local
+#
 [collectory]
 127.0.0.1 ansible_connection=local
 
@@ -101,6 +114,12 @@
 127.0.0.1 ansible_connection=local
 
 [ecodata-reporting]
+127.0.0.1 ansible_connection=local
+
+[primary]
+127.0.0.1 ansible_connection=local
+
+[secondary]
 127.0.0.1 ansible_connection=local
 
 [events]

--- a/utils/local.ini
+++ b/utils/local.ini
@@ -1,0 +1,113 @@
+[collectory]
+127.0.0.1 ansible_connection=local
+
+[biocache-hub]
+127.0.0.1 ansible_connection=local
+
+[biocache-service-clusterdb]
+127.0.0.1 ansible_connection=local
+
+[bie-hub]
+127.0.0.1 ansible_connection=local
+
+[bie-index]
+127.0.0.1 ansible_connection=local
+
+[image-service]
+127.0.0.1 ansible_connection=local
+
+[species-list]
+127.0.0.1 ansible_connection=local
+
+[regions]
+127.0.0.1 ansible_connection=local
+
+[logger-service]
+127.0.0.1 ansible_connection=local
+
+[solr7-server]
+127.0.0.1 ansible_connection=local
+
+[solrcloud]
+127.0.0.1 ansible_connection=local
+
+[zookeeper]
+127.0.0.1 ansible_connection=local
+
+[cas-servers]
+127.0.0.1 ansible_connection=local
+
+[biocache-db]
+127.0.0.1 ansible_connection=local
+
+[biocache-cli]
+127.0.0.1 ansible_connection=local
+
+[spatial]
+127.0.0.1 ansible_connection=local
+
+[webapi_standalone]
+127.0.0.1 ansible_connection=local
+
+[dashboard]
+127.0.0.1 ansible_connection=local
+
+[alerts-service]
+127.0.0.1 ansible_connection=local
+
+[doi-service]
+127.0.0.1 ansible_connection=local
+
+[nameindexer]
+127.0.0.1 ansible_connection=local
+
+[sds]
+127.0.0.1 ansible_connection=local
+
+[pipelines]
+127.0.0.1 ansible_connection=local
+
+[spark]
+127.0.0.1 ansible_connection=local
+
+[hadoop]
+127.0.0.1 ansible_connection=local
+
+[jenkins]
+127.0.0.1 ansible_connection=local
+
+[pipelines_jenkins]
+127.0.0.1 ansible_connection=local
+
+[data_quality_filter_service]
+127.0.0.1 ansible_connection=local
+
+[namematching-service]
+127.0.0.1 ansible_connection=local
+
+[sensitive-data-service]
+127.0.0.1 ansible_connection=local
+
+[branding]
+127.0.0.1 ansible_connection=local
+
+[biocollect]
+127.0.0.1 ansible_connection=local
+
+[pdfgen]
+127.0.0.1 ansible_connection=local
+
+[ecodata]
+127.0.0.1 ansible_connection=local
+
+[ecodata-reporting]
+127.0.0.1 ansible_connection=local
+
+[events]
+127.0.0.1 ansible_connection=local
+
+[events_elasticsearch]
+127.0.0.1 ansible_connection=local
+
+[cassandra3]
+127.0.0.1 ansible_connection=local


### PR DESCRIPTION
This PR is a variant of the https://github.com/living-atlases/la-data-generator that generates the /data in a local machine. The idea is to generate configurations suitable for docker images.

Run with:
```
   ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate doi
```
or for all services:
```
  ./ala-data-generator --inv=/home/youruser/ala/ansible-inventories/ --data=/data/docker generate
```

For la-toolkit generated inventories, use `./la-data-generator` instead. 

You can use `./utils/la-data-generator` too, and run it from other directories.

Some roles still need some adaptation and I trying to generate all the files with the $user of the user running the script. 

A sample of a db url for a `collectory-mysql` container:

```
$ grep mysql /data/docker/collectory/config/collectory-config.properties 
dataSource.url=jdbc:mysql://collectory-mysql:3306/collectory?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8&useSSL=False&serverTimezone=Australia/Sydney
```

In `la-data-generator` line 71 there is the name used as hosts in db urls. Dockerfiles and charts should match these hosts:

![image](https://github.com/AtlasOfLivingAustralia/ala-install/assets/180085/610e060b-deec-4fb3-b0bf-efc877fd85da)

Next steps:

- Make this also configurable via extra-vars (useful for cas or solr complex hosts urls)
- Create /data/docker/dbs/mysql-collectory-data and similar
- Some roles needs some extra work (pipelines, namematching, sensitive-data-service) because some tasks still fails
- There are some variable with a FIXME that also needs some work
