### PR TITLE
Fix for 712

### DIFF
--- a/ansible/roles/pg_instance/tasks/main.yml
+++ b/ansible/roles/pg_instance/tasks/main.yml
@@ -60,7 +60,7 @@
     - pg_instance
 
 - name: grant role "{{db_user}}" to "{{ db_login_user }}" - remote
-  community.postgresql.postgresql_membership:
+  postgresql_membership:
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_login_user }}"
     login_password: "{{ db_login_password }}"


### PR DESCRIPTION
Fix for #712.

This does not fails now:

![image](https://github.com/AtlasOfLivingAustralia/ala-install/assets/180085/1ca48a38-364e-4a97-ab14-2554936229a0)
