### PR TITLE
Ensure SOLR cores are created only if missing

### DIFF
--- a/ansible/roles/solr/tasks/main.yml
+++ b/ansible/roles/solr/tasks/main.yml
@@ -149,8 +149,32 @@
     - solr
     - solr_check_running
 
-- name: Create SOLR cores
-  get_url: url="{{ solr_base_url }}/solr/admin/cores?action=CREATE&name={{ item }}&instanceDir={{data_dir}}/solr/data/{{ item }}&config=solrconfig.xml&dataDir=data" force=yes timeout=30 dest=/tmp/solr-output-{{ item }}
+- name: Get SOLR cores status
+  uri:
+    url: "{{ solr_base_url }}/solr/admin/cores?action=STATUS&wt=json"
+    method: GET
+    timeout: 30
+    return_content: yes
+  register: solr_status
+  ignore_errors: yes
+  tags:
+    - solr
+    - solr_create_cores
+
+- name: Extract existing cores from SOLR status
+  set_fact:
+    existing_cores: "{{ (solr_status.json.status | default({}) | dict2items | map(attribute='key') | list) if solr_status.status == 200 else [] }}"
+  tags:
+    - solr
+    - solr_create_cores
+
+- name: Create missing SOLR cores
+  get_url:
+    url: "{{ solr_base_url }}/solr/admin/cores?action=CREATE&name={{ item }}&instanceDir={{ data_dir }}/solr/data/{{ item }}&config=solrconfig.xml&dataDir=data"
+    force: yes
+    timeout: 30
+    dest: "/tmp/solr-output-{{ item }}"
+  when: item not in existing_cores
   with_items:
     - "biocache"
     - "bie"
@@ -158,10 +182,3 @@
   tags:
     - solr
     - solr_create_cores
-
-
-
-
-
-
-


### PR DESCRIPTION
This pull request updates the SOLR core creation logic in the Ansible role to ensure that only missing cores are created, preventing errors when trying the recreation of existing cores (fixing #937). 

Output of this PR in a new VM withot solr cores:
```
TASK [solr : Create missing SOLR cores] ****************************************
changed: [ala-install-test-2] => (item=biocache)
changed: [ala-install-test-2] => (item=bie)
changed: [ala-install-test-2] => (item=bie-offline)
```

Output with a missing/deleted core:
```
TASK [solr : Get SOLR cores status] ********************************************
ok: [ala-install-test-2]

TASK [solr : Extract existing cores from SOLR status] **************************
ok: [ala-install-test-2]

TASK [solr : Create missing SOLR cores] ****************************************
changed: [ala-install-test-2] => (item=biocache)
skipping: [ala-install-test-2] => (item=bie) 
skipping: [ala-install-test-2] => (item=bie-offline) 
```

Output with all cores already created:
```
TASK [solr : Get SOLR cores status] ********************************************
ok: [ala-install-test-2]

TASK [solr : Extract existing cores from SOLR status] **************************
ok: [ala-install-test-2]

TASK [solr : Create missing SOLR cores] ****************************************
skipping: [ala-install-test-2] => (item=biocache) 
skipping: [ala-install-test-2] => (item=bie) 
skipping: [ala-install-test-2] => (item=bie-offline) 
skipping: [ala-install-test-2]
```