### PR TITLE
Make the IPv6 listen optional in nginx_vhost

### DIFF
--- a/ansible/roles/nginx_vhost/defaults/main.yml
+++ b/ansible/roles/nginx_vhost/defaults/main.yml
@@ -36,6 +36,9 @@ nginx_set_real_ips: []
 # Set to true to enable the proxy protocol
 # https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/
 nginx_proxy_protocol_enabled: False
+# Set to false where the host has no IPv6 stack: nginx aborts on "listen [::]:80"
+# rather than skipping it, so the vhost never starts
+nginx_listen_ipv6: true
 # Set to "proxy_protocol" to support the nginx proxy protocol
 nginx_real_ip_header: "X-Forwarded-For"
 # If either of the following are set to true, a default host will be created

--- a/ansible/roles/nginx_vhost/templates/fragment_10_start_http.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_10_start_http.j2
@@ -2,4 +2,6 @@
 #{{ ansible_managed }}
 server {
     listen 80 {% if nginx_proxy_protocol_enabled | bool %}proxy_protocol{% endif %};
+{% if nginx_listen_ipv6 | bool %}
     listen [::]:80 {% if nginx_proxy_protocol_enabled | bool %}proxy_protocol{% endif %};
+{% endif %}

--- a/ansible/roles/nginx_vhost/templates/fragment_10_start_https.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_10_start_https.j2
@@ -1,5 +1,7 @@
 
 server {
     listen 443 ssl {% if nginx_proxy_protocol_enabled | bool %}proxy_protocol{% endif %};
+{% if nginx_listen_ipv6 | bool %}
     listen [::]:443 ssl {% if nginx_proxy_protocol_enabled | bool %}proxy_protocol{% endif %};
+{% endif %}
     {% if nginx_http2_enabled | bool %}http2 on;{% endif %}


### PR DESCRIPTION
On a host with no IPv6 stack, nginx does not skip `listen [::]:80`: it aborts with `socket() [::]:80 failed (97: Address family not supported by protocol)` and never starts, so every vhost this role renders is dead. Docker bridge networks are the common case, since they have no IPv6 unless the daemon is explicitly configured for it, but any IPv6-less host hits the same thing. The nginx image's own entrypoint strips that line only from its bundled `default.conf`, never from the vhosts rendered here.

`nginx_listen_ipv6` gates both listens and defaults to `true`, so nothing changes unless an inventory opts out.
