### PR TITLE
tomcat9 log fix

### DIFF
--- a/ansible/roles/tomcat/templates/systemd-service-override.conf.j2
+++ b/ansible/roles/tomcat/templates/systemd-service-override.conf.j2
@@ -7,3 +7,5 @@ Environment='UMASK={{ tomcat_umask }}'
 Restart=on-failure
 RestartSec=5
 
+StandardOutput=append:{{ catalina_log_file | default('/var/log/tomcat9/catalina.out') }}
+StandardError=append:{{ catalina_log_file | default('/var/log/tomcat9/catalina.out') }}


### PR DESCRIPTION
Tomcat9 uses the app logger config and write logs to the default catalina.out