### PR TITLE
Create the SDS directories on every host, not just the first

### DIFF
--- a/ansible/roles/sensitive-data-service/tasks/docker-tasks.yml
+++ b/ansible/roles/sensitive-data-service/tasks/docker-tasks.yml
@@ -1,10 +1,11 @@
 ---
+# No run_once here, same reason as in main.yml: the downloads below write into
+# {{ data_dir }}/biocache/layers on every host, not just the first.
 - name: ensure target db directories exist
   file: path={{item}} state=directory
   with_items:
     - "{{ ala_sensitive_data_service_docker_dir }}"
     - "{{ data_dir }}/biocache/layers"
-  run_once: true
   tags:
     - docker
     - docker-service

--- a/ansible/roles/sensitive-data-service/tasks/main.yml
+++ b/ansible/roles/sensitive-data-service/tasks/main.yml
@@ -44,11 +44,12 @@
   import_tasks: vm-tasks.yml
   when: deployment_type == 'vm'
 
+# No run_once here: the next task templates into this directory on *every* host, so creating it
+# only on the first one makes the rest fail with "Destination directory does not exist".
 - name: ensure sds directories exist
   file: path={{item}} state=directory
   with_items:
     - "{{ data_dir }}/sds/config"
-  run_once: true
   tags:
     - sds
     - properties


### PR DESCRIPTION
Deploying `sensitive-data-service` on more than one host, for redundancy, does not work. The two tasks that create its directories are `run_once: true`, but the tasks that write into those directories are not: the `config.properties` template and the layer downloads both run on every host in the play.

So only the first host ends up with the directories. Every other host fails with `Destination directory /data/sds/config does not exist` and drops out of the play, taking with it every later role that would have run there. The first host completes normally, so the run reads as a success.

Dropping `run_once` puts the directory creation where the writes actually happen. It is idempotent and costs one extra `file` task per host.
