### PR TITLE
Playbooks to deploy by-type

### DIFF
--- a/ansible/auth-by-type.yml
+++ b/ansible/auth-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: cas-servers
+  gather_facts: false
+
+- name: Deploy cas-servers in VM
+  import_playbook: cas5-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy cas-servers in Docker Swarm
+  import_playbook: auth-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/bie-hub-by-type.yml
+++ b/ansible/bie-hub-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: bie-hub
+  gather_facts: false
+
+- name: Deploy bie-hub in VM
+  import_playbook: bie-hub.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy bie-hub in Docker Swarm
+  import_playbook: bie-hub-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/bie-index-by-type.yml
+++ b/ansible/bie-index-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: bie-index
+  gather_facts: false
+
+- name: Deploy bie-index in VM
+  import_playbook: bie-index.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy bie-index in Docker Swarm
+  import_playbook: bie-index-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/biocache-hub-by-type.yml
+++ b/ansible/biocache-hub-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: biocache-hub
+  gather_facts: false
+
+- name: Deploy biocache-hub in VM
+  import_playbook: biocache-hub-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy biocache-hub in Docker Swarm
+  import_playbook: biocache-hub-standalone-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/biocache-service-by-type.yml
+++ b/ansible/biocache-service-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: biocache-service-clusterdb
+  gather_facts: false
+  tasks:
+    - name: Deploy biocache-service-clusterdb in VM
+      import_playbook: biocache-service-clusterdb.yml
+      when: (deployment_type | default('vm')) == 'vm'
+
+    - name: Deploy biocache-service-clusterdb in Docker Swarm
+      import_playbook: biocache-service-clusterdb-docker.yml
+      when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/biocache-service-by-type.yml
+++ b/ansible/biocache-service-by-type.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: biocache-service-clusterdb
   gather_facts: false
-  tasks:
-    - name: Deploy biocache-service-clusterdb in VM
-      import_playbook: biocache-service-clusterdb.yml
-      when: (deployment_type | default('vm')) == 'vm'
 
-    - name: Deploy biocache-service-clusterdb in Docker Swarm
-      import_playbook: biocache-service-clusterdb-docker.yml
-      when: (deployment_type | default('vm')) == 'swarm'
+- name: Deploy biocache-service-clusterdb in VM
+  import_playbook: biocache-service-clusterdb.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy biocache-service-clusterdb in Docker Swarm
+  import_playbook: biocache-service-clusterdb-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/biocache-service-clusterdb-by-type.yml
+++ b/ansible/biocache-service-clusterdb-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: biocache-service-clusterdb
+  gather_facts: false
+
+- name: Deploy biocache-service-clusterdb in VM
+  import_playbook: biocache-service-clusterdb.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy biocache-service-clusterdb in Docker Swarm
+  import_playbook: biocache-service-clusterdb-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/collectory-by-type.yml
+++ b/ansible/collectory-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: collectory
+  gather_facts: false
+
+- name: Deploy collectory in VM
+  import_playbook: collectory-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy collectory in Docker Swarm
+  import_playbook: collectory-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/image-service-by-type.yml
+++ b/ansible/image-service-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: image-service
+  gather_facts: false
+
+- name: Deploy image-service in VM
+  import_playbook: image-service.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy image-service in Docker Swarm
+  import_playbook: image-service-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/logger-service-by-type.yml
+++ b/ansible/logger-service-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: logger-service
+  gather_facts: false
+
+- name: Deploy logger-service in VM
+  import_playbook: logger-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy logger-service in Docker Swarm
+  import_playbook: logger-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/namematching-service-by-type.yml
+++ b/ansible/namematching-service-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: namematching-service
+  gather_facts: false
+
+- name: Deploy namematching-service in VM
+  import_playbook: namematching-service.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy namematching-service in Docker Swarm
+  import_playbook: namematching-service-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/namematching-service.yml
+++ b/ansible/namematching-service.yml
@@ -1,4 +1,4 @@
-# Installs bie-index
+# Installs namematching-service
 - hosts: namematching-service
   roles:
     - common

--- a/ansible/regions-by-type.yml
+++ b/ansible/regions-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: regions
+  gather_facts: false
+
+- name: Deploy regions in VM
+  import_playbook: regions-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy regions in Docker Swarm
+  import_playbook: regions-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/sensitive-data-service-by-type.yml
+++ b/ansible/sensitive-data-service-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: sensitive-data-service
+  gather_facts: false
+
+- name: Deploy sensitive-data-service in VM
+  import_playbook: sensitive-data-service.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy sensitive-data-service in Docker Swarm
+  import_playbook: sensitive-data-service-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/solrcloud-by-type.yml
+++ b/ansible/solrcloud-by-type.yml
@@ -2,8 +2,10 @@
 - hosts: zookeeper,solrcloud
   gather_facts: false
 
-- import_playbook: solrcloud-monit.yml
+- name: Deploy solrcloud in VM
+  import_playbook: solrcloud-monit.yml
   when: (deployment_type | default('vm')) == 'vm'
 
-- import_playbook: solrcloud-docker.yml
+- name: Deploy solrcloud in Docker Swarm
+  import_playbook: solrcloud-docker.yml
   when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/solrcloud-by-type.yml
+++ b/ansible/solrcloud-by-type.yml
@@ -1,0 +1,9 @@
+---
+- hosts: zookeeper,solrcloud
+  gather_facts: false
+
+- import_playbook: solrcloud-monit.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- import_playbook: solrcloud-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/spatial-by-type.yml
+++ b/ansible/spatial-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: spatial
+  gather_facts: false
+
+- name: Deploy spatial in VM
+  import_playbook: spatial.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy spatial in Docker Swarm
+  import_playbook: spatial-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'

--- a/ansible/species-list-by-type.yml
+++ b/ansible/species-list-by-type.yml
@@ -1,0 +1,11 @@
+---
+- hosts: species-list
+  gather_facts: false
+
+- name: Deploy species-list in VM
+  import_playbook: species-list-standalone.yml
+  when: (deployment_type | default('vm')) == 'vm'
+
+- name: Deploy species-list in Docker Swarm
+  import_playbook: species-list-docker.yml
+  when: (deployment_type | default('vm')) == 'swarm'


### PR DESCRIPTION
I added some new playbooks to deploy on VMs or other deployments types based a `deployment_type` variable.

I'm not 100% happy with the solution as I prefer the something like "include" but for the moment it works. Maybe it can be improved in future ansible releases:
https://github.com/ansible/ansible/issues/34281

As this only add new playbooks it does not affect a previous uses.