### PR TITLE
Revert relative symlink to sites-available for docker environments

### DIFF
--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -526,7 +526,7 @@
 - name: symlink vhost to sites-enabled
   file:
     state: link
-    src: "{{nginx_conf_dir}}/sites-available/{{hostname}}{{vfragments_suffix}}.conf"
+    src: "../sites-available/{{hostname}}{{vfragments_suffix}}.conf"
     dest: "{{nginx_conf_dir}}/sites-enabled/{{hostname}}{{vfragments_suffix}}.conf"
   when: vhost_required | bool == True
   notify:

--- a/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
@@ -1,3 +1,3 @@
 {% if nginx_cors_origin_regexp is defined and nginx_cors_origin_regexp|length > 0 %}
-        include {{nginx_conf_dir}}/conf.d/ala_cors_{{appname}};
+        include ../conf.d/ala_cors_{{appname}};
 {% endif %}


### PR DESCRIPTION
This allows to use  nginx confs generated by ansible outside the containers but it works too in traditional VM environments.

This was introduced by 9b58a27d6f2650d78ebdf83f28e763046167427a and lost in aacd03a1586a328f8291e20f77f796ab20b7e4ad  for some reason.