### PR TITLE
Add try_files SPA fallback for mobile-app

### DIFF
--- a/ansible/roles/biocollect/tasks/main.yml
+++ b/ansible/roles/biocollect/tasks/main.yml
@@ -145,6 +145,7 @@
       - path: "{{ biocollect_context_path | default('/') }}mobile-app"
         sort_label: "3_pwa_app"
         alias: "{{ biocollect_pwa_app_path | default('/data/biocollect/mobile-app') }}"
+        try_files: "$uri $uri/ {{ biocollect_context_path | default('/') }}mobile-app/index.html"
         index: "index.html"
   tags:
     - nginx_vhost
@@ -177,6 +178,7 @@
       - path: "{{ biocollect_context_path | default('/') }}mobile-app"
         sort_label: "4_pwa_app"
         alias: "{{ biocollect_pwa_app_path | default('/data/biocollect/mobile-app') }}"
+        try_files: "$uri $uri/ {{ biocollect_context_path | default('/') }}mobile-app/index.html"
         index: "index.html"
   tags:
     - nginx_vhost


### PR DESCRIPTION
Add nginx try_files directive to the biocollect mobile-app vhost entries so missing routes fall back to mobile-app/index.html. This enables single-page-app routing for both PWA entries, using the configured biocollect_context_path and biocollect_pwa_app_path.