### PR TITLE
Updates for image service 3

### DIFF
--- a/ansible/image-service.yml
+++ b/ansible/image-service.yml
@@ -17,7 +17,6 @@
     - image-service
     - { role: datadog_sql_user, become: yes, become_user: postgres, when: datadog_monitoring is defined }
     - { role: datadog.datadog, when: datadog_monitoring is defined }
-    - { role: datadog_apm, become: yes, when: datadog_monitoring is defined }
 
   become: yes
   become_user: root

--- a/ansible/roles/datadog_sql_user/tasks/main.yml
+++ b/ansible/roles/datadog_sql_user/tasks/main.yml
@@ -29,7 +29,11 @@
 - name: Grant pg_monitor role to the Datadog user
   postgresql_privs:
     db: "{{ datadog_db_name }}"
-    role: datadog
+    login_host: "{{ datadog_db_login_host | default(omit) }}"
+    login_password: "{{ datadog_db_login_password | default(omit) }}"
+    login_unix_socket: "{{ datadog_db_socket | default(omit) }}"
+    login_user: "{{ datadog_db_login_user | default(omit) }}"
+    roles: datadog
     type: group
     objs: pg_monitor
   when: datadog_postgress_enabled | default(False) | bool

--- a/ansible/roles/exec-jar/tasks/main.yml
+++ b/ansible/roles/exec-jar/tasks/main.yml
@@ -68,6 +68,29 @@
   tags:
   - service
 
+- name: "Download datadog JAR"
+  ansible.builtin.get_url:
+    url: https://github.com/DataDog/dd-trace-java/releases/{{datadog_version | default('latest')}}/download/dd-java-agent.jar
+    force: true
+    dest: "/opt/atlas/{{service_name}}/dd-java-agent.jar"
+    mode: '0550'
+    owner: "{{ service_owner | default(service_name) }}"
+    group: "{{ service_group | default(service_name) }}"
+  notify: "restart {{service_name}}"
+  when: datadog_java_apm_enabled is defined and datadog_java_apm_enabled
+  tags:
+  - datadog
+  - service
+
+- name: "Check datadog agent JAR state"
+  ansible.builtin.file:
+    path: "/opt/atlas/{{service_name}}/dd-java-agent.jar"
+    state: absent
+  when: datadog_java_apm_enabled is not defined or not datadog_java_apm_enabled
+  tags:
+  - datadog
+  - service
+
 - name: "Download {{service_name}} JAR (unauthenticated)"
   maven_artifact:
     group_id: "{{groupId}}"

--- a/ansible/roles/exec-jar/templates/service.conf
+++ b/ansible/roles/exec-jar/templates/service.conf
@@ -1,9 +1,14 @@
 #jinja2:trim_blocks: False
 JAVA_HOME="{{ java_home }}"
 
-JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }} -XX:+UseConcMarkSweepGC{% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %} {{java_security_opts}}"
+JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }} {% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %} {{java_security_opts}}"
 #JAVA_OPTS="${JAVA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
 
+{% if datadog_java_apm_enabled is defined and datadog_java_apm_enabled %}
+{# TODO allow JMX config separately #}
+JAVA_OPTS="${JAVA_OPTS} -Djava.rmi.server.hostname={{ jmx_hostname | default(inventory_hostname) }} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port={{ jmx_port | default('10058')}} -Dcom.sun.management.jmxremote.authenticate={{jmx_authenticate | default('false')}} -Dcom.sun.management.jmxremote.ssl={{jmx_ssl | default('false')}} -Dcom.sun.management.jmxremote.rmi.port={{ jmx_rmi_port | default(jmx_port | default('10058'))}}"
+JAVA_OPTS="${JAVA_OPTS} -javaagent:/opt/atlas/{{service_name}}/dd-java-agent.jar -Ddd.version={{version|default('latest')}} -Ddd.service={{service_name}} -Ddd.env={{datadog_env | default('production') }} -Ddd.logs.injection={{datadog_log_injection | default('true')}} -Ddd.profiling.enabled={{datadog_profiling_enabled | default('true')}}"
+{% endif %}
 export LOGGING_CONFIG=/data/{{service_name}}/config/{{log_config_filename | default('logback.groovy') }}
 export LOG_DIR="/var/log/atlas/{{service_name}}"
 

--- a/ansible/roles/exec-jar/templates/service.conf
+++ b/ansible/roles/exec-jar/templates/service.conf
@@ -1,7 +1,7 @@
 #jinja2:trim_blocks: False
 JAVA_HOME="{{ java_home }}"
 
-JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }} {% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %} {{java_security_opts}}"
+JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ max_memory | default('2g') }} -Xms{{ min_memory | default('1g') }}{% for jvm_param in jvm_params | default([]) %} {{jvm_param}}{% endfor %}{% for extra_param in extra_params | default([]) %} -D{{extra_param.key}}={{extra_param.value}}{% endfor %} {{java_security_opts}}"
 #JAVA_OPTS="${JAVA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
 
 {% if datadog_java_apm_enabled is defined and datadog_java_apm_enabled %}


### PR DESCRIPTION
- Add support for datadog jmx to exec jar roles
- Fix datadog sql role for non local database
- Remove using the CMS collector by default and replace with jvm extra params for clients if required