### PR TITLE
Add CAS .well-known headers

### DIFF
--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -136,7 +136,7 @@
           - "Pragma"
           - "Expires"
         # merge keeps the server level security headers, requires nginx >= 1.29.3
-        header_inherit: "{{ nginx_header_inherit | default('merge') }}"
+        header_inherit: "{{ nginx_header_inherit | default('off') }}"
         response_headers:
           - 'Cache-Control "max-age=3600, stale-while-revalidate=600, stale-if-error=86400"'
       - path: "/{{ cas_context_path | default('cas') }}"

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -125,7 +125,20 @@
     hostname: "{{ cas_host_name }}"
     context_path: "{{ cas_context_path | default('cas') }}"
     nginx_paths:
+      # Regex location, so proxy_pass must not have a URI part and the request URI is passed through unchanged
+      - path: "~ ^/{{ cas_context_path | default('cas') }}/oidc/\\.well-known"
+        sort_label: "cas_1_well_known"
+        appname: "cas"
+        is_proxy: true
+        proxy_pass: "http://{{ cas_docker_host | default('127.0.0.1') }}:{{ cas_port | default('9000') }}"
+        hide_headers:
+          - "Cache-Control"
+          - "Pragma"
+          - "Expires"
+        response_headers:
+          - 'Cache-Control "max-age=3600, stale-while-revalidate=600, stale-if-error=86400"'
       - path: "/{{ cas_context_path | default('cas') }}"
+        sort_label: "cas_2_app"
         appname: "cas"
         is_proxy: true
         proxy_pass: "http://{{ cas_docker_host | default('127.0.0.1') }}:{{ cas_port | default('9000') }}/{{ cas_context_path | default('cas') }}"
@@ -148,6 +161,8 @@
         is_proxy: false
         rewrite_path_alt: " /{{ cas_context_path | default('cas') }}/oidc/.well-known break"
         default_type: "application/json"
+        response_headers:
+          - 'Cache-Control "max-age=3600, stale-while-revalidate=600, stale-if-error=86400"'
       - path: "/{{ cas_context_path | default('cas') }}"
         sort_label: "cas_2_app"
         appname: "cas"

--- a/ansible/roles/cas5/tasks/main.yml
+++ b/ansible/roles/cas5/tasks/main.yml
@@ -135,6 +135,8 @@
           - "Cache-Control"
           - "Pragma"
           - "Expires"
+        # merge keeps the server level security headers, requires nginx >= 1.29.3
+        header_inherit: "{{ nginx_header_inherit | default('merge') }}"
         response_headers:
           - 'Cache-Control "max-age=3600, stale-while-revalidate=600, stale-if-error=86400"'
       - path: "/{{ cas_context_path | default('cas') }}"
@@ -161,6 +163,8 @@
         is_proxy: false
         rewrite_path_alt: " /{{ cas_context_path | default('cas') }}/oidc/.well-known break"
         default_type: "application/json"
+        # merge keeps the server level security headers, requires nginx >= 1.29.3
+        header_inherit: "{{ nginx_header_inherit | default('merge') }}"
         response_headers:
           - 'Cache-Control "max-age=3600, stale-while-revalidate=600, stale-if-error=86400"'
       - path: "/{{ cas_context_path | default('cas') }}"

--- a/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
@@ -17,6 +17,9 @@
 {% endfor %}
 {% endif %}
 {% if item.response_headers is defined and item.response_headers|length > 0 %}
+{% if item.header_inherit is defined and item.header_inherit %}
+        add_header_inherit {{ item.header_inherit }};
+{% endif %}
 {% for next_response_header in item.response_headers %}
         add_header {{ next_response_header }};
 {% endfor %}

--- a/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_73_location.j2
@@ -11,6 +11,16 @@
 {% if item.disable is defined and item.disable | bool == True %}
         return 404;
 {% endif %}
+{% if item.hide_headers is defined and item.hide_headers|length > 0 %}
+{% for next_hide_header in item.hide_headers %}
+        proxy_hide_header {{ next_hide_header }};
+{% endfor %}
+{% endif %}
+{% if item.response_headers is defined and item.response_headers|length > 0 %}
+{% for next_response_header in item.response_headers %}
+        add_header {{ next_response_header }};
+{% endfor %}
+{% endif %}
 {% if item.extra_logs is defined and item.extra_logs|length > 0 %}
         access_log {{ nginx_access_log }};
 {% for next_extra_log in item.extra_logs %}


### PR DESCRIPTION
Add headers to instruct caches to serve CAS .well-known as stale on origin error. Override any existing headers coming from the origin