### PR TITLE
Fixes for postgresql in u24.04

### DIFF
--- a/ansible/roles/postgresql/tasks/apt.yaml
+++ b/ansible/roles/postgresql/tasks/apt.yaml
@@ -38,7 +38,7 @@
 
 - name: pip3 psycopg2
   command: pip3 install psycopg2
-  when: ansible_python.version.major==3
+  when: ansible_python.version.major==3 and ansible_os_family == "Debian" and ansible_distribution_version is version('24.04', '<')
   tags: postgresql
 
 - name: install python-software-properties (Debian)

--- a/ansible/roles/postgresql/vars/Ubuntu-24.04.yml
+++ b/ansible/roles/postgresql/vars/Ubuntu-24.04.yml
@@ -1,0 +1,11 @@
+postgresql_service: postgresql
+
+gdal_src_url: http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz
+
+postgresql_data_directory: "{{ data_dir }}/postgresql-{{pg_version}}-data"
+
+psycopg2_package: "python3-psycopg2"
+
+pycurl_package: "python3-pycurl"
+
+pip_package: "python3-pip"


### PR DESCRIPTION
Part of #834.

This uses the 24.04 variables and skip to install the pip3 psycopg2 package as is installed with apt.
```
TASK [postgresql : Gather OS Specific Variables] *******************************
ok: [ala-install-test-2] => (item=/data-additional/jenkins/ala-install-test/ala-install/ansible/roles/postgresql/vars/../vars/Ubuntu-24.04.yml)
(...)
TASK [postgresql : install psycopg2] *******************************************
ok: [ala-install-test-2]
(...)
TASK [postgresql : pip3 psycopg2] **********************************************
skipping: [ala-install-test-2]
```