### PR TITLE
Fix for wrong cors include

### DIFF
--- a/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
@@ -1,3 +1,7 @@
 {% if nginx_cors_origin_regexp is defined and nginx_cors_origin_regexp|length > 0 %}
-        include ../conf.d/ala_cors_{{appname}};
+    {% if deployment_type == 'swarm' %}
+        include /etc/nginx/conf.d/ala_cors_{{appname}};
+    {% else %}
+        include {{nginx_conf_dir}}/conf.d/ala_cors_{{appname}};
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
I introduced a bug today in `nginx_vhost` that I didn't test in all the environments (in the last commit of #807). I restore the previous line with an option for docker swarm environments.

I've just tested and works as before in a normal vm environment.

Sorry.