### PR TITLE
New variables for the LA community

### DIFF
--- a/ansible/roles/alerts/templates/alerts-config.properties
+++ b/ansible/roles/alerts/templates/alerts-config.properties
@@ -45,7 +45,7 @@ biocache.baseURL={{ biocache_url | default('https://biocache.ala.org.au') }}
 biocacheService.baseURL={{ biocache_service_url | default('https://biocache-ws.ala.org.au/ws') }}
 spatial.baseURL={{ spatial_url | default('https://spatial.ala.org.au') }}
 collectory.baseURL={{ collectory_url | default('https://collections.ala.org.au') }}
-collectoryService.baseURL: {{ collectory_service_url |  default('https://collections.ala.org.au') }}
+collectoryService.baseURL: {{ alerts_collectory_service_url | default(collectory_service_url) |  default('https://collections.ala.org.au') }}
 ala.userDetailsURL={{ alerts_userdetails_url | default(userdetails_url) | default('https://auth.ala.org.au/userdetails') }}/userDetails/getUserListFull
 lists.baseURL={{ lists_url | default('https://lists.ala.org.au') }}
 

--- a/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
@@ -133,7 +133,7 @@ collectory:
   baseURL: {{ collectory_url }}
   threatenedSpeciesCodesUrl: {{ collectory_url }}/public/showDataResource
 collectoryService:
-  baseURL: {{ collectory_service_url | default(collectory_url) }}
+  baseURL: {{ bie_hub_collectory_service_url | defaul(collectory_service_url) | default(collectory_url) }}
 speciesList:
   baseURL: {{ species_list_url }}
   preferredSpeciesListDruid: {{ specieslist_preferredDruid }}

--- a/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
+++ b/ansible/roles/bie-hub/templates/bie-hub-config.yml.j2
@@ -133,7 +133,7 @@ collectory:
   baseURL: {{ collectory_url }}
   threatenedSpeciesCodesUrl: {{ collectory_url }}/public/showDataResource
 collectoryService:
-  baseURL: {{ bie_hub_collectory_service_url | defaul(collectory_service_url) | default(collectory_url) }}
+  baseURL: {{ bie_hub_collectory_service_url | default(collectory_service_url) | default(collectory_url) }}
 speciesList:
   baseURL: {{ species_list_url }}
   preferredSpeciesListDruid: {{ specieslist_preferredDruid }}

--- a/ansible/roles/bie-index/templates/bie-index-config.yml
+++ b/ansible/roles/bie-index/templates/bie-index-config.yml
@@ -55,6 +55,8 @@ security:
       serviceUrl: {{ apikey_check_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=') }}
     userdetails:
       serviceUrl: {{ apikey_userdetails_url }}
+    # still present in alaAdmin/viewConfig so let's configure properly
+    serviceUrl: {{ apikey_auth_url }}
 webservice:
   jwt: {{ webservice_jwt | default('false') }}
   jwt-scopes: {{ bie_index_webservice_jwt_scopes | default(webservice_jwt_scopes) | default('') }}

--- a/ansible/roles/dashboard/templates/dashboard-config.properties
+++ b/ansible/roles/dashboard/templates/dashboard-config.properties
@@ -18,6 +18,7 @@ security.cas.bypass={{ bypass_cas | default(true) }}
 security.oidc.clientId={{  (dashboard_client_id | default(clientId)) | default('') }}
 security.oidc.secret={{ (dashboard_client_secret | default(secret)) | default('') }}
 security.oidc.discoveryUri={{ discoveryUri | default('') }}
+security.oidc.discovery-uri={{ discoveryUri | default('') }}
 # cognito specific configs
 {% if auth_system is defined and auth_system == 'cognito' %}
 security.jwt.discoveryUri={{ discoveryUri | default('') }}
@@ -40,13 +41,17 @@ security.cookie.domain={{auth_cookie_domain | default ('.ala.org.au')}}
 ####################
 # Dashboard Config #
 ####################
+biocache.baseURL={{ dashboard_biocache_service_base_url | default('https://biocache-ws.ala.org.au/ws') }}
 biocache.webappURL={{ biocache_web_base_url | default('https://biocache.ala.org.au') }}
 ala.baseURL={{ ala_base_url | default('https://www.ala.org.au')}}
+bie.baseURL={{ dashboard_bie_base_url | default('https://bie-ws.ala.org.au/ws') }}
 bie.webappURL={{ bie_web_base_url | default('https://bie.ala.org.au')}}
 bie.searchPath={{ bie_search_path | default('/search') }}
 spatial.baseURL={{ dashboard_spatial_base_url | default(spatial_base_url) }}
+logger.baseURL={{ logger_base_url | default('https://logger.ala.org.au') }}
 collectory.baseURL={{ collectory_base_url }}
 volunteer.baseURL={{ volunteer_base_url }}
+images.baseURL={{ images_base_url | default('https://images.ala.org.au') }}
 userDetails.baseURL={{ (dashboard_userdetails_base_url | default(userdetails_base_url)) | default('https://auth.ala.org.au/userdetails') }}
 userDetails.url={{ (dashboard_userdetails_base_url | default(userdetails_base_url)) | default('https://auth.ala.org.au/userdetails') }}/
 bhl.baseURL={{ bhl_base_url | default('http://biodiversitylibrary.org/')}}

--- a/ansible/roles/doi-service/templates/doi-service-config.yml
+++ b/ansible/roles/doi-service/templates/doi-service-config.yml
@@ -37,7 +37,7 @@ security:
 {% endif %}
   jwt:
     discoveryUri: {{ discoveryUri | default('') }}
-    clientId: {{ clientId | default('') }}
+    clientId: {{ doi_client_id | default(clientId) | default('') }}
 # cognito specific configs
 {% if auth_system is defined and auth_system == 'cognito' %}
     rolesFromAccessToken: {{ rolesFromAccessToken | default('true') }}
@@ -45,7 +45,7 @@ security:
     roleClaims: {{ roleClaims | default('') }}
 {% endif %}
   apiKey:
-    enabled: {{ apikey_check_enabled | default('false') }}
+    enabled: {{ doi_apikey_check_enabled | default(apikey_check_enabled) | default('false') }}
     auth:
       serviceUrl: {{ apikey_auth_url }}
     check:

--- a/ansible/roles/logger-service/templates/logger-config.properties
+++ b/ansible/roles/logger-service/templates/logger-config.properties
@@ -55,6 +55,7 @@ skin.orgNameLong={{ skin_orgNameLong | default('Atlas of Living Australia') }}
 skin.orgNameShort = {{ orgNameShort | default('ALA') }}
 skin.orgSupportEmail={{ orgSupportEmail | default('support@ala.org.au') }}
 privacyPolicy={{ privacy_policy_url | default('https://www.ala.org.au/about/terms-of-use/privacy-policy/') }}
+info.app.description={{ skin_orgNameLong | default('Atlas of Living Australia') }}
 
 #oidc related
 security.cas.enabled={{ security_cas_enabled | default(true) }}
@@ -89,6 +90,7 @@ webservice.client-secret={{ logger_client_secret | default(webservice_secert) | 
 
 security.apikey.enabled={{ apikey_check_enabled | default('false') }}
 security.apiKey.auth.serviceUrl = {{ apikey_auth_url }}
+security.apikey.auth.serviceUrl = {{ apikey_auth_serviceUrl | default('https://auth.ala.org.au/apikey/ws/check/') }}
 security.apikey.check.serviceUrl={{ apikey_check_url | default('https://auth.ala.org.au/apikey/ws/check?apikey=') }}
 security.apikey.userdetails.serviceUrl={{ apikey_userdetails_url }}
 userdetails.url={{ userdetails_url | default('https://auth.ala.org.au/userdetails') }}
@@ -99,3 +101,6 @@ userdetails.api.url={{ userdetails_api_url | default('https://api.ala.org.au/use
 openapi.components.security.oauth2.baseUrl={{ openapi_oauth_url }}
 openapi.terms={{ terms_url | default('https://www.ala.org.au/terms-of-use/') }}
 openapi.contact.email={{ support_email | default('support@ala.org.au') }}
+
+grails.mail.default.from={{ email_info_sender | default('support@ala.org.au') }}
+grails.mail.host={{ mail_host | default('smtp.csiro.au') }}

--- a/ansible/roles/species-list/templates/specieslist-webapp-config.properties
+++ b/ansible/roles/species-list/templates/specieslist-webapp-config.properties
@@ -139,6 +139,8 @@ webservice.client-secret={{ (lists_client_secret | default(service_secret)) | de
 
 # For backward compatibility:
 userDetails.url={{ specieslist_userdetails_url | default(userdetails_url) | default('https://auth.ala.org.au/userdetails/') }}
+# Still in use
+userdetails.url={{ specieslist_userdetails_url | default(userdetails_url) | default('https://auth.ala.org.au/userdetails/') }}
 
 userdetails.web.url={{ userdetails_web_url }}
 userdetails.api.url={{ userdetails_api_url }}


### PR DESCRIPTION
Only some additional variables useful for the LA community using a single inventory for deploy all its services. It defaults to the ALA current variables/values so should not affect to ALA.

For instance, I detected some urls via `/alaAdmin/viewConfig` pointing to `ala.au.org` ones.