### PR TITLE
Derive ALLOWED_SENDER_DOMAINS from the deployment's own sender

### DIFF
--- a/ansible/roles/docker-common/templates/docker-compose.yml.j2
+++ b/ansible/roles/docker-common/templates/docker-compose.yml.j2
@@ -39,7 +39,9 @@ services:
       RELAYHOST: {{ email_sender_server | default('') }}
       RELAYHOST_USERNAME: {{ email_sender | default('') }}
       RELAYHOST_PASSWORD: {{ email_sender_password | default('') }}
-      ALLOWED_SENDER_DOMAINS: {{ email_allowed_domains | default('l-a.site') }}
+      # Derived from this deployment's own sender: email_allowed_domains is set
+      # nowhere in this repo, so a literal default here applies to everyone.
+      ALLOWED_SENDER_DOMAINS: {{ email_allowed_domains | default(email_sender | default('') | regex_replace('^.*@', '')) }}
     networks:
       la_internal:
 


### PR DESCRIPTION
`ALLOWED_SENDER_DOMAINS` for the postfix container defaulted to the literal `l-a.site`, and `email_allowed_domains` is not set anywhere in this repo, so the default always applied: every deployment authorised a domain belonging to someone else. Postfix reports it at startup as `Setting up allowed SENDER domains: l-a.site`.

It is now derived from `email_sender`, which the same block already uses for `RELAYHOST_USERNAME`. When `email_sender` is unset the result is empty, which authorises nobody. That is a safer failure than authorising a third party's domain.
