### PR TITLE
Accept container as a deployment_type

### DIFF
--- a/ansible/roles/biocache3-properties/tasks/main.yml
+++ b/ansible/roles/biocache3-properties/tasks/main.yml
@@ -17,7 +17,7 @@
   tags:
     - docker
     - docker-service
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
 
 - name: copy biocache config properties template 
   template: src={{item}} dest={{data_dir}}/biocache/config/{{item}} mode=0644 output_encoding=iso-8859-1

--- a/ansible/roles/cassandra3/tasks/main.yml
+++ b/ansible/roles/cassandra3/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Include docker tasks
   include_tasks: docker-tasks.yml
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
 
 - name: Include VM tasks
   import_tasks: vm-tasks.yml

--- a/ansible/roles/cassandra5/tasks/main.yml
+++ b/ansible/roles/cassandra5/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Include docker tasks
   fail:
     msg: "ERROR: Not implemented"
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
 
 - name: Include VM tasks
   import_tasks: vm-tasks.yml

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -33,15 +33,17 @@
 
 - name: apt-get update (Debian)
   apt: update_cache=yes
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - deployment_type == 'vm' or deployment_type is undefined
   tags:
     - common
     - apt_update
 
 - name: Check if deployment_type is valid
   fail:
-    msg: "'deployment_type' must be one of 'vm', 'swarm', 'k8s'. Current value is '{{ deployment_type }}'."
-  when: deployment_type not in ['vm', 'swarm', 'k8s']
+    msg: "'deployment_type' must be one of 'vm', 'swarm', 'k8s', 'container'. Current value is '{{ deployment_type }}'."
+  when: deployment_type not in ['vm', 'swarm', 'k8s', 'container']
   tags:
     - common
 
@@ -49,6 +51,7 @@
   file:
     path: "{{ data_dir }}"
     state: directory
+  when: deployment_type == 'vm' or deployment_type is undefined
   tags:
     - common
 
@@ -56,6 +59,7 @@
   copy:
     src: data-gitignore
     dest: "{{ data_dir }}/.gitignore"
+  when: deployment_type == 'vm' or deployment_type is undefined
   tags:
     - common
     - gitignore

--- a/ansible/roles/oidc-keys-add/tasks/main.yml
+++ b/ansible/roles/oidc-keys-add/tasks/main.yml
@@ -65,7 +65,7 @@
     mongo:5 sh -c "cat /scripts/add-key.js | mongo --host \"{{ cas_services_host }}\"
     --port \"{{ cas_services_port | default('27017') }}\" --username \"{{ cas_services_username }}\"
     --password \"{{ cas_services_password }}\" \"{{ cas_services_db | default('cas-service-registry') }}\" --quiet"
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   async: 90
   poll: 5
   tags:

--- a/ansible/roles/solrcloud/tasks/main.yml
+++ b/ansible/roles/solrcloud/tasks/main.yml
@@ -8,7 +8,7 @@
   include_tasks: docker-tasks.yml
   vars:
     solr_temp_disable_shardsWhitelist: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   tags: [docker, docker-service]
 
 - name: Include VM tasks
@@ -141,7 +141,7 @@
     solr_zk_host: la_solrcloud_zoo_1
     solr_user: "{{ docker_default_user }}"
     solrcloud_num_shards: 1
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
 
   # We can let this port open during development
 - name: Remove previous socat container for solr tunnel
@@ -149,10 +149,10 @@
   vars:
     name: la_solrcloud_solr_1
   run_once: true
-  when: deployment_type == 'swarm' and docker_development_mode is defined and docker_development_mode | bool == false
+  when: (deployment_type | default('vm')) != 'vm' and docker_development_mode is defined and docker_development_mode | bool == false
   tags:
     - solr_config
 
 - name: Redeploy stack without solr_temp_disable_shardsWhitelist
   include_tasks: docker-tasks.yml
-  when: deployment_type == 'swarm' and solr_enable_shards_white_list is defined and solr_enable_shards_white_list | bool == true
+  when: (deployment_type | default('vm')) != 'vm' and solr_enable_shards_white_list is defined and solr_enable_shards_white_list | bool == true

--- a/ansible/roles/solrcloud_config/tasks/main.yml
+++ b/ansible/roles/solrcloud_config/tasks/main.yml
@@ -23,7 +23,7 @@
   shell: "docker service ps la_solrcloud_solr_1 --format '{{ '{{' }}.Node{{ '}}' }}' | head -1"
   register: solr_node
   run_once: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   tags:
     - solrcloud_config
     - zookeeper_config
@@ -32,7 +32,7 @@
   shell: "docker ps -q -f name=la_solrcloud_solr_1"
   register: solr_container_id
   run_once: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   delegate_to: "{{ solr_node.stdout }}"
   tags:
     - solrcloud_config
@@ -41,7 +41,7 @@
 - name: Make zkcli.sh world-readable-writable-executable using Docker
   shell: "docker exec {{ solr_container_id.stdout }} chmod 777 /opt/bitnami/solr/server/scripts/cloud-scripts/zkcli.sh"
   run_once: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   delegate_to: "{{ solr_node.stdout }}"
   tags:
     - solrcloud_config
@@ -50,7 +50,7 @@
 - name: Upload biocache schema(s) to zookeeper using Docker
   shell: "docker exec {{ solr_container_id.stdout }} /opt/bitnami/solr/server/scripts/cloud-scripts/zkcli.sh -cmd upconfig -zkhost {{ solr_zk_host }} -confname biocache -solrhome /data/solr -confdir /data/solr_config/biocache/conf"
   run_once: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   delegate_to: "{{ solr_node.stdout }}"
   tags:
     - solrcloud_config
@@ -59,7 +59,7 @@
 - name: Upload bie schema(s) to zookeeper using Docker
   shell: "docker exec {{ solr_container_id.stdout }} /opt/bitnami/solr/server/scripts/cloud-scripts/zkcli.sh -cmd upconfig -zkhost {{ solr_zk_host }} -confname bie -solrhome /data/solr -confdir /data/solr_config/bie/conf"
   run_once: true
-  when: deployment_type == 'swarm'
+  when: (deployment_type | default('vm')) != 'vm'
   delegate_to: "{{ solr_node.stdout }}"
   tags:
     - solrcloud_config


### PR DESCRIPTION
This comes from [la-docker-compose](https://github.com/living-atlases/la-docker-compose), which runs a Living Atlas on docker compose by reusing these roles. It needs a fourth `deployment_type` value, `container`, for docker compose.

`container` joins the validated list in the common role, and that role stops doing machine level provisioning when there is no machine being built: `apt-get update`, `data_dir` and its `.gitignore`.

The rest is one substitution: the checks that single out a specific non-VM deployment become "not a VM", so every existing deployment type keeps behaving as it does today. They use the parenthesised default `auth-by-type.yml` already had, so a play that never sets the variable skips them instead of failing the conditional.