### PR TITLE
Feature/specieslist jwt properties

### DIFF
--- a/ansible/roles/species-list/tasks/main.yml
+++ b/ansible/roles/species-list/tasks/main.yml
@@ -65,9 +65,9 @@
   when: webserver_nginx
 
 - name: Include docker tasks
-  include: docker-tasks.yml
+  include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'
 
 - name: Include VM tasks
-  include: vm-tasks.yml
+  include_tasks: vm-tasks.yml
   when: deployment_type == 'vm'

--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -97,9 +97,11 @@ security.oidc.secret={{ (lists_client_secret | default(secret)) | default('') }}
 security.oidc.discoveryUri={{ discoveryUri | default('') }}
 security.jwt.discoveryUri={{ discoveryUri | default('') }}
 
+#websevice jwt
 webservice.jwt={{ webservice_jwt | default('false') }}
 webservice.jwt-scopes={{ webservice_jwt_scopes | default('') }}
-
+webservice.client-id={{ jwt_client_id }}
+webservice.client-secret={{ jwt_secret }}
 userDetails.url={{ userdetails_url | default('https://auth.ala.org.au/userdetails/') }}
 
 openapi.components.security.oauth2.authorizationUrl={{ auth_base_url }}/cas/oidc/authorize


### PR DESCRIPTION
- Added some missing config to the config.properties file. Note that added properties `webservice.client-id` and `webservice.client-secret` are identical in value to `security.oidc.clientId` and `security.oidc.secret` Unsure of the background on this, possibly the config can be simplified

- updated the deprecated Ansible directive `include` to `include_tasks`. There will be another PR updating this for other roles 