### PR TITLE
Create bie and bie-offline collection if not exists

### DIFF
--- a/ansible/roles/solrcloud/tasks/docker-facts.yml
+++ b/ansible/roles/solrcloud/tasks/docker-facts.yml
@@ -18,6 +18,7 @@
     - docker
     - docker-service
     - docker-compose
+    - solr_config
     - gatus
 
 - name: Create Sorlcloud zk host list
@@ -32,6 +33,7 @@
     - docker
     - docker-service
     - docker-compose
+    - solr_config
     - gatus
 
 - name: Create Sorlcloud solr_url
@@ -41,3 +43,4 @@
     - docker
     - docker-service
     - docker-compose
+    - solr_config

--- a/ansible/roles/solrcloud/tasks/docker-tasks.yml
+++ b/ansible/roles/solrcloud/tasks/docker-tasks.yml
@@ -18,6 +18,7 @@
   tags:
     - solrcloud
     - solr_config
+    - solrcloud_config
     - docker
     - docker-service
 
@@ -47,6 +48,7 @@
   tags:
     - solrcloud
     - solrcloud_config
+    - solr_config
     - docker
     - docker-service
 
@@ -130,7 +132,6 @@
   vars:
     name: la_solrcloud_solr_1
   run_once: true
-  when: docker_development_mode is defined and docker_development_mode == false
   tags:
     - solr_config
 
@@ -139,7 +140,6 @@
     name: la_solrcloud_solr_1
     port: 8983
   run_once: true
-  when: docker_development_mode is defined and docker_development_mode == false
   tags:
     - solr_config
 

--- a/ansible/roles/solrcloud/tasks/main.yml
+++ b/ansible/roles/solrcloud/tasks/main.yml
@@ -142,6 +142,7 @@
     - solrcloud_num_shards: 1
   when: deployment_type == 'swarm'
 
+  # We can let this port open during development
 - name: Remove previous socat container for solr tunnel
   import_tasks: ../../docker-common/tasks/socat-rm.yml
   vars:

--- a/ansible/roles/solrcloud_config/tasks/main.yml
+++ b/ansible/roles/solrcloud_config/tasks/main.yml
@@ -20,7 +20,7 @@
     - solrcloud_config
 
 - name: Get Solr container ID on the specific node if using docker
-  shell: "docker service ps la_sorlcloud_solr_1 --format '{{ '{{' }}.Node{{ '}}' }}' | head -1"
+  shell: "docker service ps la_solrcloud_solr_1 --format '{{ '{{' }}.Node{{ '}}' }}' | head -1"
   register: solr_node
   run_once: true
   when: deployment_type == 'swarm'
@@ -86,17 +86,34 @@
     - solrcloud_config
     - zookeeper_config
 
-- name: Delete biocache collection if it exists
-  get_url: url="http://{{ solr_config_host }}:{{ solr_port }}/solr/admin/collections?action=DELETE&name=biocache" dest=/tmp/delete-collection.txt force=yes
+- name: Check if collections exist
+  uri:
+    url: "http://{{ solr_config_host }}:{{ solr_port }}/solr/admin/collections?action=LIST&wt=json"
+    return_content: true
+  register: solr_collections
+  delegate_to: "{{ solr_node.stdout if deployment_type == 'swarm' else inventory_hostname }}"
   tags:
-    - solrcloud_create_collection
-  ignore_errors: true
-  run_once: true
-  when: solrcloud_config_create_biocache_collection == True
+    - solrcloud_config
+    - zookeeper_config
 
-- name: Create biocache collection
-  get_url: url="http://{{ solr_config_host }}:{{ solr_port }}/solr/admin/collections?action=CREATE&name=biocache&maxShardsPerNode=2&numShards={{ solrcloud_num_shards | default(4)}}&replicationFactor={{ solr_hosts | default(2) }}&collection.configName=biocache" dest=/tmp/create-collection.txt force=yes timeout=30
-  tags:
-    - solrcloud_create_collection
+- name: Create SolrCloud collections if they don't exist
+  uri:
+    url: "http://{{ solr_config_host }}:{{ solr_port }}/solr/admin/collections"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      action: CREATE
+      name: "{{ item.collection_name }}"
+      numShards: "{{ solrcloud_num_shards | default(4) }}"
+      replicationFactor: "{{ solr_hosts | default(2) }}"
+      collection.configName: "{{ item.configset_name }}"
+  when: item.collection_name not in solr_collections.content | from_json | json_query("collections")
+  delegate_to: "{{ solr_node.stdout if deployment_type == 'swarm' else inventory_hostname }}"
   run_once: true
-  when: solrcloud_config_create_biocache_collection == True
+  loop:
+    - {collection_name: "biocache", configset_name: "biocache"}
+    - {collection_name: "bie", configset_name: "bie"}
+    - {collection_name: "bie-offline", configset_name: "bie"}
+  tags:
+    - solrcloud_config
+    - zookeeper_config


### PR DESCRIPTION
As commented with @djtfmartin, in `solrcloud-config` role `bie` and `bie-offline` collections are not created, only `biocache`.

But in `solr` old roles all cores are created.

This PR add both `bie` collections if they don't exist (similarly to `biocache`).

I added some tags, and remove some `where` not necessary in docker-swarm deployment.
