### PR TITLE
- fixed config to allow CORS requests from bie prod

### DIFF
--- a/ansible/roles/profile-service/templates/profile-service-config.properties
+++ b/ansible/roles/profile-service/templates/profile-service-config.properties
@@ -62,7 +62,7 @@ webservice.client-secret={{ profile_service_ws_clientSecret | default('') }}
 
 grails.cors.enabled=true
 grails.cors.allowedOrigins[0]=https://bie.ala.org.au
-grails.cors.allowedOrigins[0]=https://bie-test.ala.org.au
+grails.cors.allowedOrigins[1]=https://bie-test.ala.org.au
 
 # fathom analytics
 fathom.api.url={{ fathom_api_url | default('https://api.usefathom.com/v1/aggregations') }}


### PR DESCRIPTION
Linked to https://github.com/AtlasOfLivingAustralia/profile-hub/issues/805