### PR TITLE
separate variables for the service tag and the actual service name

### DIFF
--- a/ansible/roles/datadog_apm/tasks/main.yml
+++ b/ansible/roles/datadog_apm/tasks/main.yml
@@ -11,7 +11,7 @@
       lineinfile:
         path: "{{ datadog_apm_service_conf}}"
         regexp: '^JAVA_OPTS=".*/dd-java-agent.jar.*'
-        line: 'JAVA_OPTS="${JAVA_OPTS} -javaagent:{{ datadog_apm_service_jar_dir }}dd-java-agent.jar -Ddd.version={{ datadog_apm_service_version }} -Ddd.service={{ datadog_apm_service_name }} -Ddd.env={{ datadog_apm_environment }} -Ddd.logs.injection=true -Ddd.profiling.enabled=true"'
+        line: 'JAVA_OPTS="${JAVA_OPTS} -javaagent:{{ datadog_apm_service_jar_dir }}dd-java-agent.jar -Ddd.version={{ datadog_apm_service_version }} -Ddd.service={{ datadog_apm_service_tag }} -Ddd.env={{ datadog_apm_environment }} -Ddd.logs.injection=true -Ddd.profiling.enabled=true"'
 
     - name: Restart the service
       systemd:


### PR DESCRIPTION
For specieslists the actual service that runs is called tomcat9 but we still want to tag it as specieslists. This change lets us have separate values for the service tag namer and the actual service name

Not sure if lists is the only service where this occurs? Preference would be to change the specieslists service name from tomcat9 to specieslists

companion PR https://github.com/AtlasOfLivingAustralia/ansible-inventories/pull/52