### PR TITLE
nginx_vhost: add X-Forwarded-Host header for proxy

### DIFF
--- a/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
@@ -56,8 +56,10 @@
         # proxy_set_header Host $host;
 {% if item.proxy_hostname is defined and item.proxy_hostname | length > 0 %}
         proxy_set_header Host {{ item.proxy_hostname }};
+        proxy_set_header X-Forwarded-Host {{ item.proxy_hostname }};
 {% else %}
         proxy_set_header Host {{ hostname }};
+        proxy_set_header X-Forwarded-Host {{ hostname }};
 {% endif %}
 {% if item.proxy_x_request_id is defined %}
         set $x_request_id {{ item.proxy_x_request_id }};


### PR DESCRIPTION
Used by spring boot 2 to set server.tomcat.remoteip.host-header