### PR TITLE
Fix mysql collate error in ubuntu 20.04 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ then you have an older version of Ansible.
 
 ### Operating System
 
-These playbooks and roles are currently well tested on Ubuntu `18.04`. We are also starting to use Ubuntu `20.04` but it's a work in progress. We have less tested other distributions like Redhat or even Debian as the big majority of our production deployments run over Ubuntu.
+These playbooks and roles are currently well tested on Ubuntu `20.04`. We are also starting to use Ubuntu `20.04` but it's a work in progress. We have less tested other distributions like Redhat or even Debian as the big majority of our production deployments run over Ubuntu.
 
 ## Setup a Living Atlas
 

--- a/ansible/roles/userdetails/templates/sql/auth-ip.sql
+++ b/ansible/roles/userdetails/templates/sql/auth-ip.sql
@@ -2,4 +2,4 @@
 INSERT INTO authorised_system (host, description, version)
     SELECT host, description, version
     FROM (SELECT @ip as host, @description as description, 1 as version) t
-    WHERE NOT EXISTS (SELECT 1 FROM authorised_system a WHERE a.host = t.host);
+    WHERE NOT EXISTS (SELECT 1 FROM authorised_system a WHERE a.host = t.host COLLATE utf8mb4_unicode_ci);


### PR DESCRIPTION
When testing `ala-install` with ubuntu `20.04` (see #598) this error was raising:

```
TASK [userdetails : create auth ip in db if does not exists] *******************
Monday 29 April 2024  20:09:46 +0200 (0:00:01.300)       0:04:56.059 ********** 
(...)
ERROR 1267 (HY000) at line 2 in file: '/data/userdetails/setup/auth-ip.sql': Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure
```

This PR fix this issue. 

This is the last issue I've detected testing Ubuntu `20.04`, so I modified the recommended version in the `README`.