### PR TITLE
Cast the solrcloud host counts before building the range

### DIFF
--- a/ansible/roles/solrcloud/tasks/docker-facts.yml
+++ b/ansible/roles/solrcloud/tasks/docker-facts.yml
@@ -13,7 +13,7 @@
     zookeeper_servers_plain_l: >-
           {{ zookeeper_servers_plain_l |default([]) +
            [ 'la_solrcloud_zoo_' + (item|string) ] }}
-  loop: "{{ range(1, zookeeper_hosts + 1) | list }}"
+  loop: "{{ range(1, (zookeeper_hosts | int) + 1) | list }}"
   tags:
     - docker
     - docker-service
@@ -28,7 +28,7 @@
     solr_servers_plain_l: >-
           {{ solr_servers_plain_l |default([]) +
            [ 'la_solrcloud_solr_' + (item|string) ] }}
-  loop: "{{ range(1, solr_hosts + 1) | list }}"
+  loop: "{{ range(1, (solr_hosts | int) + 1) | list }}"
   tags:
     - docker
     - docker-service


### PR DESCRIPTION
`zookeeper_hosts` and `solr_hosts` feed `range()` directly. Ansible only knows they are numbers when the value came from YAML; set in an INI inventory, or passed with `-e`, they arrive as strings and `range()` raises "Integer argument expected, got str" while building the docker facts.

`| int` is a no-op when the value is already an integer.