### PR TITLE
Fix vars syntax in profile-service include_tasks

### DIFF
--- a/ansible/roles/profile-service/tasks/main.yml
+++ b/ansible/roles/profile-service/tasks/main.yml
@@ -231,8 +231,8 @@
 #
 - include_tasks: ../../apache_vhost/tasks/main.yml
   vars:
-    context_path='{{ profile_service_context_path }}'
-    hostname='{{ profile_service_hostname }}'
+    context_path: "{{ profile_service_context_path }}"
+    hostname: "{{ profile_service_hostname }}"
   tags:
     - profile-service
     - deploy


### PR DESCRIPTION
Replace shell-style var assignments with proper YAML mappings in ansible/roles/profile-service/tasks/main.yml. This ensures variables are passed correctly to the included task (context_path: '{{ profile_service_context_path }}', hostname: '{{ profile_service_hostname }}') and avoids YAML parsing issues.