### PR TITLE
Moved vernacularName.show to ala-hub

### DIFF
--- a/ansible/roles/biocache-hub/templates/config/config.properties
+++ b/ansible/roles/biocache-hub/templates/config/config.properties
@@ -295,3 +295,5 @@ userproperties.provider={{ userproperties_provider | default('userdetails') }}
 dataResourceUuid.alaSightings={{ dataResourceUuid_alaSightings | default('') }}
 dataResourceUuid.flickr={{ dataResourceUuid_flickr | default('') }}
 dataResourceUuid.iNaturalist={{ dataResourceUuid_iNaturalist | default('') }}
+
+vernacularName.show={{ vernacularName_show | default('true') }}

--- a/ansible/roles/biocache3-properties/templates/biocache-config.properties
+++ b/ansible/roles/biocache3-properties/templates/biocache-config.properties
@@ -495,8 +495,6 @@ webservice.client-id = {{ (biocache_service_client_id | default(webservice_clien
 webservice.client-secret = {{ (biocache_service_client_secret | default(webservice_secert)) | default('') }}
 webservices.cache-tokens=false
 
-
-vernacularName.show={{ vernacularName_show | default('true') }}
 userdetails.url={{ biocache_userdetails_url | default(userdetails_url) | default('https://auth.ala.org.au/userdetails') }}
 userdetails.web.url={{ userdetails_web_url | default('https://auth.ala.org.au/userdetails/') }}
 userdetails.api.url={{ userdetails_api_url | default('https://api.ala.org.au/userdetails/') }}


### PR DESCRIPTION
Just adding this variable that was introduced by https://github.com/AtlasOfLivingAustralia/biocache-hubs/pull/562 but added incorrectly to the `biocache-service` config.