### PR TITLE
Add option for OpenJDK 17 in defaults

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -2,3 +2,4 @@ packaging: "war"
 use_zulu8: False
 use_openjdk8: True
 use_openjdk11: False
+use_openjdk17: False


### PR DESCRIPTION
This pull request includes a small change to the `ansible/roles/common/defaults/main.yml` file. The change adds a new configuration option for `use_openjdk17` to avoid errors like #854 and with a similar use than for older versions.