### PR TITLE
Remove hardcoded pg version from doi-service playbook

### DIFF
--- a/ansible/doi-service-standalone.yml
+++ b/ansible/doi-service-standalone.yml
@@ -4,7 +4,7 @@
     - java
     - postfix
     - {role: db-backup, db: postgres, db_name: "{{ doi_db_name }}", db_user: "postgres" }
-    - {role: postgresql, pg_version: "10"}
+    - {role: postgresql}
     - {role: pg_instance, extensions: ["citext", "pgcrypto"], db_name: "{{ doi_db_name }}", db_user: "{{ doi_db_user }}", db_password: "{{ doi_db_password }}" }
     - {role: ansible-elasticsearch, es_templates: false,  es_instance_name: 'doi-elasticsearch', es_data_dirs: ['/data/elasticsearch'], tags: ['elasticsearch']}
     - webserver


### PR DESCRIPTION
Continuation of #834 removing the pg version from the doi playbook.