### PR TITLE
image-service 4.2.0 support:

### DIFF
--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -147,6 +147,18 @@
     - properties
     - image-service
 
+- name: Configure TCP keepalive for S3 connection stability
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    sysctl_file: /etc/sysctl.d/99-tcp-keepalive.conf
+    reload: true
+  loop:
+    - { name: net.ipv4.tcp_keepalive_time,   value: "{{ tcp_keepalive_time | default('60') }}"  }
+    - { name: net.ipv4.tcp_keepalive_intvl,  value: "{{ tcp_keepalive_intvl | default('10') }}" }
+    - { name: net.ipv4.tcp_keepalive_probes, value: "{{ tcp_keepalive_probes | default('3') }}" }
+
 - name: install openjfx (Debian)
   apt: pkg=openjfx state=latest update_cache=yes
   when: ansible_os_family == "Debian" and use_openjdk8
@@ -171,6 +183,12 @@
             - "main.yml"
           paths:
             - "vars"
+
+    - name: Install libvips
+      package:
+        name: "{{ libvips_packages }}"
+        state: present
+      become: true
 
     - name: Install base image optimisation packages
       package:

--- a/ansible/roles/image-service/templates/config/image-service-config.yml
+++ b/ansible/roles/image-service/templates/config/image-service-config.yml
@@ -138,6 +138,7 @@ biocache:
 headerAndFooter:
   version: "{{ header_and_footer_version | default('1')}}"
   baseURL: "{{ header_and_footer_baseurl | default('https://www.ala.org.au/commonui-bs3-2019')}}"
+  challengeJsUrl: {{ header_and_footer_challenge_js_url | default('') }}
 ala:
   baseURL: "{{ ala_base_url | default('https://www.ala.org.au')}}"
 bie:

--- a/ansible/roles/image-service/vars/Debian.yml
+++ b/ansible/roles/image-service/vars/Debian.yml
@@ -10,3 +10,11 @@ image_optimisation_packages:
   - gifsicle
   - webp
   - libavif-bin
+libvips_packages:
+  - libvips42t64
+  - libvips-tools
+  - libvips-dev
+  - libjpeg-turbo8
+  - libpng16-16t64
+  - libwebp7
+  - libtiff6 

--- a/ansible/roles/image-service/vars/RedHat.yml
+++ b/ansible/roles/image-service/vars/RedHat.yml
@@ -10,3 +10,11 @@ image_optimisation_packages:
   - gifsicle
   - libwebp-tools
   - libavif
+libvips_packages:
+  - vips
+  - vips-tools
+  - vips-devel
+  - libjpeg-turbo
+  - libpng
+  - libwebp
+  - libtiff


### PR DESCRIPTION
- Add AWS WAF Challenge JS support
- Add install of native libvips packages
- Add tcp keepalive tuning support for AWS C Runtime library tuning