### PR TITLE
Tolerate nginx_paths entries without sort_label

### DIFF
--- a/ansible/roles/nginx_vhost/templates/nginx_vhost.j2
+++ b/ansible/roles/nginx_vhost/templates/nginx_vhost.j2
@@ -16,7 +16,11 @@
 {{ m.fragment_50_root() }}
 {{ m.fragment_55_include() -}}
 {{ m.fragment_60_robots() }}
-{% for item in nginx_paths | sort(attribute='sort_label') %}
+{# nginx_paths entries may omit sort_label; sorting on it directly raises
+   AnsibleUndefinedVariable as soon as one entry has it and another does not.
+   Keep the labelled ones sorted first and append the unlabelled ones in
+   declaration order. #}
+{% for item in (nginx_paths | selectattr('sort_label', 'defined') | sort(attribute='sort_label')) + (nginx_paths | rejectattr('sort_label', 'defined') | list) %}
 {{ m.fragment_70_location_start(item) -}}
 {{ m.fragment_73_location(item) -}}
 {% if (nginx_cors_origin_regexp is defined) -%}
@@ -37,7 +41,11 @@
 {{ m.fragment_50_root() }}
 {{ m.fragment_55_include() -}}
 {{ m.fragment_60_robots() }}
-{% for item in nginx_paths | sort(attribute='sort_label') %}
+{# nginx_paths entries may omit sort_label; sorting on it directly raises
+   AnsibleUndefinedVariable as soon as one entry has it and another does not.
+   Keep the labelled ones sorted first and append the unlabelled ones in
+   declaration order. #}
+{% for item in (nginx_paths | selectattr('sort_label', 'defined') | sort(attribute='sort_label')) + (nginx_paths | rejectattr('sort_label', 'defined') | list) %}
 {{ m.fragment_70_location_start(item) -}}
 {{ m.fragment_73_location(item) -}}
 {{ m.fragment_74_location_cors() }}

--- a/ansible/roles/nginx_vhost/templates/nginx_vhost_default.j2
+++ b/ansible/roles/nginx_vhost/templates/nginx_vhost_default.j2
@@ -1,7 +1,11 @@
 {% import 'nginx_vhost_macros.j2' as m with context %}
 {% if (ala_default_vhost and vhost_required) -%}
 {{ m.ala_default_start() }}
-{% for item in nginx_paths | sort(attribute='sort_label') %}
+{# nginx_paths entries may omit sort_label; sorting on it directly raises
+   AnsibleUndefinedVariable as soon as one entry has it and another does not.
+   Keep the labelled ones sorted first and append the unlabelled ones in
+   declaration order. #}
+{% for item in (nginx_paths | selectattr('sort_label', 'defined') | sort(attribute='sort_label')) + (nginx_paths | rejectattr('sort_label', 'defined') | list) %}
 {{ m.fragment_70_location_start(item) -}}
 {{ m.fragment_71_location_default(item) }}
 {{ m.fragment_73_location(item) }}


### PR DESCRIPTION
`sort_label` is optional everywhere else in the role: every fragment task spells it `item.sort_label | default(item.path | basename)`. The two templates that render a whole vhost in one pass do not. They call `nginx_paths | sort(attribute='sort_label')`, and Jinja raises `UndefinedError` the moment one entry carries the attribute and another does not, so the play dies while rendering the vhost.

Those templates are only reached with `nginx_vhost_fast_mode: true`, so it affects deployments that opted into the optimisation, where it is a hard stop rather than a degradation. Any role that adds an unlabelled path to a labelled list hits it.

This sorts the labelled entries as before and appends the unlabelled ones in declaration order. `nginx_vhost_default.j2` had the same call and is fixed too.

Compatibility: with every entry labelled, which is the common case, the output is unchanged, duplicate labels included, because Jinja's sort is stable. Checked by rendering both expressions over a large batch of randomly generated fully labelled lists: identical every time. A list with no labels at all keeps declaration order in both versions.