### PR TITLE
Configure java version and port for jenkins

### DIFF
--- a/ansible/roles/jenkins-simple/tasks/main.yml
+++ b/ansible/roles/jenkins-simple/tasks/main.yml
@@ -51,9 +51,64 @@
   when: ansible_os_family == "Debian"
   tags: jenkins
 
-- service: name=jenkins enabled=yes state=started
-  when: ansible_os_family == "Debian"
-  tags: jenkins
+- name: Get current default Java version
+  shell: |
+    update-alternatives --query java | grep '^Value:' | awk '{print $2}'
+  register: current_java_path
+  changed_when: false
+  ignore_errors: yes
+  tags:
+    - java
+    - jenkins
+
+- name: Store previous Java default
+  set_fact:
+    previous_java_path: "{{ current_java_path.stdout }}"
+    previous_java_name: "{{ current_java_path.stdout | dirname | dirname | basename }}"
+  when: current_java_path.stdout is defined
+  tags:
+    - java
+    - jenkins
+
+- name: Install Java {{ jenkins_java_version }}
+  apt:
+    name: "{{ jenkins_java_package }}"
+    state: present
+  tags:
+    - java
+    - jenkins
+
+- name: Restore previous Java default
+  command: update-alternatives --set java "{{ previous_java_path }}"
+  when:
+    - previous_java_path is defined
+    - previous_java_path | length > 0
+  tags:
+    - java
+    - jenkins
+
+- name: Create systemd override directory
+  file:
+    path: "/etc/systemd/system/jenkins.service.d"
+    state: directory
+    mode: '0755'
+  tags:
+    - jenkins
+    - properties
+
+- name: Configure Jenkins Java override
+  copy:
+    dest: "{{ jenkins_override_path }}"
+    content: |
+      [Service]
+      Environment="JENKINS_PORT={{ jenkins_http_port }}"
+      Environment="JAVA_HOME={{ jenkins_java_home }}"
+    owner: root
+    group: root
+    mode: '0644'
+  tags:
+    - jenkins
+    - properties
 
   # Retry to reinstall deps, specially jenkins
   # Useful if we use a different port than 8080 and 8080 is in use (so the first install fails)
@@ -67,3 +122,12 @@
   # with correct ports
   ignore_errors: no
   tags: jenkins
+
+- name: Reload systemd and restart Jenkins
+  systemd:
+    name: jenkins
+    state: restarted
+    daemon_reload: yes
+  tags:
+    - jenkins
+    - service

--- a/ansible/roles/jenkins-simple/vars/main.yml
+++ b/ansible/roles/jenkins-simple/vars/main.yml
@@ -2,3 +2,7 @@ local_repo_dir: ~/.ala
 data_dir: /data
 # Jenkins LTS channel is debian-stable, bleeding edge is debian
 jenkins_channel: debian-stable
+jenkins_java_version: 17
+jenkins_java_package: "openjdk-{{ jenkins_java_version }}-jdk"
+jenkins_java_home: "/usr/lib/jvm/java-{{ jenkins_java_version }}-openjdk-amd64"
+jenkins_override_path: "/etc/systemd/system/jenkins.service.d/override.conf"


### PR DESCRIPTION
This pull request introduces changes to the `jenkins-simple` ansible role to improve Java configuration management and systemd service handling for Jenkins. The updates include dynamically managing the Java version, configuring systemd overrides, and ensuring proper port configuration.

This allows to have pipelines and jenkins with different java versions. 

Fix for #887.

With this PR:
```
# service jenkins status
* jenkins.service - Jenkins Continuous Integration Server
     Loaded: loaded (/usr/lib/systemd/system/jenkins.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/jenkins.service.d
             `-override.conf
     Active: active (running) since Tue 2025-06-17 14:22:24 UTC; 2min 14s ago
   Main PID: 31343 (java)
      Tasks: 46 (limit: 76848)
     Memory: 510.4M
        CPU: 8.471s
     CGroup: /system.slice/jenkins.service
             `-31343 /usr/lib/jvm/java-17-openjdk-amd64/bin/java -Djava.awt.headless=true -jar /usr/share/java/jenkins.war --webroot=/var/cache/jenkins/war --ht>

Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: Please use the following password to proceed to installation:
Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: 36897f43a81145068b1faf5669317177
Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: This may also be found at: /var/lib/jenkins/secrets/initialAdminPassword
Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: *************************************************************
Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: *************************************************************
Jun 17 14:22:22 ala-install-test-1 jenkins[31343]: *************************************************************
Jun 17 14:22:23 ala-install-test-1 jenkins[31343]: 2025-06-17 14:22:23.403+0000 [id=51]        INFO        h.m.DownloadService$Downloadable#load: Obtained the u>
Jun 17 14:22:24 ala-install-test-1 jenkins[31343]: 2025-06-17 14:22:24.879+0000 [id=31]        INFO        jenkins.InitReactorRunner$1#onAttained: Completed ini>
Jun 17 14:22:24 ala-install-test-1 jenkins[31343]: 2025-06-17 14:22:24.923+0000 [id=23]        INFO        hudson.lifecycle.Lifecycle#onReady: Jenkins is fully >
Jun 17 14:22:24 ala-install-test-1 systemd[1]: Started Jenkins Continuous Integration Server.
```