### PR TITLE
Updates to support the latest ansible stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project includes a playbook for setting up an ALA demo.
 
 ## Prerequisites
 
-### Ansible: The current supported version is: **2.10.3**
+### Ansible: The current supported version is: **2.16.6** (core) and **9.5.1** (community)
 
 The playbooks and roles in this repository have been developed and tested against the above version. Typically you need to install ansible in your computer or in the computer you'll use to deploy from.
 
@@ -15,7 +15,7 @@ For APT:
 ```
 $ sudo apt-get install software-properties-common python-dev git python-pip
 $ sudo pip install setuptools
-$ sudo pip install -I ansible==[version]
+$ sudo pip install -I ansible==[community-version] ansible-core==[core-version]
 ```
 
 where ```[version]``` is the supported version listed above.
@@ -24,10 +24,10 @@ For OSX:
 
 ```
 $ sudo easy_install pip
-$ sudo pip install -I ansible==[version]
+$ sudo pip install -I ansible==[community-version] ansible-core==[core-version]
 ```
 
-where ```[version]``` is the supported version listed above.
+where ```[version]``` is the supported version listed above. You'll need also python >= `3.10`.
 
 If you see this error:
 ```

--- a/ansible/archived/roles/ozatlas-proxy/tasks/main.yml
+++ b/ansible/archived/roles/ozatlas-proxy/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - ozatlas-proxy
 
@@ -36,7 +36,10 @@
     - ozatlas-proxy
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ ozatlas_proxy_context_path }}' hostname='{{ ozatlas_proxy_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ ozatlas_proxy_context_path }}'
+    hostname: '{{ ozatlas_proxy_hostname }}'
   tags:
     - ozatlas-proxy
     - apache_vhost
@@ -56,7 +59,11 @@
     - ozatlas-proxy
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ ozatlas_proxy_war_url }}' context_path='{{ozatlas_proxy_context_path}}' hostname='{{ ozatlas_proxy_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ ozatlas_proxy_war_url }}'
+    context_path: '{{ozatlas_proxy_context_path}}'
+    hostname: '{{ ozatlas_proxy_hostname }}'
   tags:
     - ozatlas-proxy
     - tomcat_vhost

--- a/ansible/roles/alerts/tasks/main.yml
+++ b/ansible/roles/alerts/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - alerts
     - properties
@@ -45,7 +45,10 @@
     - properties
     - alerts
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ alerts_context_path }}' hostname='{{ alerts_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ alerts_context_path }}'
+    hostname: '{{ alerts_hostname }}'
   tags:
     - alerts
     - apache_vhost
@@ -65,7 +68,11 @@
     - alerts
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ alerts_war_url }}' context_path='{{ alerts_context_path }}' hostname='{{ alerts_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ alerts_war_url }}'
+    context_path: '{{ alerts_context_path }}'
+    hostname: '{{ alerts_hostname }}'
   tags:
     - alerts
     - tomcat_vhost

--- a/ansible/roles/ansible-elasticsearch/filter_plugins/custom.py
+++ b/ansible/roles/ansible-elasticsearch/filter_plugins/custom.py
@@ -2,7 +2,9 @@ __author__ = 'dale mcdiarmid'
 
 import re
 import os.path
-from six import string_types
+# Workaround for:
+# https://github.com/elastic/ansible-elasticsearch/issues/819
+from ansible.module_utils.six import string_types
 
 def modify_list(values=[], pattern='', replacement='', ignorecase=False):
     ''' Perform a `re.sub` on every item in the list'''

--- a/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
@@ -65,7 +65,7 @@
 
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
-  include: elasticsearch-optional-user.yml
+  include_tasks: elasticsearch-optional-user.yml
 
 - name: Debian - Get installed elasticsearch version
   command: dpkg-query --showformat='${Version}' --show {{ es_package_name }}

--- a/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-Debian.yml
@@ -74,12 +74,16 @@
   changed_when: False
   check_mode: no
 
+- name: Output installed Elasticsearch version
+  debug:
+    msg: "Installed Elasticsearch version: '{{ installed_es_version.stdout }}'"
+
 - name: Debian - unhold elasticsearch version
   become: yes
   dpkg_selections:
     name: "{{ es_package_name }}"
     selection: "install"
-  when: not es_version_lock or (installed_es_version.stdout and installed_es_version.stdout != es_version)
+  when: (not es_version_lock or (installed_es_version.stdout and installed_es_version.stdout != es_version)) and installed_es_version.stdout != ""
 
 - name: Debian - Ensure elasticsearch is installed
   become: yes

--- a/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-RedHat.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/elasticsearch-RedHat.yml
@@ -26,7 +26,7 @@
   when: es_use_repository
 
 - name: RedHat - include versionlock
-  include: elasticsearch-RedHat-version-lock.yml
+  include_tasks: elasticsearch-RedHat-version-lock.yml
 
 - name: RedHat - Remove the other elasticsearch package if switching between OSS and standard
   become: yes
@@ -36,7 +36,7 @@
 
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
-  include: elasticsearch-optional-user.yml
+  include_tasks: elasticsearch-optional-user.yml
 
 - name: RedHat - Install Elasticsearch
   become: yes

--- a/ansible/roles/ansible-elasticsearch/tasks/elasticsearch.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/elasticsearch.yml
@@ -1,9 +1,9 @@
 ---
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-Debian.yml
+  include_tasks: elasticsearch-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-RedHat.yml
+  include_tasks: elasticsearch-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/ansible/roles/ansible-elasticsearch/tasks/main.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/main.yml
@@ -12,44 +12,44 @@
       - always
 
 - name: set compatibility variables
-  include: compatibility-variables.yml
+  include_tasks: compatibility-variables.yml
   tags:
       - always
 
 - name: check-set-parameters
-  include: elasticsearch-parameters.yml
+  include_tasks: elasticsearch-parameters.yml
   tags:
       - always
 
 - name: use snapshot release
-  include: snapshot-release.yml
+  include_tasks: snapshot-release.yml
   when: es_use_snapshot_release
 
 - name: include java.yml
-  include: java.yml
+  include_tasks: java.yml
   when: es_java_install
   tags:
       - java
 
 - name: include elasticsearch.yml
-  include: elasticsearch.yml
+  include_tasks: elasticsearch.yml
   tags:
       - install
 
 - name: include elasticsearch-config.yml
-  include: elasticsearch-config.yml
+  include_tasks: elasticsearch-config.yml
   tags:
       - config
 
 - name: include elasticsearch-plugins.yml
-  include: elasticsearch-plugins.yml
+  include_tasks: elasticsearch-plugins.yml
   when: es_plugins is defined or es_plugins_reinstall
   tags:
       - plugins
 
   #We always execute xpack as we may need to remove features
 - name: include xpack/elasticsearch-xpack.yml
-  include: xpack/elasticsearch-xpack.yml
+  include_tasks: xpack/elasticsearch-xpack.yml
   tags:
       - xpack
 
@@ -81,18 +81,18 @@
   when: manage_native_realm
 
 - name: activate-license
-  include: ./xpack/security/elasticsearch-xpack-activation.yml
+  include_tasks: ./xpack/security/elasticsearch-xpack-activation.yml
   when: es_start_service and es_enable_xpack and es_xpack_license is defined and es_xpack_license != ''
 
 #perform security actions here now elasticsearch is started
 - name: include xpack/security/elasticsearch-security-native.yml
-  include: ./xpack/security/elasticsearch-security-native.yml
+  include_tasks: ./xpack/security/elasticsearch-security-native.yml
   when: manage_native_realm
 
 #Templates done after restart - handled by flushing the handlers. e.g. suppose user removes security on a running node and doesn't specify es_api_basic_auth_username and es_api_basic_auth_password.  The templates will subsequently not be removed if we don't wait for the node to restart.
 #We also do after the native realm to ensure any changes are applied here first and its denf up.
 - name: include elasticsearch-template.yml
-  include: elasticsearch-template.yml
+  include_tasks: elasticsearch-template.yml
   when: es_templates
   tags:
       - templates

--- a/ansible/roles/ansible-elasticsearch/tasks/xpack/elasticsearch-xpack.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/xpack/elasticsearch-xpack.yml
@@ -2,7 +2,7 @@
 
 #Security configuration
 - name: include security/elasticsearch-security.yml
-  include: security/elasticsearch-security.yml
+  include_tasks: security/elasticsearch-security.yml
   when: es_enable_xpack
 
 #Make sure elasticsearch.keystore has correct Permissions

--- a/ansible/roles/ansible-elasticsearch/tasks/xpack/security/elasticsearch-security.yml
+++ b/ansible/roles/ansible-elasticsearch/tasks/xpack/security/elasticsearch-security.yml
@@ -38,7 +38,7 @@
 
 #-----------------------------FILE BASED REALM----------------------------------------
 
-- include: elasticsearch-security-file.yml
+- include_tasks: elasticsearch-security-file.yml
   when: (es_users is defined and es_users.file is defined) or (es_roles is defined and es_roles.file is defined)
 
 #-----------------------------ROLE MAPPING ----------------------------------------

--- a/ansible/roles/ansible-elasticsearch/test/integration/issue-test.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/issue-test.yml
@@ -6,7 +6,7 @@
 - name: Simple Example
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/ansible-elasticsearch/test/integration/oss-to-xpack-upgrade.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/oss-to-xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -13,7 +13,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/ansible-elasticsearch/test/integration/oss-upgrade.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/oss-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -13,7 +13,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/ansible-elasticsearch/test/integration/oss.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/oss.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/ansible-elasticsearch/test/integration/xpack-upgrade.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Elasticsearch Xpack tests initial
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -110,7 +110,7 @@
 - name: Elasticsearch Xpack modify
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/ansible-elasticsearch/test/integration/xpack.yml
+++ b/ansible/roles/ansible-elasticsearch/test/integration/xpack.yml
@@ -3,7 +3,7 @@
 - name: Elasticsearch Xpack tests - no security and manual download
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/ansible/roles/appd/tasks/main.yml
+++ b/ansible/roles/appd/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - appd
 

--- a/ansible/roles/arga-service/tasks/main.yml
+++ b/ansible/roles/arga-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - arga-service
     - nginx_vhost

--- a/ansible/roles/bie-hub/tasks/main.yml
+++ b/ansible/roles/bie-hub/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - webapps
     - properties
@@ -87,7 +87,10 @@
     - properties
     - bie
 
-- include: ../../apache_vhost/tasks/main.yml context_path='/{{ bie_hub_context_path }}' hostname='{{ bie_hub_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '/{{ bie_hub_context_path }}'
+    hostname: '{{ bie_hub_hostname }}'
   tags:
     - webapps
     - apache_vhost

--- a/ansible/roles/bie-hub/tasks/vm-tasks.yml
+++ b/ansible/roles/bie-hub/tasks/vm-tasks.yml
@@ -1,5 +1,9 @@
 ---
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ bie_hub_war_url }}' context_path='{{ bie_hub_context_path }}' hostname='{{ bie_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ bie_hub_war_url }}'
+    context_path: '{{ bie_hub_context_path }}'
+    hostname: '{{ bie_hub_hostname }}'
   when: bie_hub_local_build is not defined
   tags:
     - webapps
@@ -7,7 +11,11 @@
     - deploy
     - bie
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ bie_hub_local_build }}' context_path='{{ bie_hub_context_path }}' hostname='{{ bie_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ bie_hub_local_build }}'
+    context_path: '{{ bie_hub_context_path }}'
+    hostname: '{{ bie_hub_hostname }}'
   when: bie_hub_local_build is defined
   tags:
     - webapps

--- a/ansible/roles/bie-index/tasks/main.yml
+++ b/ansible/roles/bie-index/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - webapps
     - config
@@ -106,7 +106,10 @@
     - properties
     - bie-index
 
-- include: ../../apache_vhost/tasks/main.yml context_path='/{{ bie_index_context_path }}' hostname='{{ bie_index_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '/{{ bie_index_context_path }}'
+    hostname: '{{ bie_index_hostname }}'
   tags:
     - webapps
     - apache_vhost

--- a/ansible/roles/bie-index/tasks/vm-tasks.yml
+++ b/ansible/roles/bie-index/tasks/vm-tasks.yml
@@ -1,5 +1,9 @@
 ---
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ bie_index_war_url }}' context_path='{{ bie_index_context_path }}' hostname='{{ bie_index_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ bie_index_war_url }}'
+    context_path: '{{ bie_index_context_path }}'
+    hostname: '{{ bie_index_hostname }}'
   when: bie_index_local_build is not defined
   tags:
     - webapps
@@ -7,7 +11,11 @@
     - deploy
     - bie-index
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ bie_index_local_build }}' context_path='{{ bie_index_context_path }}' hostname='{{ bie_index_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ bie_index_local_build }}'
+    context_path: '{{ bie_index_context_path }}'
+    hostname: '{{ bie_index_hostname }}'
   when: bie_index_local_build is defined
   tags:
     - webapps

--- a/ansible/roles/bie-webapp/tasks/main.yml
+++ b/ansible/roles/bie-webapp/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - bie-webapp
 
@@ -30,7 +30,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ bie_webapp_context_path }}' hostname='{{ bie_webapp_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ bie_webapp_context_path }}'
+    hostname: '{{ bie_webapp_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -50,7 +53,11 @@
     - bie-webapp
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ bie_webapp_war_url }}' context_path='{{bie_webapp_context_path}}' hostname='{{ bie_webapp_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ bie_webapp_war_url }}'
+    context_path: '{{bie_webapp_context_path}}'
+    hostname: '{{ bie_webapp_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/biocache-cli/tasks/main.yml
+++ b/ansible/roles/biocache-cli/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - biocache-cli
     - vocabs

--- a/ansible/roles/biocache-db/tasks/main.yml
+++ b/ansible/roles/biocache-db/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: disable swap
   shell: "swapoff --all"

--- a/ansible/roles/biocache-hub/tasks/main.yml
+++ b/ansible/roles/biocache-hub/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - webapps
     - properties
@@ -11,7 +11,10 @@
 # Apache/Tomcat virtual host configuration
 #
 
-- include: ../../apache_vhost/tasks/main.yml context_path='/{{ biocache_hub_context_path }}' hostname='{{ biocache_hub_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '/{{ biocache_hub_context_path }}'
+    hostname: '{{ biocache_hub_hostname }}'
   tags:
     - webapps
     - apache_vhost
@@ -34,7 +37,11 @@
     - biocache_hub
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocache_hub_artifact_url }}' context_path='{{ biocache_hub_context_path }}' hostname='{{ biocache_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ biocache_hub_artifact_url }}'
+    context_path: '{{ biocache_hub_context_path }}'
+    hostname: '{{ biocache_hub_hostname }}'
   tags:
     - webapps
     - tomcat_vhost

--- a/ansible/roles/biocache-hub/tasks/vm-tasks.yml
+++ b/ansible/roles/biocache-hub/tasks/vm-tasks.yml
@@ -15,7 +15,11 @@
     - biocache_hub
   when: exec_jar
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocache_hub_artifact_url }}' context_path='{{ biocache_hub_context_path }}' hostname='{{ biocache_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ biocache_hub_artifact_url }}'
+    context_path: '{{ biocache_hub_context_path }}'
+    hostname: '{{ biocache_hub_hostname }}'
   tags:
     - webapps
     - tomcat_vhost

--- a/ansible/roles/biocache-properties/tasks/main.yml
+++ b/ansible/roles/biocache-properties/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - biocache-properties

--- a/ansible/roles/biocache-service/tasks/main.yml
+++ b/ansible/roles/biocache-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - tomcat_vhost
     - biocache-service
@@ -8,7 +8,10 @@
     - symlinks
     - apache_vhost
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}' 
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}' 
   tags:
     - biocache-service
     - deploy
@@ -340,7 +343,11 @@
 #    - deploy
 #  when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocache_service_war_path }}' context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ biocache_service_war_path }}'
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}'
   when: biocache_service_local_build is not defined
   tags:
     - biocache-service
@@ -348,7 +355,11 @@
     - tomcat_vhost
     - webapps
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ biocache_service_local_build }}' context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ biocache_service_local_build }}'
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}'
   when: biocache_service_local_build is defined
   tags:
     - biocache-service

--- a/ansible/roles/biocache3-db/tasks/main.yml
+++ b/ansible/roles/biocache3-db/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: disable swap
   shell: "swapoff --all"

--- a/ansible/roles/biocache3-properties/tasks/main.yml
+++ b/ansible/roles/biocache3-properties/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - biocache-properties

--- a/ansible/roles/biocache3-service/tasks/main.yml
+++ b/ansible/roles/biocache3-service/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - tomcat_vhost
     - biocache-service
@@ -9,7 +9,10 @@
     - symlinks
     - apache_vhost
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}' 
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}' 
   tags:
     - biocache-service
     - deploy

--- a/ansible/roles/biocache3-service/tasks/vm-tasks.yml
+++ b/ansible/roles/biocache3-service/tasks/vm-tasks.yml
@@ -1,6 +1,10 @@
 ---
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocache_service_war_path }}' context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ biocache_service_war_path }}'
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}'
   when: biocache_service_local_build is not defined
   tags:
     - biocache-service
@@ -8,7 +12,11 @@
     - tomcat_vhost
     - webapps
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ biocache_service_local_build }}' context_path='{{ biocache_service_context_path }}' hostname='{{ biocache_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ biocache_service_local_build }}'
+    context_path: '{{ biocache_service_context_path }}'
+    hostname: '{{ biocache_service_hostname }}'
   when: biocache_service_local_build is defined
   tags:
     - biocache-service

--- a/ansible/roles/biocollect/tasks/main.yml
+++ b/ansible/roles/biocollect/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - deploy
     - biocollect
@@ -102,7 +102,7 @@
 
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ biocollect_context_path }}'
     hostname='{{ biocollect_hostname }}'
   tags:
@@ -168,7 +168,11 @@
     - biocollect
   when: webserver_nginx and biocollect_rewrite_root | bool
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ biocollect_war_url }}' context_path='{{biocollect_context_path}}' hostname='{{ biocollect_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ biocollect_war_url }}'
+    context_path: '{{biocollect_context_path}}'
+    hostname: '{{ biocollect_hostname }}'
   tags:
     - deploy
     - biocollect

--- a/ansible/roles/branding/tasks/main.yml
+++ b/ansible/roles/branding/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - branding
 

--- a/ansible/roles/calendars/tasks/main.yml
+++ b/ansible/roles/calendars/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - calendars
     - deploy
@@ -31,7 +31,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ calendars_context_path }}' hostname='{{ calendars_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ calendars_context_path }}'
+    hostname: '{{ calendars_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -51,7 +54,11 @@
     - calendars
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ calendars_war_url }}' context_path='{{calendars_context_path}}' hostname='{{ calendars_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ calendars_war_url }}'
+    context_path: '{{calendars_context_path}}'
+    hostname: '{{ calendars_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/cas2/tasks/main.yml
+++ b/ansible/roles/cas2/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - cas
     - properties
@@ -94,7 +94,7 @@
   when: not webserver_nginx
 
 
-- include: ../../apache_vhost/tasks/main.yml 
+- include_tasks: ../../apache_vhost/tasks/main.yml
      context_path='{{ cas_context_path }}' 
      hostname='{{ cas_hostname }}' 
   tags:
@@ -116,7 +116,11 @@
     - cas
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ cas_war_url }}' context_path='{{ cas_context_path }}' hostname='{{ cas_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ cas_war_url }}'
+    context_path: '{{ cas_context_path }}'
+    hostname: '{{ cas_hostname }}'
   tags:
     - cas
     - deploy

--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Install pymongo for Python 3 using pip
   pip:
     name: pymongo
-    version: ">=4.0"
+    version: "3.12.2"
   when: ansible_python.version.major==3
   tags:
     - cas-dbs

--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -26,7 +26,6 @@
     packages:
       - mysql-client
       - python3-mysqldb
-      - python3-pymongo
   when: ansible_python.version.major==3
   tags:
     - cas-dbs
@@ -41,6 +40,14 @@
 - name: Install pip3 when necessary
   apt:
     name: python3-pip
+  when: ansible_python.version.major==3
+  tags:
+    - cas-dbs
+
+- name: Install pymongo for Python 3 using pip
+  pip:
+    name: pymongo
+    version: ">=4.0"
   when: ansible_python.version.major==3
   tags:
     - cas-dbs
@@ -179,7 +186,7 @@
     password: "{{ item.password }}"
     database: "{{ item.database }}"
     roles: "{{ item.roles }}"
-    replica_set: "{{ item.replica_set }}"
+    replica_set: "{{ item.replica_set | default(omit) if item.replica_set != '' else omit }}"
     ssl: "{{ item.ssl }}"
     state: present
     login_host: "{{ item.login_host }}"

--- a/ansible/roles/cassandra3/tasks/main.yml
+++ b/ansible/roles/cassandra3/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - cassandra
 

--- a/ansible/roles/cassandra3/tasks/vm-tasks.yml
+++ b/ansible/roles/cassandra3/tasks/vm-tasks.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - cassandra
 

--- a/ansible/roles/collectory/tasks/main.yml
+++ b/ansible/roles/collectory/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - collectory
@@ -51,7 +51,10 @@
     - properties
     - collectory
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ collectory_context_path }}' hostname='{{ collectory_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ collectory_context_path }}'
+    hostname: '{{ collectory_hostname }}'
   tags:
     - deploy
     - apache_vhost

--- a/ansible/roles/collectory/tasks/vm-tasks.yml
+++ b/ansible/roles/collectory/tasks/vm-tasks.yml
@@ -26,7 +26,11 @@
     - properties
     - collectory
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ collectory_war_url }}' context_path='{{ collectory_context_path }}' hostname='{{ collectory_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ collectory_war_url }}'
+    context_path: '{{ collectory_context_path }}'
+    hostname: '{{ collectory_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags: common
 # We need to: 
 #

--- a/ansible/roles/dashboard/tasks/main.yml
+++ b/ansible/roles/dashboard/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - dashboard
     - properties
@@ -39,7 +39,10 @@
     - dashboard
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ dashboard_context_path }}' hostname='{{ dashboard_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ dashboard_context_path }}'
+    hostname: '{{ dashboard_hostname }}'
   tags:
     - dashboard
     - apache_vhost
@@ -59,7 +62,11 @@
     - dashboard
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ dashboard_war_url }}' context_path='{{ dashboard_context_path }}' hostname='{{ dashboard_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ dashboard_war_url }}'
+    context_path: '{{ dashboard_context_path }}'
+    hostname: '{{ dashboard_hostname }}'
   tags:
     - dashboard
     - tomcat_vhost

--- a/ansible/roles/data_quality_filter_service/tasks/main.yml
+++ b/ansible/roles/data_quality_filter_service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - webapps
     - properties
@@ -10,7 +10,10 @@
 # Apache/Tomcat virtual host configuration
 #
 
-- include: ../../apache_vhost/tasks/main.yml context_path='/{{ data_quality_filter_service_context_path }}' hostname='{{ data_quality_filter_service_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '/{{ data_quality_filter_service_context_path }}'
+    hostname: '{{ data_quality_filter_service_hostname }}'
   tags:
     - webapps
     - apache_vhost
@@ -47,7 +50,11 @@
     - data_quality_filter_service
   when: exec_jar
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ data_quality_filter_service_artifact_url }}' context_path='{{ data_quality_filter_service_context_path }}' hostname='{{ data_quality_filter_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ data_quality_filter_service_artifact_url }}'
+    context_path: '{{ data_quality_filter_service_context_path }}'
+    hostname: '{{ data_quality_filter_service_hostname }}'
   tags:
     - webapps
     - tomcat_vhost

--- a/ansible/roles/datacheck/tasks/main.yml
+++ b/ansible/roles/datacheck/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: Install lxml for ansible python 2
   apt:

--- a/ansible/roles/db-backup/tasks/main.yml
+++ b/ansible/roles/db-backup/tasks/main.yml
@@ -1,11 +1,11 @@
-- include: ./mongo.yml
+- include_tasks: ./mongo.yml
   when: db == 'mongo' or db == 'mongodb'
   tags: db
 
-- include: ./mysql.yml
+- include_tasks: ./mysql.yml
   when: db == 'mysql'
   tags: db
 
-- include: ./postgres.yml
+- include_tasks: ./postgres.yml
   when: db == 'postgres'
   tags: db

--- a/ansible/roles/demo/tasks/main.yml
+++ b/ansible/roles/demo/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - demo
 

--- a/ansible/roles/doi-service/tasks/main.yml
+++ b/ansible/roles/doi-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - doi-service
     - deploy
@@ -8,7 +8,10 @@
 #
 # JAR file deployment
 #
-#- include: ../../exec_jar/tasks/main.yml jar_url='{{ doi_service_jar_url }}' service_name='doi-service'
+#- include_tasks: ../../exec_jar/tasks/main.yml
+  vars:
+    jar_url: '{{ doi_service_jar_url }}'
+    service_name: 'doi-service'
 - name: add jar and service
   include_role:
     name: exec-jar

--- a/ansible/roles/ecodata/tasks/main.yml
+++ b/ansible/roles/ecodata/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - ecodata
     - deploy
@@ -140,7 +140,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ ecodata_context_path }}' hostname='{{ ecodata_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ ecodata_context_path }}'
+    hostname: '{{ ecodata_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -240,7 +243,11 @@
     - ecodata
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ ecodata_war_url }}' context_path='{{ecodata_context_path}}' hostname='{{ ecodata_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ ecodata_war_url }}'
+    context_path: '{{ecodata_context_path}}'
+    hostname: '{{ ecodata_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/elasticsearch/tasks/elasticsearch.yml
+++ b/ansible/roles/elasticsearch/tasks/elasticsearch.yml
@@ -1,20 +1,20 @@
 ---
 
-- include: install.deb.yml
+- include_tasks: install.deb.yml
   when: ansible_os_family == 'Debian'
   tags: [elasticsearch, elasticsearch-install]
 
-- include: install.yum.yml
+- include_tasks: install.yum.yml
   when: ansible_os_family == 'RedHat'
   tags: [elasticsearch, elasticsearch-install]
 
-- include: configure.yml
+- include_tasks: configure.yml
   tags: [elasticsearch, elasticsearch-configure]
 
-- include: plugins.yml
+- include_tasks: plugins.yml
   tags: [elasticsearch, elasticsearch-plugins]
 
-- include: proxy.yml
+- include_tasks: proxy.yml
   when: elasticsearch_proxy | bool == True
   tags: [elasticsearch, elasticsearch-proxy]
 

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: elasticsearch.yml
+- include_tasks: elasticsearch.yml
   when: elasticsearch_enabled | bool == True
   tags: [elasticsearch]

--- a/ansible/roles/elasticsearch/test.yml
+++ b/ansible/roles/elasticsearch/test.yml
@@ -1,8 +1,8 @@
 - hosts: all
   tasks:
-    - include: 'tasks/main.yml'
+    - include_tasks: 'tasks/main.yml'
   handlers:
-    - include: 'handlers/main.yml'
+    - include_tasks: 'handlers/main.yml'
   vars_files:
     - 'defaults/main.yml'
     - '.travis.yml'

--- a/ansible/roles/exec-jar-generic/tasks/main.yml
+++ b/ansible/roles/exec-jar-generic/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - service
 

--- a/ansible/roles/exec-jar/tasks/main.yml
+++ b/ansible/roles/exec-jar/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - service
 

--- a/ansible/roles/expert/tasks/main.yml
+++ b/ansible/roles/expert/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - expert
 
@@ -31,7 +31,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ expert_context_path }}' hostname='{{ expert_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ expert_context_path }}'
+    hostname: '{{ expert_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -51,7 +54,11 @@
     - expert
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ expert_war_url }}' context_path='{{expert_context_path}}' hostname='{{ expert_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ expert_war_url }}'
+    context_path: '{{expert_context_path}}'
+    hostname: '{{ expert_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/fieldguide/tasks/main.yml
+++ b/ansible/roles/fieldguide/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - fieldguide
     - properties
@@ -10,7 +10,10 @@
 # WAR file deployment and virtual host configuration
 #
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ fieldguide_context_path }}' hostname='{{ fieldguide_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ fieldguide_context_path }}'
+    hostname: '{{ fieldguide_hostname }}'
   tags:
     - fieldguide
     - deploy
@@ -30,7 +33,11 @@
     - fieldguide
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ fieldguide_war_url }}' context_path='{{ fieldguide_context_path }}' hostname='{{ fieldguide_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ fieldguide_war_url }}'
+    context_path: '{{ fieldguide_context_path }}'
+    hostname: '{{ fieldguide_hostname }}'
   tags:
     - fieldguide
     - deploy

--- a/ansible/roles/gatus/tasks/main.yml
+++ b/ansible/roles/gatus/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - gatus

--- a/ansible/roles/geonetwork/tasks/main.yml
+++ b/ansible/roles/geonetwork/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - geonetwork
 
@@ -12,7 +12,10 @@
   tags:
     - geonetwork
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ geonetwork_context_path }}' hostname='{{ geonetwork_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ geonetwork_context_path }}'
+    hostname: '{{ geonetwork_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -32,7 +35,12 @@
     - geonetwork
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ geonetwork_war_url }}' context_path='{{ geonetwork_context_path }}' hostname='{{ geonetwork_hostname }}' tomcat_deploy_from_url=true
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ geonetwork_war_url }}'
+    context_path: '{{ geonetwork_context_path }}'
+    hostname: '{{ geonetwork_hostname }}'
+    tomcat_deploy_from_url:true
   notify:
     - restart tomcat
   tags:

--- a/ansible/roles/geoserver/tasks/ecodata-geoserver.yml
+++ b/ansible/roles/geoserver/tasks/ecodata-geoserver.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - geoserver
     - geoserver_run_script
@@ -27,7 +27,10 @@
 - debug:
     msg: "geoserver_context_path is {{geoserver_context_path}} hostname {{ geoserver_hostname }}"
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ geoserver_context_path }}' hostname='{{ geoserver_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ geoserver_context_path }}'
+    hostname: '{{ geoserver_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -47,7 +50,11 @@
     - geoserver
   when: webserver_nginx and (geoserver_private == True)
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ geoserver_war_url }}' context_path='{{ geoserver_context_path }}' hostname='{{ geoserver_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ geoserver_war_url }}'
+    context_path: '{{ geoserver_context_path }}'
+    hostname: '{{ geoserver_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/geoserver/tasks/geoserver.yml
+++ b/ansible/roles/geoserver/tasks/geoserver.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - geoserver
     - geoserver_run_script
@@ -42,7 +42,10 @@
   register: geoserver_data_dir_check
   check_mode: no
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ geoserver_context_path }}' hostname='{{ geoserver_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ geoserver_context_path }}'
+    hostname: '{{ geoserver_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -62,7 +65,11 @@
     - geoserver
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ geoserver_war_url }}' context_path='{{ geoserver_context_path }}' hostname='{{ geoserver_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ geoserver_war_url }}'
+    context_path: '{{ geoserver_context_path }}'
+    hostname: '{{ geoserver_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/geoserver/tasks/main.yml
+++ b/ansible/roles/geoserver/tasks/main.yml
@@ -5,12 +5,12 @@
     - geoserver
     - which-geoserver
 
-- include: ./geoserver.yml
+- include_tasks: ./geoserver.yml
   when: geoserver_task == "geoserver"
   tags:
     - geoserver
 
-- include: ./ecodata-geoserver.yml
+- include_tasks: ./ecodata-geoserver.yml
   when: geoserver_task == "ecodata"
   tags:
     - geoserver

--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - image-service
     - properties
@@ -13,7 +13,10 @@
     - image-service
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ image_service_context_path }}' hostname='{{ image_service_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ image_service_context_path }}'
+    hostname: '{{ image_service_hostname }}'
   tags:
     - deploy
     - apache_vhost

--- a/ansible/roles/ipt/tasks/main.yml
+++ b/ansible/roles/ipt/tasks/main.yml
@@ -1,4 +1,7 @@
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ ipt_context_path }}' hostname='{{ ipt_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ ipt_context_path }}'
+    hostname: '{{ ipt_hostname }}'
   tags:
     - ipt
     - apache_vhost
@@ -18,7 +21,11 @@
     - ipt
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ ipt_war_url }}' context_path='{{ipt_context_path}}' hostname='{{ ipt_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ ipt_war_url }}'
+    context_path: '{{ipt_context_path}}'
+    hostname: '{{ ipt_hostname }}'
   tags:
     - ipt
     - tomcat_vhost

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
 
 
 - name: "Show java version"
@@ -7,11 +7,11 @@
   tags:
     - java
 
-- include: openjdk-java-8.yml
+- include_tasks: openjdk-java-8.yml
   when: use_openjdk8 is defined and use_openjdk8 | bool == True
 
-- include: zulu-8.yml
+- include_tasks: zulu-8.yml
   when: use_zulu8 is defined and use_zulu8 | bool == True
 
-- include: openjdk-java-11.yml
+- include_tasks: openjdk-java-11.yml
   when: use_openjdk11 is defined and use_openjdk11 | bool == True

--- a/ansible/roles/java/tasks/openjdk-java-11.yml
+++ b/ansible/roles/java/tasks/openjdk-java-11.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - java
 

--- a/ansible/roles/java/tasks/openjdk-java-8.yml
+++ b/ansible/roles/java/tasks/openjdk-java-8.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - java
 

--- a/ansible/roles/java/tasks/zulu-8.yml
+++ b/ansible/roles/java/tasks/zulu-8.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - java
 

--- a/ansible/roles/jenkins-simple/tasks/main.yml
+++ b/ansible/roles/jenkins-simple/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - apt_key: url="https://pkg.jenkins.io//{{ jenkins_channel }}/jenkins.io-2023.key" state=present id=5BA31D57EF5975CA
   when: ansible_os_family == "Debian"

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - apt_key: url="https://pkg.jenkins.io/{{ jenkins_channel }}/jenkins.io.key" state=present
   when: ansible_os_family == "Debian"

--- a/ansible/roles/layer-ingestion/tasks/main.yml
+++ b/ansible/roles/layer-ingestion/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - ingestion
 

--- a/ansible/roles/layers-db/tasks/main.yml
+++ b/ansible/roles/layers-db/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:    
     - layers-db
 

--- a/ansible/roles/layers-service/tasks/main.yml
+++ b/ansible/roles/layers-service/tasks/main.yml
@@ -1,9 +1,12 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:    
     - layers-service
     - webapps
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ layers_service_context_path }}' hostname='{{ layers_service_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ layers_service_context_path }}'
+    hostname: '{{ layers_service_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -24,7 +27,11 @@
     - layers-service
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ layers_service_war_url }}' context_path='{{ layers_service_context_path }}' hostname='{{ layers_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ layers_service_war_url }}'
+    context_path: '{{ layers_service_context_path }}'
+    hostname: '{{ layers_service_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/logger-client/tasks/main.yml
+++ b/ansible/roles/logger-client/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: ensure target directories exist [data subdirectories etc.]
   file: path={{item}} state=directory owner={{tomcat_user}} group={{tomcat_user}}

--- a/ansible/roles/logger-service/tasks/main.yml
+++ b/ansible/roles/logger-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - logger-service
     - properties
@@ -75,7 +75,10 @@
     - logger-service
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ logger_context_path }}' hostname='{{ logger_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ logger_context_path }}'
+    hostname: '{{ logger_hostname }}'
   tags:
     - logger-service
     - deploy
@@ -163,7 +166,11 @@
     - logger-service
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ logger_war_url }}' context_path='{{ logger_context_path }}' hostname='{{ logger_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ logger_war_url }}'
+    context_path: '{{ logger_context_path }}'
+    hostname: '{{ logger_hostname }}'
   tags:
     - logger-service
     - deploy

--- a/ansible/roles/lucene4to5/tasks/main.yml
+++ b/ansible/roles/lucene4to5/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: download lucene 5 core and backward-codecs
   get_url:

--- a/ansible/roles/merit-grails4/tasks/main.yml
+++ b/ansible/roles/merit-grails4/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - deploy
     - merit
@@ -80,7 +80,7 @@
 
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ merit_context_path }}'
     hostname='{{ merit_hostname }}'
   tags:

--- a/ansible/roles/merit/tasks/main.yml
+++ b/ansible/roles/merit/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - deploy
     - apache_vhost
@@ -8,7 +8,7 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ merit_context_path }}'
     hostname='{{ merit_hostname }}'
   tags:
@@ -35,7 +35,11 @@
     - merit
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ merit_war_url }}' context_path='{{merit_context_path}}' hostname='{{ merit_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ merit_war_url }}'
+    context_path: '{{merit_context_path}}'
+    hostname: '{{ merit_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -7,13 +7,13 @@
     - mongodb
     - packages
 
-- include: ./install_2_x.yml
+- include_tasks: ./install_2_x.yml
   when: ansible_os_family == "Debian" and mongo_version.find('2.') == 0
   tags:
     - mongo
     - pagackes
 
-- include: ./install_3_x.yml
+- include_tasks: ./install_3_x.yml
   when: ansible_os_family == "Debian" and mongo_version.find('3.') == 0
   tags:
     - mongo

--- a/ansible/roles/moths/tasks/main.yml
+++ b/ansible/roles/moths/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - moths
 

--- a/ansible/roles/mysql-5.7/tasks/main.yml
+++ b/ansible/roles/mysql-5.7/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: install mysql (RedHat)
   yum:

--- a/ansible/roles/mysql-8.0/tasks/main.yml
+++ b/ansible/roles/mysql-8.0/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: install mysql (RedHat)
   yum:

--- a/ansible/roles/mysql-legacy/tasks/main.yml
+++ b/ansible/roles/mysql-legacy/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - mysql
 

--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: install mysql (RedHat)
   yum:

--- a/ansible/roles/namedata/tasks/main.yml
+++ b/ansible/roles/namedata/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - namedata
     - deploy

--- a/ansible/roles/nameindex/tasks/main.yml
+++ b/ansible/roles/nameindex/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - "nameindex"
     - "nameindex-stage"

--- a/ansible/roles/nameindexer/tasks/main.yml
+++ b/ansible/roles/nameindexer/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:  
     - "data_archives"  
     - "nameindexer"

--- a/ansible/roles/namematching-service/tasks/main.yml
+++ b/ansible/roles/namematching-service/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - namematching-service
     - deploy

--- a/ansible/roles/namematching-service/tasks/vm-tasks.yml
+++ b/ansible/roles/namematching-service/tasks/vm-tasks.yml
@@ -1,6 +1,6 @@
 ---
 
-- include: ./apt.yml
+- include_tasks: ./apt.yml
   tags:
     - namematching-service
     - deploy

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -15,32 +15,32 @@
     - nginx
 
 # Setup/install tasks.
-- include: setup-redhat.yml
+- include_tasks: setup-redhat.yml
   when: ansible_os_family | lower == 'redhat'
   tags:
     - nginx
 
-- include: setup-ubuntu.yml
+- include_tasks: setup-ubuntu.yml
   when: ansible_distribution | lower == 'ubuntu'
   tags:
     - nginx
 
-- include: setup-debian.yml
+- include_tasks: setup-debian.yml
   when: ansible_os_family | lower == 'debian'
   tags:
     - nginx
 
-- include: setup-freebsd.yml
+- include_tasks: setup-freebsd.yml
   when: ansible_os_family | lower == 'freebsd'
   tags:
     - nginx
 
-- include: setup-openbsd.yml
+- include_tasks: setup-openbsd.yml
   when: ansible_os_family | lower == 'openbsd'
   tags:
     - nginx
 
-- include: setup-archlinux.yml
+- include_tasks: setup-archlinux.yml
   when: ansible_os_family | lower == 'archlinux'
   tags:
     - nginx
@@ -55,7 +55,7 @@
     - nginx
 
 # Vhost configuration.
-- include: vhosts.yml
+- include_tasks: vhosts.yml
   tags:
     - nginx
 

--- a/ansible/roles/nginx_vhost/handlers/main.yml
+++ b/ansible/roles/nginx_vhost/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: clear nginx cache
-  include: clear_nginx_cache.yml
+  include_tasks: clear_nginx_cache.yml
 
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf

--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -540,11 +540,9 @@
     - nginx_vhost
 
 - name: "Default host"
-  include: "defaulthost.yml"
+  include_tasks: "defaulthost.yml"
   when:
     - ( aws_elb_healthcheck_default | bool == True or nginx_default_vhost_required | bool == True ) and vhost_required | bool == True
-  notify:
-   - reload nginx
   tags:
     - nginx_vhost
 

--- a/ansible/roles/oznome-demo/tasks/main.yml
+++ b/ansible/roles/oznome-demo/tasks/main.yml
@@ -1,11 +1,14 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - oznome-demo
 
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ oznome_demo_context_path }}' hostname='{{ oznome_demo_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ oznome_demo_context_path }}'
+    hostname: '{{ oznome_demo_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -25,7 +28,11 @@
     - oznome-demo
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ oznome_demo_war_url }}' context_path='{{oznome_demo_context_path}}' hostname='{{ oznome_demo_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ oznome_demo_war_url }}'
+    context_path: '{{oznome_demo_context_path}}'
+    hostname: '{{ oznome_demo_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/pdf-service/tasks/main.yml
+++ b/ansible/roles/pdf-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags: 
     - pdf-service
     - nginx_vhost
@@ -168,7 +168,7 @@
 #
 # webserver virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml 
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ profile_service_context_path }}' 
     hostname='{{ profile_service_hostname }}'
   tags:

--- a/ansible/roles/phylolink/tasks/main.yml
+++ b/ansible/roles/phylolink/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - phylolink
     - deploy

--- a/ansible/roles/pigeonhole/tasks/main.yml
+++ b/ansible/roles/pigeonhole/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - pigeonhole
 
@@ -18,7 +18,10 @@
     - properties
     - config    
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ pigeonhole_context_path }}' hostname='{{ pigeonhole_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ pigeonhole_context_path }}'
+    hostname: '{{ pigeonhole_hostname }}'
   tags:
     - pigeonhole
     - apache_vhost
@@ -38,7 +41,11 @@
     - pigeonhole
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ pigeonhole_war_url }}' context_path='{{ pigeonhole_context_path }}' hostname='{{ pigeonhole_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ pigeonhole_war_url }}'
+    context_path: '{{ pigeonhole_context_path }}'
+    hostname: '{{ pigeonhole_hostname }}'
   tags:
     - pigeonhole
     - tomcat_vhost

--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - pipelines
     - docker
@@ -273,7 +273,7 @@
     - pipelines-services
     - docker
 
-- include: ../../namematching-service/tasks/apt.yml
+- include_tasks: ../../namematching-service/tasks/apt.yml
   when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
   tags:
     - pipelines
@@ -281,7 +281,7 @@
     - la-pipelines
     - apt
 
-- include: ../../sensitive-data-service/tasks/apt.yml
+- include_tasks: ../../sensitive-data-service/tasks/apt.yml
   when: use_docker_with_pipelines is defined and use_docker_with_pipelines | bool == False
   tags:
     - pipelines

--- a/ansible/roles/pipelines_jenkins/tasks/main.yml
+++ b/ansible/roles/pipelines_jenkins/tasks/main.yml
@@ -2,7 +2,7 @@
 # to enable master/slave setup through the Jenkins admin UI
 #
 
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - pipelines_jenkins
     - pipelines_jenkins_jobs

--- a/ansible/roles/pipelines_migration/tasks/main.yml
+++ b/ansible/roles/pipelines_migration/tasks/main.yml
@@ -1,5 +1,5 @@
 # Steps up pipelines migration
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - pipelines_migration
 

--- a/ansible/roles/portainer/tasks/main.yml
+++ b/ansible/roles/portainer/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - portainer

--- a/ansible/roles/postgresql/tasks/barman.yml
+++ b/ansible/roles/postgresql/tasks/barman.yml
@@ -1,5 +1,5 @@
 - name: setup apt
-  include: apt.yml
+  include_tasks: apt.yml
 
 - name: Barman | Install Barman
   apt:

--- a/ansible/roles/postgresql/tasks/debian.yml
+++ b/ansible/roles/postgresql/tasks/debian.yml
@@ -49,11 +49,11 @@
     - restart postgresql
 
 - name: Set database directory
-  ini_file:
-    dest: "/etc/postgresql/{{pg_version}}/main/postgresql.conf"
-    section:
-    option: "data_directory"
-    value: "'{{ postgresql_data_directory }}'"
+  lineinfile:
+    path: "/etc/postgresql/{{ pg_version }}/main/postgresql.conf"
+    regexp: '^data_directory ='
+    line: "data_directory = '{{ postgresql_data_directory }}'"
+    backrefs: yes
   tags: postgresql
   notify:
     - restart postgresql

--- a/ansible/roles/postgresql/tasks/debian.yml
+++ b/ansible/roles/postgresql/tasks/debian.yml
@@ -6,7 +6,7 @@
     - "../vars/{{ ansible_os_family }}.yml"
   tags: postgresql
 
-- include: apt.yaml
+- include_tasks: apt.yaml
 
 - set_fact:
     postgresql_packages: [ "{{ psycopg2_package }}", "postgresql-{{pg_version}}", "postgresql-contrib-{{pg_version}}", "libpq-dev" ]

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags: postgresql
 
 # tasks file for ntp
@@ -10,27 +10,27 @@
     - "../vars/{{ ansible_os_family }}.yml"
   tags: postgresql
 
-- include: ./old.yml
+- include_tasks: ./old.yml
   when: ansible_os_family == "RedHat" or pg_version is not defined
   tags:
     - postgresql
     - packages
     - info
 
-- include: ./debian.yml
+- include_tasks: ./debian.yml
   when: ansible_os_family == "Debian" and pg_version is defined
   tags:
     - postgresql
     - packages
     - info
 
-- include: ./postgis.yml
+- include_tasks: ./postgis.yml
   when: postgis_version is defined
   tags:
     - postgresql
     - postgis
 
-- include: ./gdal.yml
+- include_tasks: ./gdal.yml
   when: postgis_version is defined
   tags:
     - postgresql

--- a/ansible/roles/postgresql/tasks/old.yml
+++ b/ansible/roles/postgresql/tasks/old.yml
@@ -11,7 +11,7 @@
     msg: "WARNING YOU ARE USING THE DEPRECATED LEGACY POSTGRES SUPPORT ROLE, PLEASE UPDATE INVENTORY TO USE NEW ROLE + pg_instance BY PROVIDING pg_version AND OPTIONALLY postgis_version VARIABLES AND ADDING pg_instance ROLES AS APPROPRIATE"
 
 - name: Setup apt repositories
-  include: apt.yaml
+  include_tasks: apt.yaml
   tags: postgresql
 
 - name: install setfacl support

--- a/ansible/roles/profile-hub/tasks/main.yml
+++ b/ansible/roles/profile-hub/tasks/main.yml
@@ -20,7 +20,7 @@
   tags:
     - profile-hub
 
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - profile-hub
     - deploy
@@ -164,7 +164,7 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ profile_hub_context_path }}'
     hostname='{{ profile_hub_hostname }}'
   tags:
@@ -188,7 +188,11 @@
   when: webserver_nginx
 
 # deploy to tomcat container
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ profile_hub_war_url }}' context_path='{{ profile_hub_context_path }}' hostname='{{ profile_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ profile_hub_war_url }}'
+    context_path: '{{ profile_hub_context_path }}'
+    hostname: '{{ profile_hub_hostname }}'
   tags:
     - profile-hub
     - deploy

--- a/ansible/roles/profile-service/tasks/main.yml
+++ b/ansible/roles/profile-service/tasks/main.yml
@@ -14,7 +14,7 @@
     - profile-service
   when: exec_jar
 
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - profile-service
     - deploy
@@ -144,7 +144,7 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml
+- include_tasks: ../../apache_vhost/tasks/main.yml
     context_path='{{ profile_service_context_path }}'
     hostname='{{ profile_service_hostname }}'
   tags:
@@ -188,7 +188,11 @@
     - profile-service
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ profile_service_war_url }}' context_path='{{ profile_service_context_path }}' hostname='{{ profile_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ profile_service_war_url }}'
+    context_path: '{{ profile_service_context_path }}'
+    hostname: '{{ profile_service_hostname }}'
   tags:
     - profile-service
     - deploy

--- a/ansible/roles/regions/tasks/main.yml
+++ b/ansible/roles/regions/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - properties
     - regions
@@ -6,7 +6,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ regions_context_path }}' hostname='{{ regions_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ regions_context_path }}'
+    hostname: '{{ regions_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -26,7 +29,11 @@
     - regions
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ regions_war_url }}' context_path='{{regions_context_path}}' hostname='{{ regions_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ regions_war_url }}'
+    context_path: '{{regions_context_path}}'
+    hostname: '{{ regions_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/sampling-service-apache/tasks/main.yml
+++ b/ansible/roles/sampling-service-apache/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: Copy proxy config to sites-available (Debian)
   template: src=sampling-service.conf dest=/etc/apache2/sites-available/ owner=root group=root

--- a/ansible/roles/sampling-service/tasks/main.yml
+++ b/ansible/roles/sampling-service/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: download from maven repo
   command: "wget {{sampling_service_war_url}} --output-document={{tomcat_webapps}}sampling-service.war"

--- a/ansible/roles/sandbox/tasks/main.yml
+++ b/ansible/roles/sandbox/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: setup sandbox
-  include: ../../common/tasks/setfacts.yml
+  include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - sandbox
 
@@ -8,7 +8,11 @@
 #
 
 - name: setup apache for sandbox
-  include: ../../apache_vhost/tasks/main.yml context_path='{{ sandbox_context_path }}' hostname='{{ sandbox_hostname }}' additional_proxy_pass='{{ additional_proxy_pass_values }}'
+  include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ sandbox_context_path }}'
+    hostname: '{{ sandbox_hostname }}'
+    additional_proxy_pass: '{{ additional_proxy_pass_values }}'
   tags:
     - sandbox
     - deploy
@@ -45,7 +49,11 @@
      - sandbox
 
 - name: setup tomcat for sandbox
-  include: ../../tomcat_deploy/tasks/main.yml war_url='{{ sandbox_war_url }}' context_path='{{ sandbox_context_path }}' hostname='{{ sandbox_hostname }}'
+  include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ sandbox_war_url }}'
+    context_path: '{{ sandbox_context_path }}'
+    hostname: '{{ sandbox_hostname }}'
   tags:
     - sandbox
     - deploy

--- a/ansible/roles/sds/tasks/main.yml
+++ b/ansible/roles/sds/tasks/main.yml
@@ -1,9 +1,12 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - sds
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ sds_context_path }}' hostname='{{ sds_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ sds_context_path }}'
+    hostname: '{{ sds_hostname }}'
   tags:
     - sds
     - apache_vhost
@@ -33,14 +36,22 @@
     - sds
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ sds_webapp_url }}' context_path='{{ sds_context_path }}' hostname='{{ sds_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ sds_webapp_url }}'
+    context_path: '{{ sds_context_path }}'
+    hostname: '{{ sds_hostname }}'
   when: sds_webapp_local_build is not defined
   tags:
     - sds
     - tomcat_vhost
     - deploy
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ sds_webapp_local_build }}' context_path='{{ sds_context_path }}' hostname='{{ sds_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ sds_webapp_local_build }}'
+    context_path: '{{ sds_context_path }}'
+    hostname: '{{ sds_hostname }}'
   when: sds_webapp_local_build is defined
   tags:
     - sds

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - sensitive-data-service
     - deploy

--- a/ansible/roles/sensitive-data-service/tasks/vm-tasks.yml
+++ b/ansible/roles/sensitive-data-service/tasks/vm-tasks.yml
@@ -1,12 +1,12 @@
 ---
 
-- include: ../namematching-service/tasks/apt.yml
+- include_tasks: ../namematching-service/tasks/apt.yml
   tags:
     - sensitive-data-service
     - deploy
     - apt
 
-- include: ./apt.yml
+- include_tasks: ./apt.yml
   tags:
     - sensitive-data-service
     - deploy

--- a/ansible/roles/sightings/tasks/main.yml
+++ b/ansible/roles/sightings/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - sightings
 
@@ -30,7 +30,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ sightings_context_path }}' hostname='{{ sightings_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ sightings_context_path }}'
+    hostname: '{{ sightings_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -50,7 +53,11 @@
     - sightings
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ sightings_war_url }}' context_path='{{sightings_context_path}}' hostname='{{ sightings_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ sightings_war_url }}'
+    context_path: '{{sightings_context_path}}'
+    hostname: '{{ sightings_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/solr4/tasks/main.yml
+++ b/ansible/roles/solr4/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - apache_vhost
     - tomcat_vhost
@@ -19,7 +19,10 @@
   tags:
     - solr       
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ solr_context_path }}' hostname='{{ solr_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ solr_context_path }}'
+    hostname: '{{ solr_hostname }}'
   tags:
     - solr
     - apache_vhost
@@ -36,7 +39,11 @@
     - nginx_vhost
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ solr_war_url }}' context_path='{{ solr_context_path }}' hostname='{{ solr_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ solr_war_url }}'
+    context_path: '{{ solr_context_path }}'
+    hostname: '{{ solr_hostname }}'
   tags:
     - solr    
 

--- a/ansible/roles/solr6/tasks/main.yml
+++ b/ansible/roles/solr6/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - solr6
     - solr6_create_cores

--- a/ansible/roles/solr7/tasks/main.yml
+++ b/ansible/roles/solr7/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - solr7
     - solr7_create_cores

--- a/ansible/roles/solr_monit/tasks/main.yml
+++ b/ansible/roles/solr_monit/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - solr_monit
 

--- a/ansible/roles/solrcloud/tasks/main.yml
+++ b/ansible/roles/solrcloud/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - solrcloud
     - solr_config

--- a/ansible/roles/solrcloud/tasks/vm-tasks.yml
+++ b/ansible/roles/solrcloud/tasks/vm-tasks.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - solrcloud
     - solr_config

--- a/ansible/roles/spatial-analysis/tasks/main.yml
+++ b/ansible/roles/spatial-analysis/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:    
     - spatial-analysis
 
@@ -9,7 +9,10 @@
   tags:
     - spatial-analysis
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ spatial_analysis_context_path }}' hostname='{{ spatial_analysis_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ spatial_analysis_context_path }}'
+    hostname: '{{ spatial_analysis_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -29,7 +32,11 @@
     - spatial-analysis
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ spatial_analysis_war_url }}' context_path='{{ spatial_analysis_context_path }}' hostname='{{ spatial_analysis_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ spatial_analysis_war_url }}'
+    context_path: '{{ spatial_analysis_context_path }}'
+    hostname: '{{ spatial_analysis_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/spatial-hub-hub/tasks/main.yml
+++ b/ansible/roles/spatial-hub-hub/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - spatial-hub-hub
 

--- a/ansible/roles/spatial-hub/tasks/main.yml
+++ b/ansible/roles/spatial-hub/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
 - name: ensure target directories exist [data subdirectories etc.]
   file: path={{item}} state=directory owner={{tomcat_user}} group={{tomcat_user}}
@@ -34,7 +34,10 @@
     - spatial-hub-config
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ spatial_hub_context_path }}' hostname='{{ spatial_hub_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ spatial_hub_context_path }}'
+    hostname: '{{ spatial_hub_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -71,7 +74,11 @@
     - spatial-hub
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ spatial_hub_war_url }}' context_path='{{ spatial_hub_context_path }}' hostname='{{ spatial_hub_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ spatial_hub_war_url }}'
+    context_path: '{{ spatial_hub_context_path }}'
+    hostname: '{{ spatial_hub_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/spatial-portal/tasks/main.yml
+++ b/ansible/roles/spatial-portal/tasks/main.yml
@@ -1,9 +1,12 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - spatial-portal
     - config    
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ spatial_portal_context_path }}' hostname='{{ spatial_portal_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ spatial_portal_context_path }}'
+    hostname: '{{ spatial_portal_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -23,7 +26,11 @@
     - spatial-portal
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ spatial_portal_war_url }}' context_path='{{ spatial_portal_context_path }}' hostname='{{ spatial_portal_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ spatial_portal_war_url }}'
+    context_path: '{{ spatial_portal_context_path }}'
+    hostname: '{{ spatial_portal_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -1,6 +1,9 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ spatial_service_context_path }}' hostname='{{ spatial_service_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ spatial_service_context_path }}'
+    hostname: '{{ spatial_service_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -50,7 +53,11 @@
     - spatial-service
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ spatial_service_war_url }}' context_path='{{ spatial_service_context_path }}' hostname='{{ spatial_service_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ spatial_service_war_url }}'
+    context_path: '{{ spatial_service_context_path }}'
+    hostname: '{{ spatial_service_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/species-list/tasks/main.yml
+++ b/ansible/roles/species-list/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - specieslist
     - properties
@@ -33,7 +33,10 @@
     - specieslist
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ specieslist_context_path }}' hostname='{{ specieslist_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ specieslist_context_path }}'
+    hostname: '{{ specieslist_hostname }}'
   tags:
     - specieslist
     - apache_vhost

--- a/ansible/roles/species-list/tasks/vm-tasks.yml
+++ b/ansible/roles/species-list/tasks/vm-tasks.yml
@@ -28,14 +28,22 @@
     - db
     - dbfix
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ specieslist_war_url }}' context_path='{{ specieslist_context_path }}' hostname='{{ specieslist_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ specieslist_war_url }}'
+    context_path: '{{ specieslist_context_path }}'
+    hostname: '{{ specieslist_hostname }}'
   when: specieslist_local_build is not defined
   tags:
     - specieslist
     - tomcat_vhost
     - deploy
 
-- include: ../../tomcat_deploy/tasks/main.yml war_local_build='{{ specieslist_local_build }}' context_path='{{ specieslist_context_path }}' hostname='{{ specieslist_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_local_build: '{{ specieslist_local_build }}'
+    context_path: '{{ specieslist_context_path }}'
+    hostname: '{{ specieslist_hostname }}'
   when: specieslist_local_build is defined
   tags:
     - specieslist

--- a/ansible/roles/specimenbrowser/tasks/main.yml
+++ b/ansible/roles/specimenbrowser/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - specimenbrowser
     - properties
@@ -43,7 +43,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ specimenbrowser_context_path }}' hostname='{{ specimenbrowser_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ specimenbrowser_context_path }}'
+    hostname: '{{ specimenbrowser_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -63,7 +66,11 @@
     - specimenbrowser
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ specimenbrowser_war_url }}' context_path='{{specimenbrowser_context_path}}' hostname='{{ specimenbrowser_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ specimenbrowser_war_url }}'
+    context_path: '{{specimenbrowser_context_path}}'
+    hostname: '{{ specimenbrowser_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/taxon-overflow/tasks/main.yml
+++ b/ansible/roles/taxon-overflow/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - taxonoverflow
 
@@ -41,7 +41,10 @@
     - taxonoverflow
     - properties
 
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ taxonoverflow_context_path }}' hostname='{{ taxonoverflow_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ taxonoverflow_context_path }}'
+    hostname: '{{ taxonoverflow_hostname }}'
   tags:
     - taxonoverflow
     - apache_vhost
@@ -61,7 +64,11 @@
     - taxonoverflow
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ taxonoverflow_war_url }}' context_path='{{ taxonoverflow_context_path }}' hostname='{{ taxonoverflow_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ taxonoverflow_war_url }}'
+    context_path: '{{ taxonoverflow_context_path }}'
+    hostname: '{{ taxonoverflow_hostname }}'
   tags:
     - taxonoverflow
     - tomcat_vhost

--- a/ansible/roles/timeseries/tasks/main.yml
+++ b/ansible/roles/timeseries/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - timeseries
 
@@ -30,7 +30,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ timeseries_context_path }}' hostname='{{ timeseries_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ timeseries_context_path }}'
+    hostname: '{{ timeseries_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -50,7 +53,11 @@
     - timeseries
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ timeseries_war_url }}' context_path='{{timeseries_context_path}}' hostname='{{ timeseries_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ timeseries_war_url }}'
+    context_path: '{{timeseries_context_path}}'
+    hostname: '{{ timeseries_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -1,7 +1,7 @@
 # set up tomcat consistently whenever needed.  Used as:
-# - include: ../common/tasks/tomcat.yml 
+# - include_tasks: ../common/tasks/tomcat.yml
 # "tomcat" variable controls version (@see common/vars)
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - packages
     - tomcat

--- a/ansible/roles/tviewer/tasks/main.yml
+++ b/ansible/roles/tviewer/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - tviewer
 
@@ -30,7 +30,10 @@
 #
 # WAR file deployment and virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ tviewer_context_path }}' hostname='{{ tviewer_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ tviewer_context_path }}'
+    hostname: '{{ tviewer_hostname }}'
   tags:
     - deploy
     - apache_vhost
@@ -50,7 +53,11 @@
     - tviewer
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ tviewer_war_url }}' context_path='{{tviewer_context_path}}' hostname='{{ tviewer_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ tviewer_war_url }}'
+    context_path: '{{tviewer_context_path}}'
+    hostname: '{{ tviewer_hostname }}'
   tags:
     - deploy
     - tomcat_vhost

--- a/ansible/roles/userdetails/tasks/main.yml
+++ b/ansible/roles/userdetails/tasks/main.yml
@@ -80,7 +80,7 @@
     - properties
     - userdetails
 
-- include: ../../docker-common/tasks/common.yml
+- include_tasks: ../../docker-common/tasks/common.yml
   tags:
     - docker
   when: deployment_type == 'swarm'

--- a/ansible/roles/volunteer-portal/tasks/main.yml
+++ b/ansible/roles/volunteer-portal/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - volunteer-portal
     - deploy

--- a/ansible/roles/web2py/tasks/main.yml
+++ b/ansible/roles/web2py/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: setfacts.yml
+- include_tasks: setfacts.yml
   tags:
     - web2py
 

--- a/ansible/roles/web2pyApps/tasks/main.yml
+++ b/ansible/roles/web2pyApps/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../web2py/tasks/setfacts.yml
+- include_tasks: ../../web2py/tasks/setfacts.yml
   tags:
     - web2pyApps
 

--- a/ansible/roles/webapi_instance/tasks/main.yml
+++ b/ansible/roles/webapi_instance/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - webapi
 
@@ -41,7 +41,10 @@
 #
 # WAR file deployment and Apache/Tomcat virtual host configuration
 #
-- include: ../../apache_vhost/tasks/main.yml context_path='{{ webapi_context_path }}' hostname='{{ webapi_hostname }}'
+- include_tasks: ../../apache_vhost/tasks/main.yml
+  vars:
+    context_path: '{{ webapi_context_path }}'
+    hostname: '{{ webapi_hostname }}'
   tags:
     - webapi
     - apache_vhost
@@ -61,7 +64,11 @@
     - webapi
   when: webserver_nginx
 
-- include: ../../tomcat_deploy/tasks/main.yml war_url='{{ webapi_war_url }}' context_path='{{ webapi_context_path }}' hostname='{{ webapi_hostname }}'
+- include_tasks: ../../tomcat_deploy/tasks/main.yml
+  vars:
+    war_url: '{{ webapi_war_url }}'
+    context_path: '{{ webapi_context_path }}'
+    hostname: '{{ webapi_hostname }}'
   tags:
     - webapi
     - tomcat_vhost

--- a/ansible/roles/wkhtmltopdf/tasks/main.yml
+++ b/ansible/roles/wkhtmltopdf/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: ../../common/tasks/setfacts.yml 
+- include_tasks: ../../common/tasks/setfacts.yml
   tags:
     - wkhtmltopdf
 


### PR DESCRIPTION
This PR:

- migrate `include` to `include_tasks`.
- remove `notify` from `include_tasks` as is not available.
- update of `cas` db tasks as were failing 
- workaround for missing `six` module in `ansible_elasticsearch` role
- Fix for failing postgres datadir setup

in order to update this repository to the latest `ansible` stable version.