### PR TITLE
Unpin docker versions

### DIFF
--- a/ansible/roles/bie-hub/templates/docker-compose.yml.j2
+++ b/ansible/roles/bie-hub/templates/docker-compose.yml.j2
@@ -4,8 +4,7 @@ version: '3.8'
 services:
 
   war:
-    # image: atlasoflivingaustralia/ala-bie:{{ bie_hub_version }}
-    image: livingatlases/ala-bie-hub:3.0.1
+    image: atlasoflivingaustralia/ala-bie:{{ bie_hub_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/bie-hub/templates/docker-compose.yml.j2
+++ b/ansible/roles/bie-hub/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    # image: atlasoflivingaustralia/ala-bie:latest
+    # image: atlasoflivingaustralia/ala-bie:{{ bie_hub_version }}
     image: livingatlases/ala-bie-hub:3.0.1
     environment:
       TZ: {{ server_tz }}

--- a/ansible/roles/bie-index/templates/docker-compose.yml.j2
+++ b/ansible/roles/bie-index/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/bie-index:e87c8b2
+    image: atlasoflivingaustralia/bie-index:{{ bie_index_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/biocache-hub/templates/docker-compose.yml.j2
+++ b/ansible/roles/biocache-hub/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/ala-hub:343a0c9
+    image: atlasoflivingaustralia/ala-hub:{{ biocache_hub_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/biocache3-service/templates/docker-compose.yml.j2
+++ b/ansible/roles/biocache3-service/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/biocache-service:f3c2069e
+    image: atlasoflivingaustralia/biocache-service:{{ biocache_service_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/collectory/templates/docker-compose.yml.j2
+++ b/ansible/roles/collectory/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/collectory:9144d68
+    image: atlasoflivingaustralia/collectory:{{ collectory_version }}
     volumes:
       - config:/data/collectory/config
       - data:/data/collectory/data

--- a/ansible/roles/namematching-service/templates/docker-compose.yml.j2
+++ b/ansible/roles/namematching-service/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/ala-namematching-service:v20210811-3
+    image: atlasoflivingaustralia/ala-namematching-service:{{ namematching_service_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/sensitive-data-service/templates/docker-compose.yml.j2
+++ b/ansible/roles/sensitive-data-service/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/ala-sensitive-data-service:1.1.1-20210811-3
+    image: atlasoflivingaustralia/ala-sensitive-data-service:{{ ala_sensitive_data_service_version }}
     environment:
       TZ: {{ server_tz }}
     expose:

--- a/ansible/roles/species-list/templates/docker-compose.yml.j2
+++ b/ansible/roles/species-list/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   war:
-    image: atlasoflivingaustralia/species-list:30cf3320
+    image: atlasoflivingaustralia/species-list:{{ species_list_version }}
     volumes:
       - config:/data/specieslist-webapp/config
 {% if i18n_package_enabled | bool %}

--- a/ansible/roles/userdetails/templates/docker-compose.yml.j2
+++ b/ansible/roles/userdetails/templates/docker-compose.yml.j2
@@ -58,7 +58,7 @@ services:
 {% endif %}
 
   cas:
-    image: livingatlases/cas:latest
+    image: livingatlases/cas:{{ cas_version }}
     expose:
       - {{ cas_port | default('9000') }}
     environment:
@@ -78,7 +78,7 @@ services:
           - {{ cas_docker_host }}
 
   userdetails:
-    image: livingatlases/userdetails:latest
+    image: livingatlases/userdetails:{{ user_details_version }}
     expose:
       - {{ userdetails_port | default('9001') }}
     environment:
@@ -98,7 +98,7 @@ services:
           - {{ userdetails_docker_host }}
 
   cas-management:
-    image: livingatlases/cas-management:latest
+    image: livingatlases/cas-management:{{cas_management_version }}
     expose:
       - {{ cas_management_port | default('8070') }}
     environment:

--- a/ansible/roles/userdetails/templates/docker-compose.yml.j2
+++ b/ansible/roles/userdetails/templates/docker-compose.yml.j2
@@ -58,7 +58,7 @@ services:
 {% endif %}
 
   cas:
-    image: livingatlases/cas:{{ cas_version }}
+    image: atlasoflivingaustralia/cas:{{ cas_version }}
     expose:
       - {{ cas_port | default('9000') }}
     environment:
@@ -78,7 +78,7 @@ services:
           - {{ cas_docker_host }}
 
   userdetails:
-    image: livingatlases/userdetails:{{ user_details_version }}
+    image: atlasoflivingaustralia/userdetails:{{ user_details_version }}
     expose:
       - {{ userdetails_port | default('9001') }}
     environment:
@@ -98,7 +98,7 @@ services:
           - {{ userdetails_docker_host }}
 
   cas-management:
-    image: livingatlases/cas-management:{{cas_management_version }}
+    image: atlasoflivingaustralia/cas-management:{{cas_management_version }}
     expose:
       - {{ cas_management_port | default('8070') }}
     environment:


### PR DESCRIPTION
Unpin docker versions to allow to use the same version variables as the VM tasks and use tags of 
https://hub.docker.com/u/atlasoflivingaustralia

For instance:
https://hub.docker.com/r/atlasoflivingaustralia/collectory/tags