### PR TITLE
Fix maxent download in spatial-service

### DIFF
--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -133,6 +133,7 @@
 
 # AMNH's ?op=download endpoint is behind a Cloudflare bot-challenge and 403s automated
 # clients (hence the old ignore_errors); the mrmaxent GitHub mirror serves the same jar.
+# 3x5s is not enough to ride out a GitHub outage or a rate-limit window; ~2.5 min is.
 - name: Download maxent.jar
   get_url:
     url: "https://raw.githubusercontent.com/mrmaxent/Maxent/master/ArchivedReleases/{{ maxent_version | default('3.4.3') }}/maxent.jar"
@@ -141,8 +142,8 @@
     group: "{{ tomcat_user }}"
     mode: '0644'
   register: maxent_dl
-  retries: 3
-  delay: 5
+  retries: 5
+  delay: 30
   until: maxent_dl is succeeded
   tags:
     - spatial-service

--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -134,17 +134,28 @@
 # AMNH's ?op=download endpoint is behind a Cloudflare bot-challenge and 403s automated
 # clients (hence the old ignore_errors); the mrmaxent GitHub mirror serves the same jar.
 # 3x5s is not enough to ride out a GitHub outage or a rate-limit window; ~2.5 min is.
+# When even that is not enough, warn instead of failing: maxent.jar is optional (only
+# Maxent model runs need it), and a fatal here takes the whole host out of the play.
 - name: Download maxent.jar
-  get_url:
-    url: "https://raw.githubusercontent.com/mrmaxent/Maxent/master/ArchivedReleases/{{ maxent_version | default('3.4.3') }}/maxent.jar"
-    dest: "{{data_dir}}/spatial-data/modelling/maxent/maxent.jar"
-    owner: "{{ tomcat_user }}"
-    group: "{{ tomcat_user }}"
-    mode: '0644'
-  register: maxent_dl
-  retries: 5
-  delay: 30
-  until: maxent_dl is succeeded
+  block:
+    - name: Download maxent.jar
+      get_url:
+        url: "https://raw.githubusercontent.com/mrmaxent/Maxent/master/ArchivedReleases/{{ maxent_version | default('3.4.3') }}/maxent.jar"
+        dest: "{{data_dir}}/spatial-data/modelling/maxent/maxent.jar"
+        owner: "{{ tomcat_user }}"
+        group: "{{ tomcat_user }}"
+        mode: '0644'
+      register: maxent_dl
+      retries: 5
+      delay: 30
+      until: maxent_dl is succeeded
+  rescue:
+    - name: Warn that Maxent modelling will be unavailable
+      debug:
+        msg: >-
+          maxent.jar could not be downloaded ({{ maxent_dl.msg | default('unknown error') }}).
+          spatial-service starts without it; Maxent model runs will fail until a later deploy
+          fetches it.
   tags:
     - spatial-service
     - spatial-deps

--- a/ansible/roles/spatial-service/tasks/main.yml
+++ b/ansible/roles/spatial-service/tasks/main.yml
@@ -125,55 +125,25 @@
     - spatial-service
     - spatial-deps
 
-- name: Download maxent.zip
-  ignore_errors: yes # This is currently returning 403
-  get_url:
-    url: 'https://biodiversityinformatics.amnh.org/open_source/maxent/maxent.php?op=download'
-    dest: /tmp/maxent.zip
-  tags:
-    - spatial-service
-    - spatial-deps
-
 - name: Create directory for maxent
   file: path={{data_dir}}/spatial-data/modelling/maxent owner={{tomcat_user}} group={{tomcat_user}} recurse=true state=directory mode='0755'
   tags:
     - spatial-service
     - spatial-deps
 
-- name: Extract maxent.zip
-  ignore_errors: yes # currently failing to download maxent.zip
-  unarchive:
-    src: /tmp/maxent.zip
-    dest: /tmp/
-    remote_src: true
-  tags:
-    - spatial-service
-    - spatial-deps
-
-- name: Copy maxent.jar to the destination directory
-  ignore_errors: yes # currently failing to download maxent.zip
-  copy:
-    src: /tmp/maxent/maxent.jar
+# AMNH's ?op=download endpoint is behind a Cloudflare bot-challenge and 403s automated
+# clients (hence the old ignore_errors); the mrmaxent GitHub mirror serves the same jar.
+- name: Download maxent.jar
+  get_url:
+    url: "https://raw.githubusercontent.com/mrmaxent/Maxent/master/ArchivedReleases/{{ maxent_version | default('3.4.3') }}/maxent.jar"
     dest: "{{data_dir}}/spatial-data/modelling/maxent/maxent.jar"
-    remote_src: true
-  tags:
-    - spatial-service
-    - spatial-deps
-
-- name: Remove temporary maxent.zip file
-  ignore_errors: yes # currently failing to download maxent.zip
-  file:
-    path: /tmp/maxent.zip
-    state: absent
-  tags:
-    - spatial-service
-    - spatial-deps
-
-- name: Remove extracted maxent directory
-  ignore_errors: yes # currently failing to download maxent.zip
-  file:
-    path: /tmp/maxent
-    state: absent
+    owner: "{{ tomcat_user }}"
+    group: "{{ tomcat_user }}"
+    mode: '0644'
+  register: maxent_dl
+  retries: 3
+  delay: 5
+  until: maxent_dl is succeeded
   tags:
     - spatial-service
     - spatial-deps


### PR DESCRIPTION
Replaces the unreliable AMNH maxent download (now behind Cloudflare, returning 403 previously masked with `ignore_errors`) with a direct jar download from the upstream `mrmaxent/Maxent` GitHub mirror. Pins `3.4.3` (the version AMNH currently serves) via a new `maxent_version` variable; `3.4.4` is available if we want to bump. Removes the now-unnecessary zip extract/copy/cleanup tasks.

Two follow-up commits on the same task, from hitting it again after this PR was opened: the download now retries 5 x 30s, because the default 3 x 5s is all spent inside a single GitHub outage or rate-limit window; and if it still fails it warns instead of aborting the play. `maxent.jar` is an optional modelling dependency (spatial-service starts and serves without it, only Maxent model runs need it) so a fatal here takes the whole host out of the play over something the deployment can do without.

Tested on `ala-install-deploy-tests` (full `spatial` service): the `spatial-service : Download maxent.jar` task succeeds (`changed`) and the jar lands in `{{data_dir}}/spatial-data/modelling/maxent/maxent.jar`.

Fixes old #383 and #984.

Tested:

> 
> TASK [spatial-service : Create directory for maxent] ***************************
> changed: [ala-install-test-1.spatial]
> 
> TASK [spatial-service : Download maxent.jar] ***********************************
> changed: [ala-install-test-1.spatial]
