### PR TITLE
Add a console appender for non-VM deployments

### DIFF
--- a/ansible/roles/apikey/templates/logback.xml
+++ b/ansible/roles/apikey/templates/logback.xml
@@ -23,6 +23,13 @@
     </encoder>
   </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+    </encoder>
+  </appender>
+{% endif %}
   <logger name="org.hibernate.orm.deprecation" level="ERROR" />
   <logger name="org.grails.config.NavigableMap" level="ERROR" />
   <logger name="de.codecentric.boot.admin" level="INFO" />
@@ -34,5 +41,8 @@
 
   <root level="WARN">
     <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender-ref ref="CONSOLE" />
+{% endif %}
   </root>
 </configuration>

--- a/ansible/roles/bie-hub/templates/logback.xml
+++ b/ansible/roles/bie-hub/templates/logback.xml
@@ -23,11 +23,21 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <logger name="org.hibernate.orm.deprecation" level="ERROR"/>
     <logger name="org.grails.config.NavigableMap" level="ERROR"/>
 
     <root level="WARN">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 
 </configuration>

--- a/ansible/roles/bie-index/templates/logback.xml
+++ b/ansible/roles/bie-index/templates/logback.xml
@@ -38,6 +38,13 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <logger name="org.grails.config.NavigableMap" level="ERROR"/>
 
     <logger name="au.org.ala" level="INFO">
@@ -56,6 +63,9 @@
 
     <root level="WARN">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 
 </configuration>

--- a/ansible/roles/biocache-hub/templates/config/logback.xml
+++ b/ansible/roles/biocache-hub/templates/config/logback.xml
@@ -23,7 +23,17 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <root level="WARN">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 </configuration>

--- a/ansible/roles/biocache3-service/templates/config/log4j.xml
+++ b/ansible/roles/biocache3-service/templates/config/log4j.xml
@@ -1,5 +1,17 @@
 <!DOCTYPE log4j:configuration  SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d [%t] %p %4c (%F:%L) - %m%n"/>
+        </layout>
+        <filter class="org.apache.log4j.varia.LevelMatchFilter">
+            <param name="LevelToMatch" value="REMOTE#org.ala.client.appender.RestLevel" />
+            <param name="AcceptOnMatch" value="false"/>
+        </filter>
+    </appender>
+{% endif %}
     <appender name="FILE" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="${catalina.base}/logs/biocache-service.log"/>
         <param name="Append" value="true"/>
@@ -72,6 +84,9 @@
     </category>
     <root>
         <priority value ="WARN" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE"/>
+{% endif %}
         <appender-ref ref="FILE"/>
         <appender-ref ref="ASYNC" />
     </root>

--- a/ansible/roles/cas-management/templates/log4j2-management.xml
+++ b/ansible/roles/cas-management/templates/log4j2-management.xml
@@ -37,7 +37,9 @@
         <AsyncLogger name="org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager" level="info"/>
         <Root level="warn">
             <AppenderRef ref="cas-management"/>
-            <!-- <AppenderRef ref="console"/> -->
+{% if deployment_type | default('vm') != 'vm' %}
+            <AppenderRef ref="console"/>
+{% endif %}
         </Root>
     </Loggers>
 </Configuration>

--- a/ansible/roles/cas5/templates/log4j2.xml
+++ b/ansible/roles/cas5/templates/log4j2.xml
@@ -103,6 +103,9 @@
         <AsyncLogger name="au.org.ala.cas" level="info" includeLocation="true" />
         <AsyncRoot level="error">
             <AppenderRef ref="casFile"/>
+{% if deployment_type | default('vm') != 'vm' %}
+            <AppenderRef ref="casConsole"/>
+{% endif %}
         </AsyncRoot>
     </Loggers>
 </Configuration>

--- a/ansible/roles/collectory/templates/logback.xml
+++ b/ansible/roles/collectory/templates/logback.xml
@@ -23,6 +23,13 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <logger name="org.hibernate.orm.deprecation" level="ERROR"/>
     <logger name="org.grails.config.NavigableMap" level="ERROR"/>
 
@@ -42,6 +49,9 @@
 
     <root level="INFO">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 
 </configuration>

--- a/ansible/roles/image-service/templates/config/logback.xml
+++ b/ansible/roles/image-service/templates/config/logback.xml
@@ -23,6 +23,14 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <logger name="org.hibernate.orm.deprecation" level="OFF" />
 
     <logger name="au.org.ala" level="WARN" />
@@ -40,5 +48,8 @@
 
     <root level="ERROR">
         <appender-ref ref="APPLICATION_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 </configuration>

--- a/ansible/roles/logger-service/templates/logback.xml
+++ b/ansible/roles/logger-service/templates/logback.xml
@@ -23,7 +23,17 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <root level="WARN">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 </configuration>

--- a/ansible/roles/logger-service/templates/logback.xml
+++ b/ansible/roles/logger-service/templates/logback.xml
@@ -6,7 +6,7 @@
     <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <variable name="appName" value="logger-service"/>
-    <variable name="LOG_DIR" value="{{ jar_log_path | default('/var/log/' + tomcat ) | default('/var/log/tomcat9')}}" />
+    <variable name="LOG_DIR" value="{{ jar_log_path | default('/var/log/' + (tomcat | default('tomcat9'))) }}" />
 
     <appender name="TOMCAT_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/${appName}.log</file>

--- a/ansible/roles/species-list/templates/logback.xml
+++ b/ansible/roles/species-list/templates/logback.xml
@@ -23,7 +23,17 @@
         </encoder>
     </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+        </encoder>
+    </appender>
+{% endif %}
     <root level="WARN">
         <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+        <appender-ref ref="CONSOLE" />
+{% endif %}
     </root>
 </configuration>

--- a/ansible/roles/userdetails/templates/logback.xml
+++ b/ansible/roles/userdetails/templates/logback.xml
@@ -23,6 +23,13 @@
     </encoder>
   </appender>
 
+{% if deployment_type | default('vm') != 'vm' %}
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n%wex</pattern>
+    </encoder>
+  </appender>
+{% endif %}
   <logger name="org.hibernate.orm.deprecation" level="ERROR" />
   <logger name="org.grails.config.NavigableMap" level="ERROR" />
   <logger name="grails.spring.BeanBuilder" level="ERROR" />
@@ -36,5 +43,8 @@
 
   <root level="WARN">
     <appender-ref ref="TOMCAT_LOG" />
+{% if deployment_type | default('vm') != 'vm' %}
+    <appender-ref ref="CONSOLE" />
+{% endif %}
   </root>
 </configuration>


### PR DESCRIPTION
Two commits, both about logging config.

**A console appender for non-VM deployments.** A containerised app writes its log to a rolling file inside the container, where nothing collects it: `docker logs` shows nothing, and the file goes away with the container. This adds a CONSOLE appender, wired into the root logger, to the logback/log4j templates this repo still deploys, behind `deployment_type | default('vm') != 'vm'`.

The `default('vm')` matters: it keeps VM deployments exactly as they are, including inventories that never set `deployment_type` at all. I checked rather than assumed, by rendering all 12 touched templates with the variable undefined and diffing against what they render today. 11 come out byte-identical; `cas-management` differs only by dropping a commented-out `AppenderRef` that the real gated one now replaces. `cas5` and `cas-management` already define a console appender, so there only the `AppenderRef` is added.

`biocache-service` is deliberately left out: `biocache-service-clusterdb.yml` selects that role only for `biocache_service_version < 3`, and the 3.x path uses `biocache3-service`, which is patched here.

**A fallback in logger-service that never fell back.** The same file carries:

```
{{ jar_log_path | default('/var/log/' + tomcat ) | default('/var/log/tomcat9') }}
```

Neither fallback works when `tomcat` is unset. Jinja evaluates the argument of the first `default()` eagerly, so `'/var/log/' + tomcat` raises before any default is considered, and the trailing one never gets a chance because what reaches it is an exception, not an undefined. On a host where `tomcat` is not defined, and it is commonly set per service group rather than globally, the template fails to render. Setting `jar_log_path` does not help either, which is the one thing it exists for. `bie-hub`, `bie-index` and `species-list` already write it the safe way, so this does the same and puts the default on `tomcat` itself.

Deployed and checked on a three-host cluster: 11 of the 12 services now emit application logs on stdout (9 with the logback pattern, `cas5` and `cas-management` with log4j2). The twelfth, `biocache3-service`, emits nothing for an unrelated reason: its WAR ships an SLF4J binding for api 1.7.x against a 2.x runtime, so SLF4J falls back to the NOP logger and discards application logs whatever `log4j.xml` says.
