### PR TITLE
Geoserver and geonetwork fix for tomcat_deploy task

### DIFF
--- a/ansible/roles/geonetwork/tasks/main.yml
+++ b/ansible/roles/geonetwork/tasks/main.yml
@@ -32,7 +32,7 @@
     - geonetwork
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ geonetwork_war_url }}' context_path='{{ geonetwork_context_path }}' hostname='{{ geonetwork_hostname }}'
+- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ geonetwork_war_url }}' context_path='{{ geonetwork_context_path }}' hostname='{{ geonetwork_hostname }}' tomcat_deploy_from_url=true
   notify:
     - restart tomcat
   tags:

--- a/ansible/roles/geonetwork/vars/main.yml
+++ b/ansible/roles/geonetwork/vars/main.yml
@@ -4,4 +4,3 @@ artifactId: ""
 packaging: ""
 classifier: ""
 geonetwork_war_url: "https://github.com/geonetwork/core-geonetwork/releases/download/3.4.4/geonetwork.war"
-tomcat_deploy_from_url: true

--- a/ansible/roles/geonetwork/vars/main.yml
+++ b/ansible/roles/geonetwork/vars/main.yml
@@ -4,3 +4,4 @@ artifactId: ""
 packaging: ""
 classifier: ""
 geonetwork_war_url: "https://github.com/geonetwork/core-geonetwork/releases/download/3.4.4/geonetwork.war"
+tomcat_deploy_from_url: true

--- a/ansible/roles/geoserver/defaults/main.yml
+++ b/ansible/roles/geoserver/defaults/main.yml
@@ -1,9 +1,3 @@
-groupId: "org.geoserver.web"
-version: "{{ geoserver_version | default('2.19.2') }}"
-artifactId: "gs-web-app"
-packaging: "war"
-classifier: "war"
-
 geoserver_war_url: "https://repo.osgeo.org/repository/release/org/geoserver/web/gs-web-app/2.19.2/gs-web-app-2.19.2.war"
 geoserver_war_sha1sum: "sha1:db9ce038fb2bea7c67a7012bb338c1447260a2b0"
 

--- a/ansible/roles/geoserver/vars/main.yml
+++ b/ansible/roles/geoserver/vars/main.yml
@@ -1,0 +1,6 @@
+maven_repo_url: "https://repo.osgeo.org/repository/release/"
+groupId: "org.geoserver.web"
+version: "{{ geoserver_version | default('2.19.2') }}"
+artifactId: "gs-web-app"
+packaging: "war"
+classifier: ""

--- a/ansible/roles/tomcat_deploy/tasks/main.yml
+++ b/ansible/roles/tomcat_deploy/tasks/main.yml
@@ -58,8 +58,11 @@
 - name: remove existing webapp (to ensure a clean redeployment)
   file: path="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" state=absent
 
+- name: download from url {{ war_url }}
+  get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
+  when: war_local_build is not defined and tomcat_deploy_from_url | default(false)
+
 - name: download from maven repo {{ war_url }}
-  #get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
   maven_artifact:
     group_id: "{{groupId | default('au.org.ala')}}"
     artifact_id: "{{artifactId}}"
@@ -73,7 +76,7 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_user }}"
     verify_checksum: always
-  when: war_local_build is not defined
+  when: war_local_build is not defined and not tomcat_deploy_from_url | default(false)
   notify:
     - restart tomcat
 

--- a/ansible/roles/tomcat_deploy/tasks/main.yml
+++ b/ansible/roles/tomcat_deploy/tasks/main.yml
@@ -60,7 +60,11 @@
 
 - name: download from url {{ war_url }}
   get_url: url={{ war_url }} dest="{{ tomcat_deploy_dir }}/{{ war_filename }}.war" checksum="{{ war_checksum | default('') }}" force=true timeout=60
-  when: war_local_build is not defined and tomcat_deploy_from_url | default(false)
+  when:
+    - war_local_build is not defined
+    - tomcat_deploy_from_url | default(false)
+  notify:
+    - restart tomcat
 
 - name: download from maven repo {{ war_url }}
   maven_artifact:
@@ -76,7 +80,9 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_user }}"
     verify_checksum: always
-  when: war_local_build is not defined and not tomcat_deploy_from_url | default(false)
+  when:
+    - war_local_build is not defined
+    - not tomcat_deploy_from_url | default(false)
   notify:
     - restart tomcat
 


### PR DESCRIPTION
More work for #694, that works now as expected:

```
TASK [download from maven repo https://repo.osgeo.org/repository/release/org/geoserver/web/gs-web-app/2.19.2/gs-web-app-2.19.2.war] ***
Wednesday 11 October 2023  11:54:27 +0200 (0:00:00.472)       0:02:45.678 ***** 
changed: [ala-install-test-2]
```

Geonetwork it still failing because it's downloaded from a github release.