### PR TITLE
fix: ES8 security auto-disable + image-service default-headers template key

### DIFF
--- a/ansible/roles/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -35,6 +35,14 @@ action.auto_create_index: {{ es_action_auto_create_index }}
 xpack.security.enabled: true
 {% endif %}
 
+{% if es_version is defined and es_version is version('8.0.0', '>=') and (es_api_basic_auth_username is not defined or not es_enable_xpack) %}
+# ES8+ has security enabled by default; disable when no explicit auth is configured
+xpack.security.enabled: false
+xpack.security.enrollment.enabled: false
+xpack.security.http.ssl.enabled: false
+xpack.security.transport.ssl.enabled: false
+{% endif %}
+
 {% if es_mail_config is defined %}
 xpack.notification.email:
   account:

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -207,7 +207,7 @@ elasticsearch:
   username: "{{ elasticsearch_username | default('') }}"
   password: "{{ elasticsearch_password | default ('') }}"
 {% if elasticsearch_default_headers is defined and elasticsearch_default_headers | length > 0 %}
-  hosts:
+  default-headers:
 {% for item in elasticsearch_default_headers %}
   - name: {{ item.name }}
     value: {{ item.value }}


### PR DESCRIPTION
Two fixes to make image-service 4.x work with ES8:

1. ansible-elasticsearch: ES8 enables security by default. Added conditional to disable it when no auth is explicitly configured.

2. image-service template: PR #930 has a bug — nests the X-Elastic-Product header under duplicate "hosts:" key instead of "default-headers:". Fixed.

Tested on Ubuntu 24.04.

Related: #951