### PR TITLE
Write the gatus check on the host that runs gatus

### DIFF
--- a/ansible/roles/nginx_vhost/tasks/main.yml
+++ b/ansible/roles/nginx_vhost/tasks/main.yml
@@ -153,13 +153,18 @@
   pause: prompt="nginx_paths value is {{nginx_paths}}"
   when: nginx_paths_debug_enabled is defined and nginx_paths_debug_enabled | bool == True
 
+# The check file has to land on the host that runs gatus, and in that host's
+# gatus_config_dir: gatus only reads its own config directory. Writing it on the
+# application host leaves the check invisible whenever the two are not the same
+# machine.
 - name: add gatus monitor of nginx_paths
   template:
     src: ../../gatus/templates/http.j2
-    dest: "{{ gatus_config_dir }}/{{appname}}-http.yaml"
-  with_items:
-    - "{{ nginx_paths}}"
-  when: use_gatus is defined and use_gatus
+    dest: "{{ hostvars[groups['gatus'][0]]['gatus_config_dir'] | default(gatus_config_dir) }}/{{ appname }}-http.yaml"
+  delegate_to: "{{ groups['gatus'][0] }}"
+  when:
+    - use_gatus is defined and use_gatus
+    - groups['gatus'] is defined and groups['gatus'] | length > 0
   tags:
     - nginx_vhost
     - gatus


### PR DESCRIPTION
`nginx_vhost` renders a gatus check per application into `gatus_config_dir`, so an application appears on the dashboard without anyone maintaining the gatus config by hand for this kind of check.

It writes that file on the host being configured. gatus reads only the config directory of the machine it runs on, and hosts do not share a filesystem, so unless gatus sits on the application's host the file lands where nothing reads it. Nothing fails, the check just never exists.

Delegate the copy to the host in the `gatus` group and resolve `gatus_config_dir` from that host's vars. Also guard on the group being non-empty, since `use_gatus` with no gatus host aborts the play on `groups['gatus'][0]`, and drop the `with_items` loop, since `http.j2` never references `item` and the loop rendered the same file once per path.

Single host installs are unaffected: the file ends up where it does today.