### PR TITLE
Fix postgis version for u22 (see #599)

### DIFF
--- a/ansible/roles/common/tasks/setfacts.yml
+++ b/ansible/roles/common/tasks/setfacts.yml
@@ -175,7 +175,7 @@
     pg_version: "{{ pg_version | default('14') }}"
     postgis_version: "{{ postgis_version | default('3') }}"
     postgis_version_folder: "{{ postgis_version_folder | default('3') }}"
-    postgis_scripts_version: "{{ postgis_scripts_version | default('3.4') }}"
+    postgis_scripts_version: "{{ postgis_scripts_version | default('3.5') }}"
   when: ansible_os_family == "Debian" and ansible_distribution_version == "22.04"
   tags:
     - setfacts


### PR DESCRIPTION
Currently, services like `images` fails to install postgis extensions with the error:
```
TASK [postgresql : run the postgis SQL scripts] ********************************
failed: [ala-install-test-1] (item=/usr/share/postgresql/14/contrib/postgis-3.4/postgis.sql) => {"ansible_loop_var": "item", "changed": true, "cmd": ["psql", "-d", "postgis_template", "-f", "/usr/share/postgresql/14/contrib/postgis-3.4/postgis.sql"], "delta": "0:00:00.020077", "end": "2025-06-20 07:53:04.403125", "item": "/usr/share/postgresql/14/contrib/postgis-3.4/postgis.sql", "msg": "non-zero return code", "rc": 1, "start": "2025-06-20 07:53:04.383048", "stderr": "psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/postgis.sql: No such file or directory", "stderr_lines": ["psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/postgis.sql: No such file or directory"], "stdout": "", "stdout_lines": []}
failed: [ala-install-test-1] (item=/usr/share/postgresql/14/contrib/postgis-3.4/spatial_ref_sys.sql) => {"ansible_loop_var": "item", "changed": true, "cmd": ["psql", "-d", "postgis_template", "-f", "/usr/share/postgresql/14/contrib/postgis-3.4/spatial_ref_sys.sql"], "delta": "0:00:00.020005", "end": "2025-06-20 07:53:04.756042", "item": "/usr/share/postgresql/14/contrib/postgis-3.4/spatial_ref_sys.sql", "msg": "non-zero return code", "rc": 1, "start": "2025-06-20 07:53:04.736037", "stderr": "psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/spatial_ref_sys.sql: No such file or directory", "stderr_lines": ["psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/spatial_ref_sys.sql: No such file or directory"], "stdout": "", "stdout_lines": []}
failed: [ala-install-test-1] (item=/usr/share/postgresql/14/contrib/postgis-3.4/postgis_comments.sql) => {"ansible_loop_var": "item", "changed": true, "cmd": ["psql", "-d", "postgis_template", "-f", "/usr/share/postgresql/14/contrib/postgis-3.4/postgis_comments.sql"], "delta": "0:00:00.020175", "end": "2025-06-20 07:53:05.116427", "item": "/usr/share/postgresql/14/contrib/postgis-3.4/postgis_comments.sql", "msg": "non-zero return code", "rc": 1, "start": "2025-06-20 07:53:05.096252", "stderr": "psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/postgis_comments.sql: No such file or directory", "stderr_lines": ["psql: error: /usr/share/postgresql/14/contrib/postgis-3.4/postgis_comments.sql: No such file or directory"], "stdout": "", "stdout_lines": []}
```

And with this PR:
```
TASK [postgresql : run the postgis SQL scripts] ********************************
changed: [ala-install-test-1] => (item=/usr/share/postgresql/14/contrib/postgis-3.5/postgis.sql)
changed: [ala-install-test-1] => (item=/usr/share/postgresql/14/contrib/postgis-3.5/spatial_ref_sys.sql)
changed: [ala-install-test-1] => (item=/usr/share/postgresql/14/contrib/postgis-3.5/postgis_comments.sql)
```

See #599 for a list of u22 issues.