### PR TITLE
Opt-in include prefix for the CORS include

### DIFF
--- a/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
+++ b/ansible/roles/nginx_vhost/templates/fragment_74_location_cors.j2
@@ -1,6 +1,8 @@
 {% if nginx_cors_origin_regexp is defined and nginx_cors_origin_regexp|length > 0 %}
     {% if deployment_type == 'swarm' %}
         include /etc/nginx/conf.d/ala_cors_{{appname}};
+    {% elif nginx_include_prefix is defined %}
+        include {{ nginx_include_prefix }}/ala_cors_{{appname}};
     {% else %}
         include {{nginx_conf_dir}}/conf.d/ala_cors_{{appname}};
     {% endif %}


### PR DESCRIPTION
On a VM the directory Ansible writes the config into is the same directory nginx reads it back from, so baking `nginx_conf_dir` into the CORS include works.

That stops holding when the config is written in one place and read from another, which is what happens when nginx runs from a container image with the config mounted in: the include names the host path, nginx cannot see it, and every request to that location fails on a missing include.

Add an opt-in prefix, `nginx_include_prefix`, used only when it is defined. Nothing defines it, so the existing behaviour is untouched and there is no new default. Verified by rendering `fragment_74` through Ansible before and after: identical output for a package install and for a relocated `nginx_conf_dir`.