### PR TITLE
fix biocache-hub merge

### DIFF
--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -34,22 +34,6 @@
     - biocache_hub
   when: webserver_nginx
 
-#
-# WAR/JAR file deployment
-#
-- name: add jar and service
-  include_role:
-    name: exec-jar
-  vars:
-    service_name: '{{ biocache_hub }}'
-    jar_url: '{{ biocache_hub_artifact_url }}'
-    log_config_filename: logback.xml
-  tags:
-    - deploy
-    - service
-    - biocache_hub
-  when: exec_jar
-
 - include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocache_hub_artifact_url }}' context_path='{{ biocache_hub_context_path }}' hostname='{{ biocache_hub_hostname }}'
   tags:
     - webapps

--- a/ansible/roles/biocache-hub/tasks/vm-tasks.yml
+++ b/ansible/roles/biocache-hub/tasks/vm-tasks.yml
@@ -8,6 +8,7 @@
   vars:
     service_name: '{{ biocache_hub }}'
     jar_url: '{{ biocache_hub_artifact_url }}'
+    log_config_filename: logback.xml
   tags:
     - deploy
     - service


### PR DESCRIPTION
- biocache-hub role was running exec-jar for non-vm deployments when it is in vm-tasks. 
- It was also running exec-jar twice, with different configuration, for vm deployments.
- The most recent version of the duplicated code block was used.