### PR TITLE
Added new regions map variables

### DIFF
--- a/ansible/roles/regions/templates/regions-config.properties
+++ b/ansible/roles/regions/templates/regions-config.properties
@@ -67,8 +67,10 @@ google.apikey={{ google_apikey | default('') }}
 {{ skin_breadcrumb | default('') }}
 
 accordion.panel.maxHeight={{ regions_accordion_panel_maxheight | default('') }}
-map.height={{ regions_map_height | default('') }}
-map.bounds={{ regions_map_bounds | default('[]') }}
+map.minLat={{ regions_map_min_lat | default(-41.5) }}
+map.minLng={{ regions_map_min_lng | default(114) }}
+map.maxLat={{ regions_map_max_lat | default(-13.5) }}
+map.maxLng={{ regions_map_max_lng | default(154) }}
 
 default.regionType={{ default_region_type | default('') }}
 default.region={{ default_region | default('') }}


### PR DESCRIPTION
I added the new regions map variables introduced by [this commit](https://github.com/AtlasOfLivingAustralia/ala-install/pull/new/regions-new-map-vars) to allow other LA Portals to configure their maps.