### PR TITLE
Make the pipelines filesystem backend configurable

### DIFF
--- a/ansible/roles/pipelines/tasks/main.yml
+++ b/ansible/roles/pipelines/tasks/main.yml
@@ -7,8 +7,11 @@
     - properties
     - la-pipelines-config
 
+# Host-provisioning tasks below are skipped in container deployments (the pipelines
+# image ships these dependencies); on VMs they run exactly as before.
 - name: Install aptitude using apt
   apt: name=aptitude state=latest update_cache=yes force_apt_get=yes
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - apt
@@ -16,6 +19,7 @@
 - name: Install required system packages
   apt: name={{ item }} state=latest update_cache=yes
   loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools', 'unzip']
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - apt
@@ -58,6 +62,27 @@
     - "{{ data_dir }}/dwca-tmp"
     - "{{ data_dir }}/dwca-export"
     - "{{ data_dir }}/migration"
+  tags:
+    - properties
+    - la-pipelines-config
+    - pipelines
+    - docker
+    - la-pipelines
+
+- name: create local pipelines data directories (container only)
+  file: path={{ item }} state=directory owner={{ spark_user }} group={{ spark_user }} recurse=true
+  with_items:
+    - "{{ data_dir }}/la-pipelines/data"
+    - "{{ data_dir }}/la-pipelines/data/all-datasets"
+    - "{{ data_dir }}/la-pipelines/data/species"
+    - "{{ data_dir }}/la-pipelines/data/jackknife"
+    - "{{ data_dir }}/la-pipelines/data/clustering"
+    - "{{ data_dir }}/la-pipelines/data/outlier"
+    - "{{ data_dir }}/la-pipelines/vocabularies"
+    - "{{ data_dir }}/la-pipelines/spark-tmp"
+    - "{{ data_dir }}/la-pipelines/dwca-import"
+    - "{{ data_dir }}/logs/pipelines"
+  when: deployment_type | default('vm') == 'container'
   tags:
     - properties
     - la-pipelines-config
@@ -171,7 +196,7 @@
 
 - name: Get docopts
   shell: curl -o /usr/local/bin/docopts -LJO https://github.com/docopt/docopts/releases/download/v0.6.3-rc2/docopts_linux_amd64
-  when: is_arm is not defined
+  when: is_arm is not defined and deployment_type | default('vm') != 'container'
   tags:
     - la-pipelines
     - pipelines
@@ -179,7 +204,7 @@
 
 - name: Get docopts
   shell: curl -o /usr/local/bin/docopts -LJO https://github.com/docopt/docopts/releases/download/v0.6.3-rc2/docopts_linux_arm
-  when: is_arm is defined
+  when: is_arm is defined and deployment_type | default('vm') != 'container'
   tags:
     - la-pipelines
     - pipelines
@@ -188,6 +213,7 @@
 
 - name: Make docopts executable
   shell: chmod +x /usr/local/bin/docopts
+  when: deployment_type | default('vm') != 'container'
   tags:
     - la-pipelines
     - pipelines
@@ -195,6 +221,7 @@
 
 - name: Update apt and install pipelines
   apt: update_cache=yes name=la-pipelines={{ pipelines_version }} force=yes
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - la-pipelines
@@ -202,15 +229,18 @@
     - apt
 
 - name: Install pipelines config
-  template: src={{ item }} dest={{ data_dir }}/la-pipelines/config/{{ item }} mode=0644 output_encoding=iso-8859-1
-  with_items:
-    - la-pipelines-local.yaml
+  template:
+    # Single parametrized template (FS backend via pipelines_use_hdfs). Replaces the
+    # old container/non-container split that pointed at the missing la-pipelines-docker.yaml.j2.
+    src: la-pipelines-local.yaml
+    dest: "{{ data_dir }}/la-pipelines/config/la-pipelines-local.yaml"
+    mode: 0644
+    output_encoding: iso-8859-1
   tags:
     - properties
     - la-pipelines-config
     - pipelines
     - la-pipelines
-    - properties
 
 - name: Copy docker YAML files to {{ data_dir }}
   copy: src={{ item }} dest={{ data_dir }}/{{ item }}
@@ -305,6 +335,7 @@
     - "/migration"
   become: yes
   become_user: "{{ hadoop.user }}"
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - hadoop
@@ -325,6 +356,7 @@
     - "/migration"
   become: yes
   become_user: "{{ hadoop.user }}"
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - hadoop
@@ -340,6 +372,7 @@
     - DegreeOfEstablishment
     - EstablishmentMeans
     - Pathway
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - hadoop
@@ -354,6 +387,7 @@
     - EstablishmentMeans
     - Pathway
   become_user: "{{ hadoop.user }}"
+  when: deployment_type | default('vm') != 'container'
   tags:
     - pipelines
     - hadoop

--- a/ansible/roles/pipelines/templates/la-pipelines-local.yaml
+++ b/ansible/roles/pipelines/templates/la-pipelines-local.yaml
@@ -1,22 +1,26 @@
 # Ansible generated
+{# Filesystem backend is configurable: pipelines_use_hdfs defaults to
+   (deployment_type != 'container'): VM/cluster use HDFS, container uses local FS. #}
+{% set _use_hdfs = pipelines_use_hdfs | default((deployment_type | default('vm')) != 'container') | bool %}
+{% set fs = ('hdfs://' ~ hadoop_master ~ ':' ~ hadoop_port) if _use_hdfs else '' %}
 run:
   platform: local
   local:
     sparkTmp: {{ spark_tmp }}
     sparkMaster: ""
     dwcaTmp: {{ dwca_tmp }}
-    dwcaImportDir: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}
+    dwcaImportDir: {{ fs }}{{ dwca_import_dir }}
   spark-embedded:
     sparkTmp: {{ spark_tmp }}
     sparkMaster: ""
     dwcaTmp: {{ dwca_tmp }}
-    dwcaImportDir: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}
+    dwcaImportDir: {{ fs }}{{ dwca_import_dir }}
   spark-cluster:
     jar: /usr/share/la-pipelines/la-pipelines.jar
     sparkTmp: {{ spark_tmp }}
     sparkMaster: spark://{{ spark_master }}:7077
     dwcaTmp: {{ dwca_tmp }}
-    dwcaImportDir: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}
+    dwcaImportDir: {{ fs }}{{ dwca_import_dir }}
 
 alaNameMatch:
   wsUrl: {{ namematching_service_url | default('http://localhost:9179') }}
@@ -57,72 +61,74 @@ locationInfoConfig:
 {% endif %}
 gbifConfig:
   vocabularyConfig:
-    vocabulariesPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ vocabulary_dir }}
+    vocabulariesPath: {{ fs }}{{ vocabulary_dir }}
     lifeStageVocabName: LifeStage
 
 general:
   attempt: 1
+{% if _use_hdfs %}
   hdfsSiteConfig: {{ hadoop_install_dir }}/etc/hadoop/hdfs-site.xml
   coreSiteConfig: {{ hadoop_install_dir }}/etc/hadoop/core-site.xml
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+{% endif %}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
 dataset-validated-dump:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
 dataset-count-dump:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}/
-  dwcaImportPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}/
+  inputPath: {{ fs }}{{ pipelines_data_dir }}/
+  dwcaImportPath: {{ fs }}{{ dwca_import_dir }}/
 dataset-archive-list:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}/
+  inputPath: {{ fs }}{{ dwca_import_dir }}/
 dwca-avro:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ dwca_import_dir }}/{datasetId}/{datasetId}.zip
+  inputPath: {{ fs }}{{ dwca_import_dir }}/{datasetId}/{datasetId}.zip
   tempLocation: {{ spark_tmp }}/dwca-avro/{datasetId}
   hdfsTempLocation: {{ spark_tmp }}
 interpret:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}/{datasetId}/1/verbatim.avro
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}/{datasetId}/1/verbatim.avro
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
 images:
   tempLocation: {{ spark_tmp }}
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
   recognisedPaths: "{{ image_service_url }}"
 sampling:
   baseUrl: {{ layers_service_url | default('https://sampling.ala.org.au/sampling-service') }}/
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 speciesLists:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  speciesAggregatesPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-species
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  speciesAggregatesPath: {{ fs }}/pipelines-species
 uuid:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
 sensitive:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
 index:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 jackKnife:
-  jackKnifePath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-jackknife
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  jackKnifePath: {{ fs }}/pipelines-jackknife
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 clustering:
-  clusteringPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-clustering
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  clusteringPath: {{ fs }}/pipelines-clustering
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 outlier:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 solr:
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
-  jackKnifePath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-jackknife
-  clusteringPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-clustering
-  outlierPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-outlier
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
+  jackKnifePath: {{ fs }}/pipelines-jackknife
+  clusteringPath: {{ fs }}/pipelines-clustering
+  outlierPath: {{ fs }}/pipelines-outlier
   zkHost: {{ zk_host | default('localhost:2181') }}
   includeSampling: {{ include_sampling }}
   includeJackKnife: {{ include_jackknife }}
@@ -131,13 +137,13 @@ solr:
 validation-report:
   checkSolr: {{ check_solr }}
   checkSampling: {{ include_sampling }}
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
   zkHost: {{ zk_host | default('localhost:2181') }}
 export:
   imageServicePath: "{{ image_service_url }}/image/proxyImageThumbnailLarge?imageId={0}"
-  inputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  targetPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}{{ pipelines_data_dir }}
-  allDatasetsInputPath: hdfs://{{ hadoop_master }}:{{ hadoop_port }}/pipelines-all-datasets
+  inputPath: {{ fs }}{{ pipelines_data_dir }}
+  targetPath: {{ fs }}{{ pipelines_data_dir }}
+  allDatasetsInputPath: {{ fs }}/pipelines-all-datasets
 
 ### la-pipelines cli additional arguments, like JVM or spark command line arguments
 


### PR DESCRIPTION
`la-pipelines-local.yaml` hardcodes `hdfs://{{ hadoop_master }}:{{ hadoop_port }}` in front of every path it renders. That is right for a VM or cluster install, and wrong for a single-node one where the pipelines run against the local filesystem: there is no HDFS to point at.

The prefix now comes from one variable. `pipelines_use_hdfs` defaults to `deployment_type | default('vm') != 'container'`, so a VM install renders exactly what it renders today, including an inventory that never sets `deployment_type` at all. I checked rather than assumed, by rendering the template both ways and diffing: byte-identical with the variable unset and with it set to `vm`; in container mode the `hdfs://` prefixes drop out and nothing else moves.

The host-provisioning tasks in `tasks/main.yml` (docker, yq, docopts, the HDFS directories, the systemd units) are gated the same way rather than removed, so a VM install still runs all of them.
