### PR TITLE
Make sure browsers do not cache reuse cors requests for different sub…

### DIFF
--- a/ansible/roles/nginx_vhost/templates/ala_cors.j2
+++ b/ansible/roles/nginx_vhost/templates/ala_cors.j2
@@ -45,6 +45,7 @@ if ($cors = COPTIONS) {
   add_header 'Content-Type' 'text/plain; charset=utf-8';
   add_header 'Content-Length' 0;
   add_header 'Access-Control-Allow-Origin' $http_origin;
+  add_header 'Vary' "Origin"; 
   {% if nginx_cors_allow_credentials == True %}
     add_header 'Access-Control-Allow-Credentials' 'true';
   {% endif %}
@@ -55,6 +56,7 @@ if ($cors = CPOST) {
   add_header 'Access-Control-Allow-Headers' '{{ nginx_cors_headers }}';
   add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
   add_header 'Access-Control-Allow-Origin' $http_origin;
+  add_header 'Vary' "Origin"; 
   {% if nginx_cors_allow_credentials == True %}
     add_header 'Access-Control-Allow-Credentials' 'true';
   {% endif %}
@@ -64,6 +66,7 @@ if ($cors = CGET) {
   add_header 'Access-Control-Allow-Headers' '{{ nginx_cors_headers }}';
   add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
   add_header 'Access-Control-Allow-Origin' $http_origin;
+  add_header 'Vary' "Origin"; 
   {% if nginx_cors_allow_credentials == True %}
     add_header 'Access-Control-Allow-Credentials' 'true';
   {% endif %}


### PR DESCRIPTION
Hello everyone, just playing around with the platform in order to try and set something up for the Flemish institute of Nature and Forestry.
This project has been extremely helpful in getting to grips with the living atlas platform.
So thanks a lot !

I just noticed that, when running using subdomains, the header bars would not always be populated.
The reason seemed to be the CORS request for some of the resources were failing.

Apparently the browser was caching the CORS and reusing it for different sub-domains.
So if I were to go to the authentication page first, it would get a response with `'Access-Control-Allow-Origin' http://auth.la-flanders.org;`.
If I then navigated to the record interfaces it would reuse the same CORS response, but for a different domain i.e. `records.la-flanders.org`, causing a mismatch and the CORS check would fail.

Adding the Vary header should signal browsers they cannot reuse the responses across origins.
