### PR TITLE
tomcat9 interpreter path fix

### DIFF
--- a/ansible/library/tomcat9_connector
+++ b/ansible/library/tomcat9_connector
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # This file is part of ALA ansible scripts


### PR DESCRIPTION
This pull request includes a small change to the shebang line in the `ansible/library/tomcat9_connector` file. The change updates the interpreter path from `/usr/bin/env python3` to `/usr/bin/python3` to fix #902.

Thanks to @CodenameGreyFox for the report and for testing the fix.