### PR TITLE
change include to include_tasks

### DIFF
--- a/ansible/roles/bie-hub/tasks/main.yml
+++ b/ansible/roles/bie-hub/tasks/main.yml
@@ -198,9 +198,9 @@
     - bie
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/bie-index/tasks/main.yml
+++ b/ansible/roles/bie-index/tasks/main.yml
@@ -173,9 +173,9 @@
     - properties
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -155,9 +155,9 @@
   when: exec_jar
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/biocache3-service/tasks/main.yml
+++ b/ansible/roles/biocache3-service/tasks/main.yml
@@ -467,9 +467,9 @@
     - properties
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/cas-management/tasks/main.yml
+++ b/ansible/roles/cas-management/tasks/main.yml
@@ -69,7 +69,7 @@
     - properties
     - cas-management
 
-- include: ../../docker-common/tasks/common.yml
+- include_tasks: ../../docker-common/tasks/common.yml
   tags:
     - docker
   when: deployment_type == 'swarm'
@@ -93,9 +93,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -110,7 +110,7 @@
     - properties
     - cas
 
-- include: ../../docker-common/tasks/common.yml
+- include_tasks: ../../docker-common/tasks/common.yml
   tags:
     - docker
   when: deployment_type == 'swarm'
@@ -134,9 +134,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/cassandra3/tasks/main.yml
+++ b/ansible/roles/cassandra3/tasks/main.yml
@@ -4,9 +4,9 @@
     - cassandra
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/collectory/tasks/main.yml
+++ b/ansible/roles/collectory/tasks/main.yml
@@ -43,7 +43,7 @@
     - webapps
   when: not webserver_nginx
 
-- include: ../../docker-common/tasks/common.yml
+- include_tasks: ../../docker-common/tasks/common.yml
   tags:
     - docker
   when: deployment_type == 'swarm'
@@ -63,9 +63,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/namematching-service/tasks/main.yml
+++ b/ansible/roles/namematching-service/tasks/main.yml
@@ -91,5 +91,5 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -70,5 +70,5 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'

--- a/ansible/roles/solrcloud/tasks/main.yml
+++ b/ansible/roles/solrcloud/tasks/main.yml
@@ -5,7 +5,7 @@
     - solr_config
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   vars:
     - solr_temp_disable_shardsWhitelist: true
   when: deployment_type == 'swarm'

--- a/ansible/roles/species-list/tasks/main.yml
+++ b/ansible/roles/species-list/tasks/main.yml
@@ -41,7 +41,7 @@
     - bie_index
   when: webserver_nginx and specieslist_proxy_target is not defined
 
-- include: ../../docker-common/tasks/common.yml
+- include_tasks: ../../docker-common/tasks/common.yml
   tags:
     - docker
   when: deployment_type == 'swarm'
@@ -65,9 +65,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -104,9 +104,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'


### PR DESCRIPTION
`include` is deprecated from ansible 2.4. It appears to behave like the new `import_*` (preprocessing) as opposed to the new `include_*` (runtime parsing).