### PR TITLE
fix(image-service): install svgo via npm where snap can't mount squashfs

### DIFF
--- a/ansible/roles/common/tasks/setfacts.yml
+++ b/ansible/roles/common/tasks/setfacts.yml
@@ -1,6 +1,12 @@
 - name: show ansible versions
   debug: msg="You are using Ansible {{ ansible_version.full }} on {{ansible_os_family}}. The current supported version for ala-install is {{ supported_ansible_version.full }}."
 
+- name: set container virtualisation types where snap can't mount squashfs
+  set_fact:
+    snap_unsupported_virt_types: ['lxc', 'docker', 'podman', 'container', 'systemd-nspawn', 'openvz']
+  tags:
+    - setfacts
+
 # - name: check the ansible version
 #   pause: prompt="You are not using the supported version of Ansible. The supported version is {{ supported_ansible_version.full }}. You are using {{ ansible_version.full }}. Proceed at your own risk. Press enter to continue"
 #   when: supported_ansible_version.major != ansible_version.major or supported_ansible_version.minor != ansible_version.minor

--- a/ansible/roles/image-service/tasks/main.yml
+++ b/ansible/roles/image-service/tasks/main.yml
@@ -196,20 +196,34 @@
         state: present
       become: true
 
+    # Snap has to mount a squashfs image, which is not permitted inside
+    # unprivileged containers (LXC, Docker, ...): snap install aborts with
+    # "system does not fully support snapd: cannot mount squashfs". Detect that
+    # case up front and install svgo (a plain Node CLI) via npm instead.
     - name: Install svgo for SVG optimisation (Snap)
       snap:
         name: svgo
         state: present
       become: true
-      when: ansible_distribution == "Ubuntu"
+      when:
+        - ansible_distribution == "Ubuntu"
+        - ansible_virtualization_type not in snap_unsupported_virt_types
 
     - name: Install svgo for SVG optimisation (npm)
-      npm:
-        name: svgo
-        global: yes
-        state: present
       become: true
-      when: ansible_distribution != "Ubuntu"
+      when: >
+        ansible_distribution != "Ubuntu" or
+        ansible_virtualization_type in snap_unsupported_virt_types
+      block:
+        - name: Ensure npm is installed for svgo
+          ansible.builtin.package:
+            name: npm
+            state: present
+        - name: Install svgo via npm
+          npm:
+            name: svgo
+            global: yes
+            state: present
 
     - name: Check installed oxipng version
       command: dpkg-query -W -f='${Version}' oxipng


### PR DESCRIPTION
svgo installs via snap on Ubuntu, but snapd can't mount its squashfs image inside unprivileged containers (LXC/Docker), so the task fails with "system does not fully support snapd: cannot mount squashfs" and aborts the service deploy, even though SVG optimisation is optional.

Detect that case via ansible_virtualization_type (lxc/docker/podman/container/ systemd-nspawn/openvz) and install svgo with npm there instead (ensuring npm is present first, since the image is not otherwise installed). 

Tested on Ubuntu 22.04 in an unprivileged Proxmox LXC (ala-install-deploy-tests #1409): snap task skips, npm+svgo install cleanly, deploy completes green.

Fix for #977.