### PR TITLE
Cap container log size in the docker daemon config

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,2 +1,12 @@
 # To avoid collisions in shared data dirs we use inventory_hostname
 docker_dir: "{{ docker_data_dir | default('/data/docker/' + inventory_hostname) }}"
+
+
+# Container log rotation for the daemon. The json-file driver never truncates
+# unless log-opts says so, so a long lived container writes until the filesystem
+# fills: we lost a host that way, with two containers holding 5.4 GB and 3.5 GB
+# of logs on a 29 GB root, and the next deploy died on "No space left on device"
+# before it could do anything. 100m x 5 caps each container at 500 MB.
+docker_log_driver: json-file
+docker_log_max_size: 100m
+docker_log_max_file: "5"

--- a/ansible/roles/docker/templates/daemon.json
+++ b/ansible/roles/docker/templates/daemon.json
@@ -1,3 +1,8 @@
 {
-  "data-root": "{{ docker_dir }}"
+  "data-root": "{{ docker_dir }}",
+  "log-driver": "{{ docker_log_driver }}",
+  "log-opts": {
+    "max-size": "{{ docker_log_max_size }}",
+    "max-file": "{{ docker_log_max_file }}"
+  }
 }


### PR DESCRIPTION
The json-file driver keeps every line forever unless `log-opts` says otherwise, so a long lived container writes until the filesystem fills. We lost a host to this: two containers holding 5.4 GB and 3.5 GB of logs on a 29 GB root, and the next deploy died on "No space left on device" before it could do anything.

Set `log-driver` and `log-opts` in `daemon.json` from three new defaults, capping each container at 100m x 5. All three are overridable, and `log-driver` is spelled out rather than assumed so a deployment can switch to journald without editing the template.