### PR TITLE
Reload nginx after cas deployment

### DIFF
--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -135,6 +135,15 @@
     - cas
   when: webserver_nginx
 
+- name: Reload nginx (needed by userdetails)
+  ansible.builtin.command: nginx -s reload
+  when: deployment_type == 'vm' and webserver_nginx
+  become: yes
+  tags:
+    - nginx_vhost
+    - deploy
+    - cas
+
 - name: Include docker tasks
   include_tasks: docker-tasks.yml
   when: deployment_type == 'swarm'


### PR DESCRIPTION
This fix the #909 issue, as recent versions of `userdetails` fails because https://your.l-a.site/cas/oidc/.well-known is not yet available without a nginx reload.