### PR TITLE
Index the CAS Mongo audit repository so login stops timing out

### DIFF
--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -259,3 +259,61 @@
     - cas-dbs
   run_once: true
   when: cas_add_mongo_users is defined and cas_add_mongo_users
+
+# CAS reads the audit repository on every authentication attempt (the throttle
+# interceptor) and nothing ever indexes that collection: MongoDbAuditTrailManager only
+# implements saveAuditRecord/getAuditRecordsSince/removeAll, in 6.5.x and in master
+# alike. Once it grows, every login becomes a COLLSCAN that blows past
+# cas.audit.mongo.timeout and 500s on /cas/login.
+#
+# Opt-in via cas_audit_indexes so inventories that don't ask for it behave exactly as
+# before. Uses the mongo/mongosh shell rather than community.mongodb.mongodb_index
+# because the mongo tasks above call mongodb_user unqualified - the collection is not
+# guaranteed to be installed everywhere this role runs.
+#
+- name: Render CAS audit repository index script
+  template:
+    src: cas-audit-indexes.js.j2
+    dest: /tmp/cas-audit-indexes.js
+    mode: "0600"
+  run_once: true
+  when: cas_audit_indexes | default(false) | bool
+  tags:
+    - cas-dbs
+    - cas-audit-indexes
+
+- name: Create CAS audit repository indexes (ubuntu < 22.04)
+  shell: >
+    mongo --host "{{ cas_audit_host | default('localhost') }}"
+    --port "{{ cas_audit_port | default('27017') }}"
+    --username "{{ mongodb_root_username }}" --password "{{ mongodb_root_password }}"
+    --authenticationDatabase "{{ mongodb_root_database | default('admin') }}"
+    "{{ cas_audit_db | default('cas-audit-repository') }}" --quiet
+    < /tmp/cas-audit-indexes.js
+  register: cas_audit_indexes_result
+  changed_when: "'CAS_AUDIT_INDEXES_CHANGED' in cas_audit_indexes_result.stdout"
+  run_once: true
+  when:
+    - cas_audit_indexes | default(false) | bool
+    - ansible_distribution_version is version('22.04', '<')
+  tags:
+    - cas-dbs
+    - cas-audit-indexes
+
+- name: Create CAS audit repository indexes (ubuntu >= 22.04)
+  shell: >
+    mongosh --host "{{ cas_audit_host | default('localhost') }}"
+    --port "{{ cas_audit_port | default('27017') }}"
+    --username "{{ mongodb_root_username }}" --password "{{ mongodb_root_password }}"
+    --authenticationDatabase "{{ mongodb_root_database | default('admin') }}"
+    "{{ cas_audit_db | default('cas-audit-repository') }}" --quiet
+    < /tmp/cas-audit-indexes.js
+  register: cas_audit_indexes_result
+  changed_when: "'CAS_AUDIT_INDEXES_CHANGED' in cas_audit_indexes_result.stdout"
+  run_once: true
+  when:
+    - cas_audit_indexes | default(false) | bool
+    - ansible_distribution_version is version('22.04', '>=')
+  tags:
+    - cas-dbs
+    - cas-audit-indexes

--- a/ansible/roles/cas5-dbs/tasks/main.yml
+++ b/ansible/roles/cas5-dbs/tasks/main.yml
@@ -282,16 +282,23 @@
     - cas-dbs
     - cas-audit-indexes
 
+# Pass the script as a file, never on stdin. Fed through stdin mongosh becomes a REPL: an
+# uncaught exception is printed, execution continues to the next line and it still exits 0,
+# so a broken run reports success. The legacy shell takes the script as a positional
+# argument and aborts on an uncaught throw.
 - name: Create CAS audit repository indexes (ubuntu < 22.04)
-  shell: >
+  command: >
     mongo --host "{{ cas_audit_host | default('localhost') }}"
     --port "{{ cas_audit_port | default('27017') }}"
     --username "{{ mongodb_root_username }}" --password "{{ mongodb_root_password }}"
     --authenticationDatabase "{{ mongodb_root_database | default('admin') }}"
     "{{ cas_audit_db | default('cas-audit-repository') }}" --quiet
-    < /tmp/cas-audit-indexes.js
+    /tmp/cas-audit-indexes.js
   register: cas_audit_indexes_result
   changed_when: "'CAS_AUDIT_INDEXES_CHANGED' in cas_audit_indexes_result.stdout"
+  failed_when: >-
+    cas_audit_indexes_result.rc != 0
+    or 'CAS_AUDIT_INDEX_COUNT=' not in cas_audit_indexes_result.stdout
   run_once: true
   when:
     - cas_audit_indexes | default(false) | bool
@@ -301,15 +308,18 @@
     - cas-audit-indexes
 
 - name: Create CAS audit repository indexes (ubuntu >= 22.04)
-  shell: >
+  command: >
     mongosh --host "{{ cas_audit_host | default('localhost') }}"
     --port "{{ cas_audit_port | default('27017') }}"
     --username "{{ mongodb_root_username }}" --password "{{ mongodb_root_password }}"
     --authenticationDatabase "{{ mongodb_root_database | default('admin') }}"
     "{{ cas_audit_db | default('cas-audit-repository') }}" --quiet
-    < /tmp/cas-audit-indexes.js
+    --file /tmp/cas-audit-indexes.js
   register: cas_audit_indexes_result
   changed_when: "'CAS_AUDIT_INDEXES_CHANGED' in cas_audit_indexes_result.stdout"
+  failed_when: >-
+    cas_audit_indexes_result.rc != 0
+    or 'CAS_AUDIT_INDEX_COUNT=' not in cas_audit_indexes_result.stdout
   run_once: true
   when:
     - cas_audit_indexes | default(false) | bool

--- a/ansible/roles/cas5-dbs/templates/cas-audit-indexes.js.j2
+++ b/ansible/roles/cas5-dbs/templates/cas-audit-indexes.js.j2
@@ -14,9 +14,28 @@
 // both the $gte range and the descending sort; the remaining predicates stay as a
 // residual filter over a handful of documents. `background` is deliberately absent: it
 // has been deprecated (and ignored) since MongoDB 4.2.
+//
+// Two mongosh traps this script is shaped around, both found the hard way in CI:
+//
+//  1. getIndexes() raises NamespaceNotFound when the collection does not exist, which
+//     is the NORMAL state on a fresh install - this runs before CAS writes its first
+//     audit record. So create the collection up front; CAS would create it anyway, and
+//     this way the index is in place before the first write.
+//  2. The shell API is promise-based. Only the top level of a script gets an implicit
+//     await, so a mongo call inside a plain function returns an unresolved Promise and
+//     a try/catch around it never fires. Every db call below therefore stays at the top
+//     level - do not "tidy" them into a helper function.
+//
+// Run it with `mongosh --file`, never with `< script.js`: stdin puts mongosh in REPL
+// mode, where an uncaught exception is printed and the script carries on to the next
+// line, still exiting 0. That turned a broken run into a green one. The legacy `mongo`
+// shell aborts the script on an uncaught throw, so it is safe there either way.
 {% set audit_collection = cas_audit_collection | default('MongoDbCasAuditRepository') %}
 var coll = {{ audit_collection | to_json }};
 var retentionDays = {{ cas_audit_retention_days | default(0) | int }};
+if (!db.getCollectionNames().includes(coll)) {
+  db.createCollection(coll);
+}
 var c = db.getCollection(coll);
 var changed = 0;
 

--- a/ansible/roles/cas5-dbs/templates/cas-audit-indexes.js.j2
+++ b/ansible/roles/cas5-dbs/templates/cas-audit-indexes.js.j2
@@ -1,0 +1,55 @@
+// CAS audit repository indexes - idempotent, safe to re-run on every play.
+//
+// Why this exists: CAS hits this collection on EVERY authentication attempt, from
+// MongoDbThrottledSubmissionHandlerInterceptorAdapter.exceedsThreshold, and nothing
+// ever indexes it. Apereo's MongoDbAuditTrailManager only implements saveAuditRecord /
+// getAuditRecordsSince / removeAll - no index creation, no TTL - in 6.5.x and in master
+// alike. So the collection grows unbounded and every login degrades into a COLLSCAN that
+// blows past cas.audit.mongo.timeout (PT5S), surfacing as MongoSocketReadTimeoutException
+// and a 500 on /cas/login.
+//
+// Index shape: clientIpAddress is the only selective field - applicationCode is always
+// "CAS" and principal is null in >99.9% of the throttle queries, so including them would
+// only inflate the index and slow down every audit write. whenActionWasPerformed serves
+// both the $gte range and the descending sort; the remaining predicates stay as a
+// residual filter over a handful of documents. `background` is deliberately absent: it
+// has been deprecated (and ignored) since MongoDB 4.2.
+{% set audit_collection = cas_audit_collection | default('MongoDbCasAuditRepository') %}
+var coll = {{ audit_collection | to_json }};
+var retentionDays = {{ cas_audit_retention_days | default(0) | int }};
+var c = db.getCollection(coll);
+var changed = 0;
+
+var before = c.getIndexes().length;
+c.createIndex({ clientIpAddress: 1, whenActionWasPerformed: -1 },
+              { name: "idx_cas_throttle_lookup" });
+if (c.getIndexes().length > before) {
+  changed++;
+}
+
+// Retention. createIndex cannot change expireAfterSeconds on an index that already
+// exists (it fails with IndexOptionsConflict), so each transition is handled explicitly.
+// Default is 0 = no TTL: the audit trail is personal data and the retention period is
+// each institution's policy to set. Enabling it on an already-large collection purges
+// the backlog in the background - do it off-peak.
+var ttlName = "idx_cas_audit_ttl";
+var ttl = c.getIndexes().filter(function (i) { return i.name === ttlName; })[0];
+if (retentionDays > 0) {
+  var seconds = retentionDays * 86400;
+  if (!ttl) {
+    c.createIndex({ whenActionWasPerformed: 1 }, { name: ttlName, expireAfterSeconds: seconds });
+    changed++;
+  } else if (ttl.expireAfterSeconds !== seconds) {
+    db.runCommand({ collMod: coll, index: { name: ttlName, expireAfterSeconds: seconds } });
+    changed++;
+  }
+} else if (ttl) {
+  c.dropIndex(ttlName);
+  changed++;
+}
+
+// Sentinels for changed_when and for the read-back in the calling task.
+if (changed > 0) {
+  print("CAS_AUDIT_INDEXES_CHANGED");
+}
+print("CAS_AUDIT_INDEX_COUNT=" + c.getIndexes().length);


### PR DESCRIPTION
CAS reads the audit repository on every authentication attempt, from `MongoDbThrottledSubmissionHandlerInterceptorAdapter.exceedsThreshold`, but nothing ever indexes that collection: Apereo's `MongoDbAuditTrailManager` implements only `saveAuditRecord`, `getAuditRecordsSince` and `removeAll`, in 6.5.x and in master alike, so it cannot be fixed from CAS config. Once the collection grows, every login becomes a COLLSCAN that blows past `cas.audit.mongo.timeout` (PT5S) and surfaces as a 500 on `/cas/login`. Measured on a live install: 11.8M documents, only the `_id_` index, worst case 73s for a query the throttle runs on every login.

The index covers `clientIpAddress` and `whenActionWasPerformed`. `applicationCode` is always `"CAS"` and `principal` is null in 99.94% of the throttle queries, so neither adds selectivity. The plan goes from COLLSCAN with an in-memory sort to IXSCAN examining exactly the documents it returns.

Opt-in via `cas_audit_indexes`, so inventories that do not ask for it are unaffected. Retention via `cas_audit_retention_days` is off by default: the audit trail is personal data and the retention period is each institution's policy to set.

The second commit makes the script fail loudly instead of silently. It creates the collection up front, because `getIndexes()` raises `NamespaceNotFound` on a fresh install, and runs via `mongosh --file` rather than stdin, which puts mongosh in REPL mode where an uncaught exception is printed and execution carries on, still exiting 0. Verified against `mongo:7` across create, no-op re-run, TTL create, change and removal, plus a deliberately failing script.

Diagnosis and original fix by @CodenameGreyFox.
