### PR TITLE
Re-add i18n role to spatial

### DIFF
--- a/ansible/spatial.yml
+++ b/ansible/spatial.yml
@@ -13,7 +13,7 @@
     - {role: pg_instance, extensions: ['postgis', 'postgis_topology', 'uuid-ossp'], db_name: "{{layers_db_name}}", db_user: "{{layers_db_username}}", db_password: "{{layers_db_password}}" }
     - layers-db
     - {role: geoserver, skip_geoserver_script: false}
-#    - i18n
+    - i18n
     - spatial-service
     - spatial-hub
 #    - geonetwork


### PR DESCRIPTION
This PR re-adds the `i18n` role to the spatial playbook that was commented. In order to disable a:
```
i18n_package_enabled=False
```
can be added to the inventories (although the i18n contains the up-to-date version of English so was implemented trying to not affect ALA or other English portals).