### PR TITLE
Update geoserver to 2.25.2

### DIFF
--- a/ansible/roles/geoserver/defaults/main.yml
+++ b/ansible/roles/geoserver/defaults/main.yml
@@ -1,19 +1,21 @@
-geoserver_war_url: "https://repo.osgeo.org/repository/release/org/geoserver/web/gs-web-app/2.19.2/gs-web-app-2.19.2.war"
-geoserver_war_sha1sum: "sha1:db9ce038fb2bea7c67a7012bb338c1447260a2b0"
+geoserver_version: "2.25.2"
+
+geoserver_war_url: "https://repo.osgeo.org/repository/release/org/geoserver/web/gs-web-app/{{ geoserver_version }}/gs-web-app-{{ geoserver_version }}.war"
+geoserver_war_sha1sum: "sha1:2da0b585e4b892107c9731bc4dcd60d46dc726ed"
 
 # URLs to extensions as .zip
 # Must be compatible with the geoserver version
 # geoserver/tasks/main.yml changes gwc defaults for vectortiles extension
 geoserver_extension_urls:
-  - "https://download.sourceforge.net/project/geoserver/GeoServer/2.19.2/extensions/geoserver-2.19.2-pyramid-plugin.zip"
-  - "https://download.sourceforge.net/project/geoserver/GeoServer/2.19.2/extensions/geoserver-2.19.2-vectortiles-plugin.zip"
+  - "https://download.sourceforge.net/project/geoserver/GeoServer/{{ geoserver_version }}/extensions/geoserver-{{ geoserver_version }}-pyramid-plugin.zip"
+  - "https://download.sourceforge.net/project/geoserver/GeoServer/{{ geoserver_version }}/extensions/geoserver-{{ geoserver_version }}-vectortiles-plugin.zip"
 
 geoserver_task: "geoserver"
 
 # ecodata-geoserver.yml configs
 # uncomment to add zip extensions
 geoserver_zip_extension_urls:
-  - "https://sourceforge.net/projects/geoserver/files/GeoServer/2.7.4/extensions/geoserver-2.7.4-wps-plugin.zip"
+  - "https://sourceforge.net/projects/geoserver/files/GeoServer/{{ geoserver_version }}/extensions/geoserver-{{ geoserver_version }}-wps-plugin.zip"
 
 geoserver_jar_extension_urls:
   - "https://raw.githubusercontent.com/temi/elasticgeo/v2.7.4/gs-web-elasticsearch/target/elasticgeo2.7.4-gs2.7.4-es1.7.3.jar"

--- a/ansible/roles/geoserver/vars/main.yml
+++ b/ansible/roles/geoserver/vars/main.yml
@@ -1,6 +1,7 @@
 maven_repo_url: "https://repo.osgeo.org/repository/release/"
 groupId: "org.geoserver.web"
-version: "{{ geoserver_version | default('2.19.2') }}"
+version: "{{ geoserver_version | default('2.25.2') }}"
 artifactId: "gs-web-app"
 packaging: "war"
 classifier: ""
+


### PR DESCRIPTION
This tries to address #821 and continues with https://github.com/AtlasOfLivingAustralia/spatial-service/issues/224.

After running this:

![image](https://github.com/user-attachments/assets/dc660067-c4ec-4a48-b05c-77049e7bd071)
