### PR TITLE
nexus: replace get_url with maven_artifact

### DIFF
--- a/ansible/roles/biocache-cli/tasks/main.yml
+++ b/ansible/roles/biocache-cli/tasks/main.yml
@@ -46,8 +46,32 @@
     - download-zip
     - biocache-cli-update
 
+- name: Install lxml for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+
+- name: Install lxml for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+
 - name: download biocache store jar
-  get_url: url="{{ biocache_store_url }}" dest="/usr/lib/biocache/biocache.zip" force=yes timeout=240
+  maven_artifact:
+    group_id: "{{groupId}}"
+    artifact_id: "{{artifactId}}"
+    version: "{{version|default('latest')}}"
+    extension: "{{packaging|default('jar')}}"
+    classifier: "{{classifier|default('')}}"
+    repository_url: "{{maven_repo_url}}"
+    timeout: 30
+    dest: "/usr/lib/biocache/biocache.zip"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ service_owner | default('root') }}"
+    group: "{{ service_group | default('root') }}"
+    verify_checksum: always
   when: biocache_local_build is not defined
   become: yes
   tags:

--- a/ansible/roles/datacheck/tasks/main.yml
+++ b/ansible/roles/datacheck/tasks/main.yml
@@ -1,7 +1,31 @@
 - include: ../../common/tasks/setfacts.yml
 
+- name: Install lxml for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+
+- name: Install lxml for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+
 - name: copy datacheck webapps
-  get_url: url={{datacheck_war_url}} dest=/var/lib/{{tomcat}}/webapps/datacheck.war force=yes
+  maven_artifact:
+    group_id: "{{groupId}}"
+    artifact_id: "{{artifactId}}"
+    version: "{{version|default('latest')}}"
+    extension: "{{packaging|default('jar')}}"
+    classifier: "{{classifier|default('')}}"
+    repository_url: "{{maven_repo_url}}"
+    timeout: 30
+    dest: "/var/lib/{{tomcat}}/webapps/datacheck.war"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ tomcat_user }}"
+    group: "{{ tomcat_user }}"
+    verify_checksum: always
 
 - name: ensure data directory exists
   file: path={{data_dir}}/sandbox/config state=directory owner={{tomcat_user}} group={{tomcat_user}}

--- a/ansible/roles/datacheck/vars/main.yml
+++ b/ansible/roles/datacheck/vars/main.yml
@@ -4,3 +4,9 @@ datacheck: datacheck
 # assets
 #datacheck_war_url: "{{maven_repo}}/au/org/ala/datacheck/datacheck.war"
 datacheck_war_url: https://nexus.ala.org.au/service/local/artifact/maven/redirect?r=releases&g=au.org.ala&a=sandbox&v=LATEST&e=war
+# remote assets
+version: "LATEST"
+artifactId: "sandbox"
+classifier: "distribution"
+groupId: "au.org.ala"
+packaging: "war"

--- a/ansible/roles/pipelines_migration/tasks/main.yml
+++ b/ansible/roles/pipelines_migration/tasks/main.yml
@@ -3,8 +3,32 @@
   tags:
     - pipelines_migration
 
+- name: Install lxml for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+
+- name: Install lxml for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+
 # copy migration JAR to each node
-- name: download from maven repo {{ migration_jar_url }}
-  get_url: url={{ migration_jar_url }} dest="/usr/share/la-pipelines/{{ war_filename }}.jar" force=true timeout=60
+- name: download from maven repo 
+  maven_artifact:
+    group_id: "{{groupId}}"
+    artifact_id: "{{artifactId}}"
+    version: "{{version|default('latest')}}"
+    extension: "{{packaging|default('jar')}}"
+    classifier: "{{classifier|default('')}}"
+    repository_url: "{{maven_repo_url}}"
+    timeout: 30
+    dest: "/usr/share/la-pipelines/{{ war_filename }}.jar"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ service_owner | default('root') }}"
+    group: "{{ service_group | default('root') }}"
+    verify_checksum: always
   tags:
     - pipelines_migration

--- a/ansible/roles/tomcat_deploy/tasks/main.yml
+++ b/ansible/roles/tomcat_deploy/tasks/main.yml
@@ -15,6 +15,18 @@
 
 - debug: msg="war_filename is {{ war_filename }}; tomcat_deploy_dir is {{ tomcat_deploy_dir }}; log_filename is {{ log_filename }}"
 
+- name: Install lxml for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+
+- name: Install lxml for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
+
 - name: create tomcat vhost
   tomcat_vhost: name="{{ hostname }}" remote_ip_valve="{{tomcat_enable_remote_ip_valve | default(false)}}" remote_internal_proxies="{{tomcat_remote_internal_proxies | default(None)}}" tomcat_conf_dir="{{ tomcat_conf_dir }}"
   when: vhost
@@ -47,7 +59,20 @@
   file: path="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" state=absent
 
 - name: download from maven repo {{ war_url }}
-  get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
+  #get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
+  maven_artifact:
+    group_id: "{{groupId}}"
+    artifact_id: "{{artifactId}}"
+    version: "{{version|default('latest')}}"
+    extension: "{{packaging|default('jar')}}"
+    classifier: "{{classifier|default('')}}"
+    repository_url: "{{maven_repo_url}}"
+    timeout: 30
+    dest: "{{ tomcat_deploy_dir }}/{{ war_filename }}.war"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ tomcat_user }}"
+    group: "{{ tomcat_user }}"
+    verify_checksum: always
   when: war_local_build is not defined
   notify:
     - restart tomcat

--- a/ansible/roles/zoatrack/tasks/main.yml
+++ b/ansible/roles/zoatrack/tasks/main.yml
@@ -357,12 +357,32 @@
   ignore_errors: true
   tags: zoatrack
 
+- name: Install lxml for ansible python 2
+  apt:
+    name: python-lxml
+    state: present
+  when: ansible_python.version.major==2
+
+- name: Install lxml for ansible python 3
+  apt:
+    name: python3-lxml
+    state: present
+  when: ansible_python.version.major==3
 
 - name: download zoatrack war
-  #become_user: "{{ tomcat }}"
-  get_url:
-    url: "{{ zoatrack_war_url }}"
+  maven_artifact:
+    group_id: "{{groupId}}"
+    artifact_id: "{{artifactId}}"
+    version: "{{version|default('latest')}}"
+    extension: "{{packaging|default('jar')}}"
+    classifier: "{{classifier|default('')}}"
+    repository_url: "{{maven_repo_url}}"
+    timeout: 30
     dest: "/var/lib/{{ tomcat }}/webapps/ROOT.war"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ tomcat }}"
+    group: "{{ tomcat }}"
+    verify_checksum: always
   tags: zoatrack
 
 - name: set ownership of webapps


### PR DESCRIPTION
In preparation for ALA's move from nexus 2 to nexus 3, all get_url calls to nexus are now done via the maven_artifact module.