### PR TITLE
Clean the nameindex staging directory before extracting

### DIFF
--- a/ansible/roles/namematching-service/tasks/download-nameindex.yml
+++ b/ansible/roles/namematching-service/tasks/download-nameindex.yml
@@ -1,5 +1,14 @@
 ---
 
+# Nothing ever removed /tmp/nm, so every index extracted there stayed for good, and
+# "Find the first directory" below picks files[0] out of whatever accumulated.
+- name: wipe the nameindex staging directory
+  file:
+    path: "/tmp/nm"
+    state: absent
+  tags:
+    - nameindex
+
 - name: ensure lucene base directory exists
   file: path={{item}} state=directory
   with_items:


### PR DESCRIPTION
Nothing ever removes `/tmp/nm`. Every index extracted there stays, so a host that has installed two releases keeps both trees, several GB each, for good.

It also makes *Find the first directory/file in the untarred content* ambiguous. The `find` module gives no ordering guarantee, so once more than one tree is present, `files[0]` need not be the one just extracted, and the archive checksum would still match.

The `unarchive` task has no `creates`, so extraction already runs on every play. Wiping first costs nothing and removes both problems.
