### PR TITLE
Update alerts-config.properties adding a missing pipe before default 

### DIFF
--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -22,7 +22,7 @@ dataSource.driverClassName=com.mysql.jdbc.Driver
 dataSource.url=jdbc:mysql://{{ alerts_db_hostname }}/alerts?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8&useSSL={{mysql_connection_ssl | default(false)}}
 dataSource.username={{ alerts_db_username }}
 dataSource.password={{ alerts_db_password }}
-dataSource.dbCreate={{ dataSource_dbCreate default('update') }}
+dataSource.dbCreate={{ dataSource_dbCreate | default('update') }}
 dataSource.properties.maxActive=50
 dataSource.properties.maxIdle=25
 dataSource.properties.minIdle=5


### PR DESCRIPTION
It seems that in https://github.com/AtlasOfLivingAustralia/ala-install/commit/6d6a59d9b8881a14b9621772690b3dbbebdcac75 a pipe is missing before `default` causing an error like:

```
TASK [alerts : copy all config.properties] *************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: . expected token 'end of print statement', got 'default'
fatal: [ala-install-test-1]: FAILED! => {"changed": false, "msg": "AnsibleError: template error while templating string: expected token 'end of print statement', got 'default'. String: # Grails config\nserverName={{ alerts_base_url }}\nserverURL={{ alerts_base_url }}\ngrails.serverURL={{ alerts_base_url }}{{ alerts_context_path }}\n\n# CAS Config\nsecurity.cas.appServerName={{ alerts_base_url }}{{ alerts_context_path }}\nsecurity.cas.uriFilterPattern=/,/alaAdmin/*,/testAuth/*,/query/*,/admin/*,/admin/user/*,/admin/user/debug/*,/admin/debug/all,/notification/myAlerts,/notification/changeFrequency,/notification/addMyAlert,/notification/addMyAlert/*,/notification/deleteMyAlert/*,/notification/deleteMyAlert/*,/notification/deleteMyAlertWR/*,/webservice/*,/webservice/createTaxonAlert,/webservice/taxonAlerts,/webservice/createRegionAlert,/webservice/regionAlerts,/webservice/deleteTaxonAlert/*,/webservice/create/*,/webservice/createSpeciesGroupRegionAlert,/ws/*,/ws/createTaxonAlert,/ws/taxonAlerts,/ws/createRegionAlert,/ws/regionAlerts,/ws/deleteTaxonAlert/*,/ws/createTaxonRegionAlert,/ws/createSpeciesGroupRegionAlert,/admin/runChecksNow, /quartz/*\nsecurity.cas.uriExclusionFilterPattern=/images.*,/css.*,/js.*,/less.*\nsecurity.cas.authenticateOnlyIfLoggedInPattern=/unsubscribe/*\nsecurity.cas.adminRole=ROLE_ADMIN\nsecurity.apikey.ip.whitelist={{ alerts_apikey_whitelist | default('') }}\nsecurity.cas.casServerName={{ auth_base_url }}\nsecurity.cas.casServerUrlPrefix={{ auth_base_url }}/cas\nsecurity.cas.casServerLoginUrl={{ auth_base_url }}/cas/login\nsecurity.cas.casServerLogoutUrl={{ auth_base_url }}/cas/logout\nsecurity.cas.loginUrl={{ auth_base_url }}/cas/login\nsecurity.cas.logoutUrl={{ auth_base_url }}/cas/logout\n\n# DB config\ndataSource.driverClassName=com.mysql.jdbc.Driver\ndataSource.url=jdbc:mysql://{{ alerts_db_hostname }}/alerts?autoReconnect=true&connectTimeout=0&useUnicode=true&characterEncoding=UTF-8&useSSL={{mysql_connection_ssl | default(false)}}\ndataSource.username={{ alerts_db_username }}\ndataSource.password={{ alerts_db_password }}\ndataSource.dbCreate={{ dataSource_dbCreate default('update') }}\ndataSource.properties.maxActive=50\ndataSource.properties.maxIdle=25\ndataSource.properties.minIdle=5\ndataSource.properties.initialSize=5\ndataSource.properties.minEvictableIdleTimeMillis=60000\ndataSource.properties.timeBetweenEvictionRunsMillis=60000\ndataSource.properties.maxWait=10000\ndataSource.properties.validationQuery=SELECT 1\ndataSource.properties.removeAbandonedTimeout=3600\n\n# my annotation alert\nmyannotation.enabled={{ enable_myannotation | default('false') }}\nuseSpeciesLists: {{ enable_specieslists_alerts | default('true') }}\nuseSpatial: {{ enable_spatial_alerts | default('true') }}\nuseBlogsAlerts: {{ enable_blogs_alerts | default('true') }}\nuseCitizenScienceAlerts: {{ enable_citizen_science_alerts | default('true') }}\n\n#External services\nbiocache.baseURL={{ biocache_url | default('https://biocache.ala.org.au') }}\nbiocacheService.baseURL={{ biocache_service_url | default('https://biocache-ws.ala.org.au/ws') }}\nspatial.baseURL={{ spatial_url | default('https://spatial.ala.org.au') }}\ncollectory.baseURL={{ collectory_url | default('https://collections.ala.org.au') }}\ncollectoryService.baseURL: {{ collectory_service_url |  default('https://collections.ala.org.au') }}\nala.userDetailsURL={{ alerts_userdetails_url | default(userdetails_url) | default('https://auth.ala.org.au/userdetails') }}/userDetails/getUserListFull\nlists.baseURL={{ lists_url | default('https://lists.ala.org.au') }}\n\n# Emails\npostie.enableEmail={{  enable_email | default('') }}\nmail.ses.enabled={{  mail_ses_enabled | default('true') }}\n#mail.ses.region={{  mail_ses_region | default('ap-southeast-2') }}\n#mail.details.sender={{ email_sender | default('alerts@ala.org.au') }}\n#mail.details.alertAddressTitle={{ email_alert_address_title |  default('Atlas alerts') }}\n#mail.details.infoSender={{ email_info_sender |  default('alerts@ala.org.au') }}\n#mail.details.infoAddressTitle={{ email_info_address_title |  default('Atlas of Living Australia') }}\n#mail.details.defaultResourceName={{ email_default_resource_name |  default('Atlas of Living Australia') }}\n\n\n# Header and footer\nheaderAndFooter.baseURL={{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3-2019') }}\nheaderAndFooter.version={{ header_and_footer_version | default('2') }}\nala.baseURL={{ ala_base_url | default('https://www.ala.org.au')}}\nbie.baseURL={{ bie_base_url | default('https://bie.ala.org.au')}}\nbie.searchPath={{ bie_search_path | default('/search') }}\n\nskin.layout={{ (alerts_skin_layout | default(skin_layout)) | default('main') }}\nskin.homeUrl = {{ skin_home_url | default('http://www.ala.org.au') }}\nskin.orgNameLong={{ skin_orgNameLong | default('Atlas of Living Australia') }}\nskin.orgNameShort={{ orgNameShort | default('ALA') }}\nskin.orgSupportEmail={{ orgSupportEmail | default('support@ala.org.au') }}\nsiteDefaultLanguage={{ alerts_site_default_language | default('en') }}\n#skin.favicon={{ skin_favicon | default('https://www.ala.org.au/wp-content/themes/ala-wordpress-theme/img/favicon/favicon.ico') }}\nprivacyPolicy={{ privacy_policy_url | default('https://www.ala.org.au/about/terms-of-use/privacy-policy/') }}\n\n# Example search labels and URLs\noccurrence.searchTitle={{ occurrence_searchTitle }}\noccurrence.searchURL={{ occurrence_searchUrl }}\nregions.searchTitle={{ regions_searchTitle }}\nregions.searchURL={{ regions_searchUrl }}\nspeciesPages.searchTitle={{ speciesPages_searchTitle }}\nspeciesPages.searchURL={{ speciesPages_searchUrl }}\ncollection.searchTitle={{ collection_searchTitle }}\ncollection.searchURL={{ collection_searchUrl }}\n\n# biosecurity related\ngoogle.apikey={{ google_apikey | default('') }}\nbiosecurity.moreinfo.link={{ biosecurity_more_info | default('') }}\nbiosecurity.queryurl.template={{ biosecurity_query_url | default('/occurrences/search?q=species_list_uid:___LISTIDPARAM___&fq=decade:2020&fq=country:Australia&fq=first_loaded_date:[___DATEPARAM___%20TO%20*]&fq=occurrence_date:[___LASTYEARPARAM___%20TO%20*]&sort=first_loaded_date&dir=desc&disableAllQualityFilters=true') }}\nspecieslist.server={{ species_list_server | default('https://lists.ala.org.au') }}\n\n#oidc related\nsecurity.oidc.clientId={{ (alerts_client_id | default(clientId)) | default('') }}\nsecurity.oidc.secret={{ (alerts_client_secret | default(secret)) | default('') }}\nsecurity.oidc.discoveryUri={{ discoveryUri | default('') }}\nsecurity.jwt.discoveryUri={{ discoveryUri | default('') }}\n\n# cognito specific configs\n{% if auth_system is defined and auth_system == 'cognito' %}\n#congito related\nsecurity.oidc.logoutUrl={{ logoutUrl | default('') }}\nsecurity.oidc.alaUseridClaim={{ alaUseridClaim | default('') }}\nsecurity.oidc.logoutAction={{ logoutAction | default('') }}\nsecurity.core.roleAttribute={{ roleAttribute | default('') }}\nsecurity.core.affiliation-survey.enabled={{affiliation_survey_enabled | default ('false')}}\nsecurity.oidc.scope={{ scope | default('openid')}}\nsecurity.core.authCookieName={{ auth_cookie_name | default('ALA-Auth') }}\nsecurity.cookie.enabled={{auth_cookie_enabled | default ('false')}}\nsecurity.cookie.domain={{auth_cookie_domain | default ('.ala.org.au')}}\nsecurity.jwt.rolesFromAccessToken={{ rolesFromAccessToken | default('true') }}\nsecurity.jwt.userIdClaim={{ userIdClaim | default('') }}\nsecurity.jwt.roleClaims={{ roleClaims | default('') }}\n{% endif %}\n\n#apikey related\nsecurity.apikey.enabled={{ apikey_check_enabled | default('false') }}\nsecurity.apiKey.auth.serviceUrl = {{ apikey_auth_url }}\nsecurity.apikey.check.serviceUrl={{ apikey_check_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=') }}\nsecurity.apikey.userdetails.serviceUrl={{ apikey_userdetails_url }}\n\n#websevice jwt\nwebservice.jwt={{ webservice_jwt | default('false') }}\nwebservice.jwt-scopes={{ alerts_webservice_jwt_scopes | default(webservice_jwt_scopes) | default('') }}\nwebservice.client-id={{ alerts_client_id | default(webservice_clientId) | default('') }}\nwebservice.client-secret={{ alerts_client_secret | default(webservice_secert) | default('') }}\n\nuserDetails.url={{ userdetails_url | default('https://auth.ala.org.au/userdetails/') }}\n\n# user update releated\nalerts.user-sync.batch-size={{ usersync_batchsize | default('1000') }}\n\nuserdetails.url={{ userdetails_url | default('https://auth.ala.org.au/userdetails') }}\nuserdetails.web.url={{ userdetails_web_url | default('https://auth.ala.org.au/userdetails/') }}\nuserdetails.api.url={{ userdetails_api_url | default('https://api.ala.org.au/userdetails/') }}\n\n# openapi\nopenapi.components.security.oauth2.baseUrl={{ openapi_oauth_url }}\nopenapi.terms={{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}\nopenapi.contact.email={{ support_email | default('support@ala.org.au') }}\n. expected token 'end of print statement', got 'default'"}
```