### PR TITLE
Update newserver.yml indentation

### DIFF
--- a/ansible/newserver.yml
+++ b/ansible/newserver.yml
@@ -6,9 +6,9 @@
   gather_facts: false
   pre_tasks:
   - name: Get the distribution version
-      raw: lsb_release -r | awk '{print $2}'
-      register: os_version
-      changed_when: false
+    raw: lsb_release -r | awk '{print $2}'
+    register: os_version
+    changed_when: false
   - name: Install python2 and python3 for Ansible
     raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt-get install -qqy python3-minimal 'python2.*-minimal')"
     when: os_version.stdout is version('24.04', '<')


### PR DESCRIPTION
There is an indentation issue in `newserver.yml` that gives this error:
```
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  mapping values are not allowed in this context

The error appears to be in '/data-additional/jenkins/ala-install-test/ala-install/ansible/newserver.yml': line 9, column 10, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  - name: Get the distribution version
      raw: lsb_release -r | awk '{print $2}'
         ^ here
```