### PR TITLE
Update tomcat version in biocache-service-clusterdb.yml for u24.04

### DIFF
--- a/ansible/biocache-service-clusterdb.yml
+++ b/ansible/biocache-service-clusterdb.yml
@@ -4,7 +4,7 @@
     - java
 
     - { role: tomcat, when: "biocache_service_version is version('3', '<')" }
-    - { role: tomcat, tomcat: tomcat9, when: "biocache_service_version is version('3', '>=')" }
+    - { role: tomcat, tomcat: "{{ 'tomcat10' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24.04', '=')) else 'tomcat9' }}", when: "biocache_service_version is version('3', '>=')" }
     - webserver
 
     # biocache-service compatible with biocache-store


### PR DESCRIPTION
`tomcat10` should be used in `24.04`. Part of https://github.com/AtlasOfLivingAustralia/ala-install/issues/834