### PR TITLE
Install the namematching Lucene index on every host, not just the first

### DIFF
--- a/ansible/roles/namematching-service/tasks/docker-tasks.yml
+++ b/ansible/roles/namematching-service/tasks/docker-tasks.yml
@@ -1,9 +1,9 @@
 ---
 - name: ensure target db directories exist
+  # Not run_once: every host that runs the service needs this directory.
   file: path={{item}} state=directory
   with_items:
     - "{{ ala_namematching_service_docker_dir }}"
-  run_once: true
   tags:
     - docker
     - docker-service

--- a/ansible/roles/namematching-service/tasks/download-nameindex.yml
+++ b/ansible/roles/namematching-service/tasks/download-nameindex.yml
@@ -1,11 +1,13 @@
 ---
 
+# Nothing in this file may be run_once: the index is a per-host artifact, and every host
+# that mounts {{ final_dest }} needs its own copy on its own disk.
+
 - name: ensure lucene base directory exists
   file: path={{item}} state=directory
   with_items:
     - "{{ data_dir }}/lucene"
     - "/tmp/nm"
-  run_once: true
   tags:
     - nameindex
 
@@ -16,7 +18,6 @@
     force: "{{ force_nameindex_download | default(false) }}"
     timeout: 10000
     checksum: "sha1:{{ sha1 }}"
-  run_once: true
   tags:
     - nameindex
 
@@ -26,7 +27,6 @@
     dest: "/tmp/nm"
     remote_src: true
     extra_opts: ["--no-same-owner"]
-  run_once: true
   register: unarchive_result
   tags:
     - nameindex
@@ -36,7 +36,6 @@
     paths: "/tmp/nm"
     file_type: directory
     recurse: false
-  run_once: true
   register: find_result
   tags:
     - nameindex
@@ -52,7 +51,6 @@
     dest: "{{ final_dest }}"
     delete: true
     recursive: true
-  run_once: true
   delegate_to: "{{ inventory_hostname }}"
   tags:
     - nameindex
@@ -64,7 +62,6 @@
     # owner: "{{ namematching_user }}"
     # group: "{{ namematching_user }}"
     recurse: true
-  run_once: true
   tags:
     - nameindex
     - debug


### PR DESCRIPTION
Deploying `namematching-service` on more than one host, for redundancy, does not work. `download-nameindex.yml` downloads, extracts and rsyncs the Lucene index under `run_once`, so only the first host of the play ends up with one. Every other host keeps an empty `final_dest`, which a bind-mount accepts happily, and the service then crash-loops on `java.io.FileNotFoundException: /data/lucene/namematching-nm/cb`.

Same shape as #990, which fixes the equivalent `run_once` in `sensitive-data-service`.
